### PR TITLE
@W-21859986 add skill for policy creation

### DIFF
--- a/docs/job-template.md
+++ b/docs/job-template.md
@@ -30,7 +30,23 @@ Before starting, ensure you have:
    - [Specific requirement]
    - [How to obtain or verify it]
 
+## Starting Point
+
+(Optional - include only for skills with multiple entry points)
+
+This skill has multiple entry points depending on what you already have:
+
+- **Start at Step 1** if [condition when user needs all steps]
+  - You'll need: `[variable1]`
+
+- **Start at Step N** if [condition when user can skip earlier steps]
+  - You'll need: `[variable1]`, `[variable2]`, `[variable3]`
+
 ## Step 1: [Action-Oriented Step Name]
+
+> **Skip if:** [Condition when this step can be skipped. Include which variables the user should already have.]
+
+(Optional - include the skip annotation only for steps that can be skipped)
 
 [Prose explanation of what this step does and why it's needed. Provide context about when this would be used and what it accomplishes.]
 

--- a/docs/job-template.md
+++ b/docs/job-template.md
@@ -30,19 +30,19 @@ Before starting, ensure you have:
    - [Specific requirement]
    - [How to obtain or verify it]
 
-## Starting Point
+## Execution Paths
 
-(Optional - include only for skills with multiple entry points)
+(Optional - include only for skills with multiple execution paths)
 
-This skill has multiple entry points depending on what you already have:
+This skill has multiple execution paths depending on what you already have:
 
-- **Start at Step 1** if [condition when user needs all steps]
+- **[Path name]**: Steps 1, 2, 3, 4
+  - When: [condition when user needs all steps]
   - You'll need: `[variable1]`
-  - Steps: 1, 2, 3, 4
 
-- **Start at Step N** if [condition when user can skip earlier steps]
+- **[Another path]**: Steps 2, 4
+  - When: [condition when user can skip earlier steps]
   - You'll need: `[variable1]`, `[variable2]`, `[variable3]`
-  - Steps: 2, 4
 
 ## Step 1: [Action-Oriented Step Name]
 

--- a/docs/job-template.md
+++ b/docs/job-template.md
@@ -38,9 +38,11 @@ This skill has multiple entry points depending on what you already have:
 
 - **Start at Step 1** if [condition when user needs all steps]
   - You'll need: `[variable1]`
+  - Steps: 1, 2, 3, 4
 
 - **Start at Step N** if [condition when user can skip earlier steps]
   - You'll need: `[variable1]`, `[variable2]`, `[variable3]`
+  - Steps: 2, 4
 
 ## Step 1: [Action-Oriented Step Name]
 

--- a/docs/x-jobs-to-be-done-schema.md
+++ b/docs/x-jobs-to-be-done-schema.md
@@ -256,19 +256,23 @@ This skill has multiple entry points depending on what you already have:
 
 - **Start at Step 1** if you only have a URL and need to create an Exchange asset first
   - You'll need: `implementationUrl`
+  - Steps: 1, 2, 3, 4, 5
 
 - **Start at Step 2** if you already have an Exchange asset but no API Manager instance
   - You'll need: `organizationId`, `environmentId`, `groupId`, `assetId`, `assetVersion`
+  - Steps: 2, 3, 4, 5
 
 - **Start at Step 3** if you already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
+  - Steps: 2, 3, 5
 ```
 
 **Format rules:**
 - Each entry uses the pattern: `- **Start at Step N** if <condition>`
 - Sub-items list required variables: `- You'll need: \`var1\`, \`var2\``
+- Sub-items list the exact step sequence: `- Steps: 1, 2, 3` (the steps to execute for this path, in order)
 - Referenced step numbers must exist in the skill
-- The portal renders these as informational cards
+- The step sequence may not be strictly sequential — some paths skip steps or include earlier steps needed for context (e.g., listing environments)
 
 #### Skip Annotations
 

--- a/docs/x-jobs-to-be-done-schema.md
+++ b/docs/x-jobs-to-be-done-schema.md
@@ -241,6 +241,57 @@ outputs:
 - ❌ No `relatedJTBDs` field (use "Related Jobs" markdown section instead)
 - ❌ No time estimates or difficulty ratings
 
+### Conditional Steps (Optional)
+
+Skills can have **multiple entry points** for users who already have some prerequisites in place. This is expressed entirely in prose — no YAML changes needed.
+
+#### Starting Point Section
+
+Add an optional `## Starting Point` section between Prerequisites and Step 1 to guide users (and AI agents) to the right entry point:
+
+```markdown
+## Starting Point
+
+This skill has multiple entry points depending on what you already have:
+
+- **Start at Step 1** if you only have a URL and need to create an Exchange asset first
+  - You'll need: `implementationUrl`
+
+- **Start at Step 2** if you already have an Exchange asset but no API Manager instance
+  - You'll need: `organizationId`, `environmentId`, `groupId`, `assetId`, `assetVersion`
+
+- **Start at Step 3** if you already have an API Manager instance and want to apply a policy
+  - You'll need: `organizationId`, `environmentId`, `environmentApiId`
+```
+
+**Format rules:**
+- Each entry uses the pattern: `- **Start at Step N** if <condition>`
+- Sub-items list required variables: `- You'll need: \`var1\`, \`var2\``
+- Referenced step numbers must exist in the skill
+- The portal renders these as informational cards
+
+#### Skip Annotations
+
+Add a blockquote annotation at the top of a step's prose to indicate when it can be skipped:
+
+```markdown
+## Step 1: Create Exchange Asset
+
+> **Skip if:** You already have an Exchange asset with a known `groupId`, `assetId`, and `assetVersion`.
+
+Creates a new API asset in Exchange from your API specification...
+```
+
+**Format rules:**
+- Use the exact pattern: `> **Skip if:** <condition text>`
+- Place it as the first content after the step header
+- The condition text should clearly state what the user needs to already have
+- The parser extracts this into a separate `skip_condition` field and renders it as a banner
+- In playground mode, steps with skip annotations get a "Skip this step" button
+- When a step is skipped, the portal prompts users to manually provide any required variables
+
+**Example:** See `skills/protect-api-with-policies/SKILL.md` for a complete working example of conditional steps.
+
 ### Validation
 
 Use the validator to check:
@@ -259,6 +310,8 @@ python3 scripts/build/validate_jtbd.py job.md /path/to/api-specs-root
 - ✅ OperationId exists in referenced API spec
 - ✅ Step dependencies are valid
 - ✅ Input/output references are correct
+- ⚠️ Starting Point step references are in range (warning)
+- ⚠️ Skip annotations on steps with downstream dependencies (warning)
 
 ### Creating a New Job
 

--- a/docs/x-jobs-to-be-done-schema.md
+++ b/docs/x-jobs-to-be-done-schema.md
@@ -241,36 +241,38 @@ outputs:
 - ❌ No `relatedJTBDs` field (use "Related Jobs" markdown section instead)
 - ❌ No time estimates or difficulty ratings
 
-### Conditional Steps (Optional)
+### Execution Paths (Optional)
 
-Skills can have **multiple entry points** for users who already have some prerequisites in place. This is expressed entirely in prose — no YAML changes needed.
+Skills can have **multiple execution paths** for users who already have some prerequisites in place. Each path defines a named route through the skill's steps — the subset of steps to execute and their order. This is expressed entirely in prose — no YAML changes needed.
 
-#### Starting Point Section
+#### Execution Paths Section
 
-Add an optional `## Starting Point` section between Prerequisites and Step 1 to guide users (and AI agents) to the right entry point:
+Add an optional `## Execution Paths` section between Prerequisites and Step 1 to define the available routes:
 
 ```markdown
-## Starting Point
+## Execution Paths
 
-This skill has multiple entry points depending on what you already have:
+This skill has multiple execution paths depending on what you already have:
 
-- **Start at Step 1** if you only have a URL and need to create an Exchange asset first
+- **Full setup**: Steps 1, 2, 3, 4, 5
+  - When: You only have a URL and need to create an Exchange asset first
   - You'll need: `implementationUrl`
-  - Steps: 1, 2, 3, 4, 5
 
-- **Start at Step 2** if you already have an Exchange asset but no API Manager instance
+- **From Exchange asset**: Steps 2, 3, 4, 5
+  - When: You already have an Exchange asset but no API Manager instance
   - You'll need: `organizationId`, `environmentId`, `groupId`, `assetId`, `assetVersion`
-  - Steps: 2, 3, 4, 5
 
-- **Start at Step 3** if you already have an API Manager instance and want to apply a policy
+- **Apply policy only**: Steps 2, 3, 5
+  - When: You already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
-  - Steps: 2, 3, 5
 ```
 
 **Format rules:**
-- Each entry uses the pattern: `- **Start at Step N** if <condition>`
-- Sub-items list required variables: `- You'll need: \`var1\`, \`var2\``
-- Sub-items list the exact step sequence: `- Steps: 1, 2, 3` (the steps to execute for this path, in order)
+- Each path uses the pattern: `- **Path name**: Steps N, N, N`
+- The path name is a short, descriptive label for this route (e.g., "Full setup", "From Exchange asset")
+- The Steps list is the primary identifier — it defines which steps to execute, in order
+- Sub-item `- When: <condition>` describes when this path applies
+- Sub-item `- You'll need: \`var1\`, \`var2\`` lists required variables
 - Referenced step numbers must exist in the skill
 - The step sequence may not be strictly sequential — some paths skip steps or include earlier steps needed for context (e.g., listing environments)
 
@@ -314,7 +316,7 @@ python3 scripts/build/validate_jtbd.py job.md /path/to/api-specs-root
 - ✅ OperationId exists in referenced API spec
 - ✅ Step dependencies are valid
 - ✅ Input/output references are correct
-- ⚠️ Starting Point step references are in range (warning)
+- ⚠️ Execution Paths step references are in range (warning)
 - ⚠️ Skip annotations on steps with downstream dependencies (warning)
 
 ### Creating a New Job

--- a/scripts/build/validate_jtbd.py
+++ b/scripts/build/validate_jtbd.py
@@ -280,6 +280,92 @@ class JobValidator:
 
         return is_valid
 
+    def validate_starting_point(self, content: str, total_steps: int):
+        """Validate optional Starting Point section references."""
+        sp_match = re.search(
+            r'^## Starting Point\s*\n(.*?)(?=^## |\Z)',
+            content, re.MULTILINE | re.DOTALL
+        )
+        if not sp_match:
+            return
+
+        print("\n📍 Validating Starting Point section...")
+        sp_content = sp_match.group(1)
+
+        # Extract referenced step numbers
+        step_refs = re.findall(
+            r'\*\*Start at Step (\d+)\*\*', sp_content
+        )
+        for ref in step_refs:
+            step_num = int(ref)
+            if step_num < 1 or step_num > total_steps:
+                self.warnings.append(
+                    f"Starting Point references Step {step_num}, "
+                    f"but only {total_steps} step(s) exist"
+                )
+                print(f"  ⚠️  Step {step_num} out of range (1-{total_steps})")
+            else:
+                print(f"  ✅ Step {step_num} reference valid")
+
+    def validate_skip_annotations(self, content: str, steps: List[Dict[str, Any]]):
+        """Warn about skip annotations on steps that have downstream dependencies."""
+        # Find steps with skip annotations
+        skip_pattern = re.compile(
+            r'^## Step (\d+):.*?\n.*?>\s*\*\*Skip if:\*\*',
+            re.MULTILINE | re.DOTALL
+        )
+        skippable_steps = set()
+        for m in skip_pattern.finditer(content):
+            skippable_steps.add(int(m.group(1)))
+
+        if not skippable_steps:
+            return
+
+        print("\n⏭️  Validating skip annotations...")
+
+        # Build output names per step
+        step_outputs = {}
+        for i, step in enumerate(steps, 1):
+            if 'outputs' in step:
+                step_outputs[i] = [
+                    out['name'] for out in step['outputs']
+                    if isinstance(out, dict) and 'name' in out
+                ]
+
+        # Check if downstream steps depend on skippable step outputs
+        for skip_step in sorted(skippable_steps):
+            if skip_step not in step_outputs:
+                print(f"  ✅ Step {skip_step}: skippable (no outputs)")
+                continue
+
+            dependents = []
+            for i, step in enumerate(steps, 1):
+                if i <= skip_step:
+                    continue
+                inputs = step.get('inputs', {})
+                for param_name, input_def in inputs.items():
+                    if not isinstance(input_def, dict):
+                        continue
+                    from_def = input_def.get('from', {})
+                    if isinstance(from_def, dict) and 'step' in from_def:
+                        try:
+                            ref = int(from_def['step']) if str(from_def['step']).isdigit() else None
+                        except (ValueError, TypeError):
+                            ref = None
+                        if ref == skip_step:
+                            dependents.append(i)
+                            break
+
+            if dependents:
+                dep_str = ', '.join(f'Step {d}' for d in dependents)
+                self.warnings.append(
+                    f"Step {skip_step} has a skip annotation but {dep_str} "
+                    f"depend(s) on its outputs. Users must provide these values manually when skipping."
+                )
+                print(f"  ⚠️  Step {skip_step}: skippable, but {dep_str} depend on its outputs")
+            else:
+                print(f"  ✅ Step {skip_step}: skippable (no downstream dependencies)")
+
     def validate(self) -> bool:
         """Run all validations and return True if valid."""
         print(f"\n{'='*80}")
@@ -370,6 +456,12 @@ class JobValidator:
             print("  ✅ All step dependencies valid")
         else:
             print("  ❌ Step dependency errors found")
+
+        # 7. Validate Starting Point section (optional)
+        self.validate_starting_point(content, len(steps))
+
+        # 8. Warn about skip annotations on steps with downstream dependencies
+        self.validate_skip_annotations(content, steps)
 
         # Print summary
         self.print_summary()

--- a/scripts/build/validate_jtbd.py
+++ b/scripts/build/validate_jtbd.py
@@ -292,7 +292,7 @@ class JobValidator:
         print("\n📍 Validating Starting Point section...")
         sp_content = sp_match.group(1)
 
-        # Extract referenced step numbers
+        # Extract referenced step numbers from entry point headers
         step_refs = re.findall(
             r'\*\*Start at Step (\d+)\*\*', sp_content
         )
@@ -306,6 +306,25 @@ class JobValidator:
                 print(f"  ⚠️  Step {step_num} out of range (1-{total_steps})")
             else:
                 print(f"  ✅ Step {step_num} reference valid")
+
+        # Validate Steps: lists if present
+        steps_lists = re.findall(
+            r'- Steps:\s*(.+)', sp_content, re.IGNORECASE
+        )
+        for steps_line in steps_lists:
+            step_nums = [
+                int(s.strip()) for s in steps_line.split(',')
+                if s.strip().isdigit()
+            ]
+            for sn in step_nums:
+                if sn < 1 or sn > total_steps:
+                    self.warnings.append(
+                        f"Starting Point steps list references Step {sn}, "
+                        f"but only {total_steps} step(s) exist"
+                    )
+                    print(f"  ⚠️  Steps list: Step {sn} out of range (1-{total_steps})")
+            if step_nums:
+                print(f"  ✅ Steps list valid: {step_nums}")
 
     def validate_skip_annotations(self, content: str, steps: List[Dict[str, Any]]):
         """Warn about skip annotations on steps that have downstream dependencies."""

--- a/scripts/build/validate_jtbd.py
+++ b/scripts/build/validate_jtbd.py
@@ -280,51 +280,36 @@ class JobValidator:
 
         return is_valid
 
-    def validate_starting_point(self, content: str, total_steps: int):
-        """Validate optional Starting Point section references."""
+    def validate_execution_paths(self, content: str, total_steps: int):
+        """Validate optional Execution Paths section."""
         sp_match = re.search(
-            r'^## Starting Point\s*\n(.*?)(?=^## |\Z)',
+            r'^## Execution Paths\s*\n(.*?)(?=^## |\Z)',
             content, re.MULTILINE | re.DOTALL
         )
         if not sp_match:
             return
 
-        print("\n📍 Validating Starting Point section...")
+        print("\n📍 Validating Execution Paths...")
         sp_content = sp_match.group(1)
 
-        # Extract referenced step numbers from entry point headers
-        step_refs = re.findall(
-            r'\*\*Start at Step (\d+)\*\*', sp_content
+        # Format: - **Path name**: Steps N, N, N
+        paths = re.findall(
+            r'\*\*(.+?)\*\*:\s*Steps\s+(.+?)$', sp_content, re.MULTILINE
         )
-        for ref in step_refs:
-            step_num = int(ref)
-            if step_num < 1 or step_num > total_steps:
-                self.warnings.append(
-                    f"Starting Point references Step {step_num}, "
-                    f"but only {total_steps} step(s) exist"
-                )
-                print(f"  ⚠️  Step {step_num} out of range (1-{total_steps})")
-            else:
-                print(f"  ✅ Step {step_num} reference valid")
-
-        # Validate Steps: lists if present
-        steps_lists = re.findall(
-            r'- Steps:\s*(.+)', sp_content, re.IGNORECASE
-        )
-        for steps_line in steps_lists:
+        for name, steps_str in paths:
             step_nums = [
-                int(s.strip()) for s in steps_line.split(',')
+                int(s.strip()) for s in steps_str.split(',')
                 if s.strip().isdigit()
             ]
             for sn in step_nums:
                 if sn < 1 or sn > total_steps:
                     self.warnings.append(
-                        f"Starting Point steps list references Step {sn}, "
+                        f"Execution path \"{name}\" references Step {sn}, "
                         f"but only {total_steps} step(s) exist"
                     )
-                    print(f"  ⚠️  Steps list: Step {sn} out of range (1-{total_steps})")
+                    print(f"  ⚠️  Path \"{name}\": Step {sn} out of range (1-{total_steps})")
             if step_nums:
-                print(f"  ✅ Steps list valid: {step_nums}")
+                print(f"  ✅ Path \"{name}\": steps {step_nums} valid")
 
     def validate_skip_annotations(self, content: str, steps: List[Dict[str, Any]]):
         """Warn about skip annotations on steps that have downstream dependencies."""
@@ -476,8 +461,8 @@ class JobValidator:
         else:
             print("  ❌ Step dependency errors found")
 
-        # 7. Validate Starting Point section (optional)
-        self.validate_starting_point(content, len(steps))
+        # 7. Validate Execution Paths section (optional)
+        self.validate_execution_paths(content, len(steps))
 
         # 8. Warn about skip annotations on steps with downstream dependencies
         self.validate_skip_annotations(content, steps)

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -437,9 +437,11 @@ class PortalGenerator:
         """Generate AGENTS.md -- the primary entry point for AI agents."""
         print("  ✓ Generating AGENTS.md...")
         template = self.env.get_template('agents_md.html')
+        private_apis = [a for a in self.apis if a.get('private')]
         content = template.render(
             base_url=self.base_url,
             apis=self.public_apis,
+            private_apis=private_apis,
             all_skills=self.all_skills,
             stats=self.stats,
             build_label=self.build_label,

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -331,13 +331,23 @@ class PortalGenerator:
             slug = api['slug']
             urn = f"urn:api:{slug}"
 
-            # Copy source api.yaml to output
-            source_yaml = self.repo_root / 'apis' / slug / 'api.yaml'
+            # Copy source api.yaml and referenced subdirectories to output
+            source_dir = self.repo_root / 'apis' / slug
+            source_yaml = source_dir / 'api.yaml'
             if source_yaml.exists():
                 api_output_dir = self.output_dir / 'apis' / slug
                 api_output_dir.mkdir(parents=True, exist_ok=True)
                 dest_yaml = api_output_dir / 'api.yaml'
                 shutil.copy2(source_yaml, dest_yaml)
+
+                # Copy subdirectories (schemas, examples, requests, etc.)
+                # so that $ref links in the spec resolve correctly
+                for child in source_dir.iterdir():
+                    if child.is_dir():
+                        dest_child = api_output_dir / child.name
+                        if dest_child.exists():
+                            shutil.rmtree(dest_child)
+                        shutil.copytree(child, dest_child)
 
             entry = {
                 '$id': urn,

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -85,10 +85,14 @@ def _extract_skip_annotation(text: str) -> tuple:
     return condition, cleaned.strip()
 
 
+_steps_list_pattern = re.compile(r'^\s+- Steps:\s*(.+)', re.IGNORECASE)
+
+
 def _extract_entry_points(content: str) -> List[Dict]:
     """Extract structured entry points from a Starting Point section.
     Pattern: - **Start at Step N** if <condition>
-    Sub-items: - You'll need: `var1`, `var2`"""
+    Sub-items: - You'll need: `var1`, `var2`
+               - Steps: 1, 2, 3"""
     if not content:
         return []
     entry_points = []
@@ -104,9 +108,17 @@ def _extract_entry_points(content: str) -> List[Dict]:
                 'step': int(ep_match.group(1)),
                 'condition': ep_match.group(2).strip(),
                 'required_vars': [],
+                'steps': [],
             }
         elif current_ep and "you'll need:" in line.lower():
             current_ep['required_vars'] = _entry_point_vars_pattern.findall(line)
+        elif current_ep:
+            steps_match = _steps_list_pattern.match(line)
+            if steps_match:
+                current_ep['steps'] = [
+                    int(s.strip()) for s in steps_match.group(1).split(',')
+                    if s.strip().isdigit()
+                ]
     if current_ep:
         entry_points.append(current_ep)
     return entry_points

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -47,9 +47,9 @@ _skip_annotation_pattern = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 
-# Pattern for entry points in Starting Point section
-_entry_point_pattern = re.compile(
-    r'^\- \*\*Start at Step (\d+)\*\*\s+if\s+(.+?)$',
+# Pattern for execution paths: - **Path name**: Steps N, N, N
+_exec_path_pattern = re.compile(
+    r'^\- \*\*(.+?)\*\*:\s*Steps\s+(.+?)$',
     re.MULTILINE,
 )
 _entry_point_vars_pattern = re.compile(r'`(\w+)`')
@@ -85,40 +85,40 @@ def _extract_skip_annotation(text: str) -> tuple:
     return condition, cleaned.strip()
 
 
-_steps_list_pattern = re.compile(r'^\s+- Steps:\s*(.+)', re.IGNORECASE)
-
-
 def _extract_entry_points(content: str) -> List[Dict]:
-    """Extract structured entry points from a Starting Point section.
-    Pattern: - **Start at Step N** if <condition>
-    Sub-items: - You'll need: `var1`, `var2`
-               - Steps: 1, 2, 3"""
+    """Extract structured execution paths from an Execution Paths section.
+
+    Format: - **Path name**: Steps 1, 2, 3
+              - When: <condition>
+              - You'll need: `var1`, `var2`
+    """
     if not content:
         return []
     entry_points = []
-    # Split by entry point lines to capture sub-items
     lines = content.split('\n')
     current_ep = None
     for line in lines:
-        ep_match = _entry_point_pattern.match(line)
-        if ep_match:
+        match = _exec_path_pattern.match(line)
+        if match:
             if current_ep:
                 entry_points.append(current_ep)
+            steps = [
+                int(s.strip()) for s in match.group(2).split(',')
+                if s.strip().isdigit()
+            ]
             current_ep = {
-                'step': int(ep_match.group(1)),
-                'condition': ep_match.group(2).strip(),
+                'name': match.group(1).strip(),
+                'step': steps[0] if steps else 1,
+                'condition': '',
                 'required_vars': [],
-                'steps': [],
+                'steps': steps,
             }
-        elif current_ep and "you'll need:" in line.lower():
-            current_ep['required_vars'] = _entry_point_vars_pattern.findall(line)
         elif current_ep:
-            steps_match = _steps_list_pattern.match(line)
-            if steps_match:
-                current_ep['steps'] = [
-                    int(s.strip()) for s in steps_match.group(1).split(',')
-                    if s.strip().isdigit()
-                ]
+            when_match = re.match(r'^\s+-\s+When:\s*(.+)', line, re.IGNORECASE)
+            if when_match:
+                current_ep['condition'] = when_match.group(1).strip()
+            elif "you'll need:" in line.lower():
+                current_ep['required_vars'] = _entry_point_vars_pattern.findall(line)
     if current_ep:
         entry_points.append(current_ep)
     return entry_points
@@ -226,7 +226,7 @@ def parse_skill(skill_path: Path) -> Dict[str, Any]:
         # Extract overview, prerequisites, and starting point for structured view
         overview = _extract_section(post.content, 'Overview')
         prerequisites = _extract_section(post.content, 'Prerequisites')
-        starting_point = _extract_section(post.content, 'Starting Point')
+        starting_point = _extract_section(post.content, 'Execution Paths')
         entry_points = _extract_entry_points(starting_point)
 
         # Extract post-workflow sections

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -41,6 +41,19 @@ def _extract_yaml_blocks(content: str) -> List[Dict]:
 
 _yaml_fence_pattern = re.compile(r'```ya?ml\s*\n.*?```', re.DOTALL)
 
+# Pattern for > **Skip if:** blockquote annotations in step prose
+_skip_annotation_pattern = re.compile(
+    r'^>\s*\*\*Skip if:\*\*\s*(.+?)(?:\n(?!>)|\Z)',
+    re.MULTILINE | re.DOTALL,
+)
+
+# Pattern for entry points in Starting Point section
+_entry_point_pattern = re.compile(
+    r'^\- \*\*Start at Step (\d+)\*\*\s+if\s+(.+?)$',
+    re.MULTILINE,
+)
+_entry_point_vars_pattern = re.compile(r'`(\w+)`')
+
 # Patterns for prose blocks that duplicate structured data (inputs table, API call header)
 _redundant_prose_patterns = [
     # "**What you'll need:**" followed by a bullet list
@@ -55,6 +68,48 @@ def _strip_redundant_prose(text: str) -> str:
     for pattern in _redundant_prose_patterns:
         text = pattern.sub('', text)
     return text.strip()
+
+
+def _extract_skip_annotation(text: str) -> tuple:
+    """Extract '> **Skip if:**' blockquote from step prose.
+    Returns (skip_condition_text, cleaned_prose) or (None, original_text)."""
+    match = _skip_annotation_pattern.search(text)
+    if not match:
+        return None, text
+    condition = match.group(1).strip()
+    # Remove trailing > continuation lines that are part of the blockquote
+    # and clean up the annotation from the prose
+    cleaned = text[:match.start()] + text[match.end():]
+    # Remove any leftover blank lines from extraction
+    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
+    return condition, cleaned.strip()
+
+
+def _extract_entry_points(content: str) -> List[Dict]:
+    """Extract structured entry points from a Starting Point section.
+    Pattern: - **Start at Step N** if <condition>
+    Sub-items: - You'll need: `var1`, `var2`"""
+    if not content:
+        return []
+    entry_points = []
+    # Split by entry point lines to capture sub-items
+    lines = content.split('\n')
+    current_ep = None
+    for line in lines:
+        ep_match = _entry_point_pattern.match(line)
+        if ep_match:
+            if current_ep:
+                entry_points.append(current_ep)
+            current_ep = {
+                'step': int(ep_match.group(1)),
+                'condition': ep_match.group(2).strip(),
+                'required_vars': [],
+            }
+        elif current_ep and "you'll need:" in line.lower():
+            current_ep['required_vars'] = _entry_point_vars_pattern.findall(line)
+    if current_ep:
+        entry_points.append(current_ep)
+    return entry_points
 
 
 def _extract_step_details(content: str) -> List[Dict]:
@@ -89,11 +144,15 @@ def _extract_step_details(content: str) -> List[Dict]:
             prose_before = _strip_redundant_prose(body)
             prose_after = ''
 
+        # Extract skip annotation from prose_before
+        skip_condition, prose_before_clean = _extract_skip_annotation(prose_before)
+
         steps.append({
             'title': header,
             'yaml': yaml_data,
-            'prose_before_html': _md.render(prose_before) if prose_before else '',
+            'prose_before_html': _md.render(prose_before_clean) if prose_before_clean else '',
             'prose_after_html': _md.render(prose_after) if prose_after else '',
+            'skip_condition': skip_condition,
         })
         i += 2
 
@@ -152,9 +211,11 @@ def parse_skill(skill_path: Path) -> Dict[str, Any]:
         # Extract detailed step info with YAML blocks
         step_details = _extract_step_details(post.content)
 
-        # Extract overview and prerequisites for structured view
+        # Extract overview, prerequisites, and starting point for structured view
         overview = _extract_section(post.content, 'Overview')
         prerequisites = _extract_section(post.content, 'Prerequisites')
+        starting_point = _extract_section(post.content, 'Starting Point')
+        entry_points = _extract_entry_points(starting_point)
 
         # Extract post-workflow sections
         completion_checklist = _extract_section(post.content, 'Completion Checklist')
@@ -181,6 +242,8 @@ def parse_skill(skill_path: Path) -> Dict[str, Any]:
             'source_path': str(skill_path),
             'overview_html': _md.render(overview) if overview else '',
             'prerequisites_html': _md.render(prerequisites) if prerequisites else '',
+            'starting_point_html': _md.render(starting_point) if starting_point else '',
+            'entry_points': entry_points,
             'steps': step_headings,
             'step_details': step_details,
             'step_count': len(step_headings),

--- a/scripts/portal_generator/template_env.py
+++ b/scripts/portal_generator/template_env.py
@@ -167,8 +167,12 @@ def _resolve_skill_inputs(inputs_dict, step_details):
         if 'from' in param_config:
             from_ref = param_config['from']
             if isinstance(from_ref, dict):
-                # Try both 'output' and 'input' fields
+                # Try both 'output' and 'input' fields for step references
                 var_name = from_ref.get('output') or from_ref.get('input', '')
+
+                if not var_name and 'api' in from_ref:
+                    # From-API reference: use the parameter name as the variable
+                    var_name = param_name
 
                 if var_name:
                     # Create the reference string - just ${variableName}

--- a/scripts/portal_generator/templates/agents_md.html
+++ b/scripts/portal_generator/templates/agents_md.html
@@ -170,3 +170,12 @@ Filter: entries where kind == "agent-skill" AND apis contains "{api-slug}"
 {% for skill in all_skills %}
 - [`{{ skill.name }}`](skills/{{ skill.slug }}.html) — {{ skill.description|truncate(100, True) }}
 {%- endfor %}
+{% if private_apis %}
+
+### Internal APIs
+
+These APIs are not listed in the public catalog but are referenced by skills and available for agent use. Specs are accessible via their URN (e.g., `{{ base_url }}/apis/{slug}/api.yaml`).
+{% for api in private_apis %}
+- [`{{ api.name }}`](apis/{{ api.slug }}/api.yaml) ({{ api.version }}) — {{ api.description|truncate(100, True) }}
+{%- endfor %}
+{% endif %}

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -448,3 +448,53 @@ class TestPrivateApiExclusion:
 
     def test_private_api_yaml_copied(self, portal_with_private_api):
         assert (portal_with_private_api / 'apis' / 'private-api' / 'api.yaml').exists()
+
+
+class TestRefSubdirectoriesCopied:
+    """Verify that subdirectories (schemas, examples, requests) next to api.yaml
+    are copied to the portal output so that $ref links resolve correctly."""
+
+    @pytest.fixture
+    def portal_with_ref_subdirs(self, tmp_path):
+        repo = tmp_path / 'repo'
+        repo.mkdir()
+        apis_dir = repo / 'apis'
+        apis_dir.mkdir()
+
+        api_dir = apis_dir / 'ref-api'
+        api_dir.mkdir()
+        (api_dir / 'api.yaml').write_text(MINIMAL_OAS_YAML)
+        (api_dir / 'exchange.json').write_text(MINIMAL_EXCHANGE_JSON)
+
+        # Create subdirectories with schema/example files
+        schemas_dir = api_dir / 'schemas'
+        schemas_dir.mkdir()
+        (schemas_dir / 'model.json').write_text('{"type": "object"}')
+
+        requests_dir = api_dir / 'requests'
+        requests_dir.mkdir()
+        (requests_dir / 'body.json').write_text('{"type": "object"}')
+
+        # Nested subdirectory
+        nested_dir = schemas_dir / 'responses'
+        nested_dir.mkdir()
+        (nested_dir / 'success.json').write_text('{"type": "object"}')
+
+        setup_schema_docs(repo)
+
+        output = tmp_path / 'output'
+        generator = PortalGenerator(output)
+        generator.generate(repo)
+        return output
+
+    def test_schema_file_copied(self, portal_with_ref_subdirs):
+        assert (portal_with_ref_subdirs / 'apis' / 'ref-api' / 'schemas' / 'model.json').exists()
+
+    def test_requests_file_copied(self, portal_with_ref_subdirs):
+        assert (portal_with_ref_subdirs / 'apis' / 'ref-api' / 'requests' / 'body.json').exists()
+
+    def test_nested_subdir_copied(self, portal_with_ref_subdirs):
+        assert (portal_with_ref_subdirs / 'apis' / 'ref-api' / 'schemas' / 'responses' / 'success.json').exists()
+
+    def test_api_yaml_still_exists(self, portal_with_ref_subdirs):
+        assert (portal_with_ref_subdirs / 'apis' / 'ref-api' / 'api.yaml').exists()

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -15,6 +15,8 @@ from portal_generator.parsers.skill_parser import (
     _extract_step_details,
     _extract_section,
     _extract_related_jobs,
+    _extract_skip_annotation,
+    _extract_entry_points,
     _convert_to_plain,
     parse_skill,
 )
@@ -593,6 +595,179 @@ class TestExtractSection:
 
     def test_missing_section(self):
         assert _extract_section('## Other\nStuff', 'Overview') == ''
+
+
+# ============================================================================
+# skill_parser._extract_skip_annotation
+# ============================================================================
+
+class TestExtractSkipAnnotation:
+    def test_extracts_skip_condition(self):
+        text = '> **Skip if:** You already have an Exchange asset.\n\nSome prose.'
+        condition, cleaned = _extract_skip_annotation(text)
+        assert condition == 'You already have an Exchange asset.'
+        assert 'Some prose' in cleaned
+        assert 'Skip if' not in cleaned
+
+    def test_no_annotation(self):
+        text = 'Just regular prose here.'
+        condition, cleaned = _extract_skip_annotation(text)
+        assert condition is None
+        assert cleaned == text
+
+    def test_annotation_with_backtick_vars(self):
+        text = '> **Skip if:** You have `groupId`, `assetId`, and `assetVersion`.\n\nNext.'
+        condition, cleaned = _extract_skip_annotation(text)
+        assert '`groupId`' in condition
+        assert 'Next' in cleaned
+
+    def test_annotation_is_entire_content(self):
+        text = '> **Skip if:** This step is optional.'
+        condition, cleaned = _extract_skip_annotation(text)
+        assert condition == 'This step is optional.'
+
+    def test_step_details_include_skip_condition(self):
+        content = (
+            '## Step 1: Optional step\n'
+            '> **Skip if:** Already done.\n\n'
+            'Some prose.\n\n'
+            '```yaml\napi: urn:api:test\noperation: op1\n```\n'
+        )
+        steps = _extract_step_details(content)
+        assert steps[0]['skip_condition'] == 'Already done.'
+        assert 'Skip if' not in steps[0]['prose_before_html']
+        assert 'Some prose' in steps[0]['prose_before_html']
+
+    def test_step_without_skip_has_none(self):
+        content = (
+            '## Step 1: Normal step\n'
+            'Regular prose.\n\n'
+            '```yaml\napi: urn:api:test\noperation: op1\n```\n'
+        )
+        steps = _extract_step_details(content)
+        assert steps[0]['skip_condition'] is None
+
+
+# ============================================================================
+# skill_parser._extract_entry_points
+# ============================================================================
+
+class TestExtractEntryPoints:
+    def test_extracts_entry_points(self):
+        content = (
+            'This skill has multiple entry points:\n\n'
+            '- **Start at Step 1** if you need to create everything from scratch\n'
+            '  - You\'ll need: `apiUrl`\n\n'
+            '- **Start at Step 3** if you already have an API instance\n'
+            '  - You\'ll need: `organizationId`, `environmentId`, `environmentApiId`\n'
+        )
+        eps = _extract_entry_points(content)
+        assert len(eps) == 2
+        assert eps[0]['step'] == 1
+        assert eps[0]['condition'] == 'you need to create everything from scratch'
+        assert eps[0]['required_vars'] == ['apiUrl']
+        assert eps[1]['step'] == 3
+        assert eps[1]['required_vars'] == ['organizationId', 'environmentId', 'environmentApiId']
+
+    def test_empty_content(self):
+        assert _extract_entry_points('') == []
+
+    def test_no_matching_patterns(self):
+        assert _extract_entry_points('Just some text about starting points.') == []
+
+    def test_entry_without_vars(self):
+        content = '- **Start at Step 2** if you have an Exchange asset\n'
+        eps = _extract_entry_points(content)
+        assert len(eps) == 1
+        assert eps[0]['step'] == 2
+        assert eps[0]['required_vars'] == []
+
+
+# ============================================================================
+# skill_parser.parse_skill with conditional features
+# ============================================================================
+
+class TestParseSkillConditional:
+    def test_parse_skill_with_starting_point(self, tmp_path):
+        import textwrap
+        skill_md = textwrap.dedent("""\
+            ---
+            name: conditional-skill
+            description: A skill with entry points
+            ---
+            ## Overview
+            Does things conditionally.
+
+            ## Prerequisites
+            Need auth.
+
+            ## Starting Point
+
+            This skill has multiple entry points:
+
+            - **Start at Step 1** if you need everything
+              - You'll need: `apiUrl`
+
+            - **Start at Step 2** if you already have an asset
+              - You'll need: `groupId`, `assetId`
+
+            ## Step 1: Create Asset
+
+            > **Skip if:** You already have an Exchange asset with `groupId` and `assetId`.
+
+            Creates the asset.
+
+            ```yaml
+            api: urn:api:test-api
+            operationId: listResources
+            inputs: {}
+            outputs:
+              - name: assetId
+                path: $.id
+            ```
+
+            ## Step 2: Use Asset
+
+            Normal step.
+
+            ```yaml
+            api: urn:api:test-api
+            operationId: createResource
+            inputs: {}
+            ```
+        """)
+        skill_file = tmp_path / 'conditional-skill' / 'SKILL.md'
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(skill_md)
+
+        result = parse_skill(skill_file)
+        assert result is not None
+
+        # Starting point fields
+        assert result['starting_point_html'] != ''
+        assert len(result['entry_points']) == 2
+        assert result['entry_points'][0]['step'] == 1
+        assert result['entry_points'][1]['step'] == 2
+        assert result['entry_points'][1]['required_vars'] == ['groupId', 'assetId']
+
+        # Skip condition on step 1
+        assert result['step_details'][0]['skip_condition'] is not None
+        assert 'Exchange asset' in result['step_details'][0]['skip_condition']
+
+        # No skip condition on step 2
+        assert result['step_details'][1]['skip_condition'] is None
+
+    def test_parse_skill_without_conditionals(self, tmp_path):
+        from tests.conftest import MINIMAL_SKILL_MD
+        skill_file = tmp_path / 'plain-skill' / 'SKILL.md'
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(MINIMAL_SKILL_MD)
+
+        result = parse_skill(skill_file)
+        assert result is not None
+        assert result['starting_point_html'] == ''
+        assert result['entry_points'] == []
+        assert result['step_details'][0]['skip_condition'] is None
 
 
 class TestConvertToPlain:

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -657,17 +657,21 @@ class TestExtractEntryPoints:
         content = (
             'This skill has multiple entry points:\n\n'
             '- **Start at Step 1** if you need to create everything from scratch\n'
-            '  - You\'ll need: `apiUrl`\n\n'
+            '  - You\'ll need: `apiUrl`\n'
+            '  - Steps: 1, 2, 3\n\n'
             '- **Start at Step 3** if you already have an API instance\n'
             '  - You\'ll need: `organizationId`, `environmentId`, `environmentApiId`\n'
+            '  - Steps: 2, 3\n'
         )
         eps = _extract_entry_points(content)
         assert len(eps) == 2
         assert eps[0]['step'] == 1
         assert eps[0]['condition'] == 'you need to create everything from scratch'
         assert eps[0]['required_vars'] == ['apiUrl']
+        assert eps[0]['steps'] == [1, 2, 3]
         assert eps[1]['step'] == 3
         assert eps[1]['required_vars'] == ['organizationId', 'environmentId', 'environmentApiId']
+        assert eps[1]['steps'] == [2, 3]
 
     def test_empty_content(self):
         assert _extract_entry_points('') == []
@@ -680,6 +684,17 @@ class TestExtractEntryPoints:
         eps = _extract_entry_points(content)
         assert len(eps) == 1
         assert eps[0]['step'] == 2
+        assert eps[0]['required_vars'] == []
+        assert eps[0]['steps'] == []
+
+    def test_entry_with_steps_only(self):
+        content = (
+            '- **Start at Step 1** if you need everything\n'
+            '  - Steps: 1, 3, 5\n'
+        )
+        eps = _extract_entry_points(content)
+        assert len(eps) == 1
+        assert eps[0]['steps'] == [1, 3, 5]
         assert eps[0]['required_vars'] == []
 
 
@@ -707,9 +722,11 @@ class TestParseSkillConditional:
 
             - **Start at Step 1** if you need everything
               - You'll need: `apiUrl`
+              - Steps: 1, 2
 
             - **Start at Step 2** if you already have an asset
               - You'll need: `groupId`, `assetId`
+              - Steps: 2
 
             ## Step 1: Create Asset
 
@@ -747,8 +764,10 @@ class TestParseSkillConditional:
         assert result['starting_point_html'] != ''
         assert len(result['entry_points']) == 2
         assert result['entry_points'][0]['step'] == 1
+        assert result['entry_points'][0]['steps'] == [1, 2]
         assert result['entry_points'][1]['step'] == 2
         assert result['entry_points'][1]['required_vars'] == ['groupId', 'assetId']
+        assert result['entry_points'][1]['steps'] == [2]
 
         # Skip condition on step 1
         assert result['step_details'][0]['skip_condition'] is not None

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -653,23 +653,25 @@ class TestExtractSkipAnnotation:
 # ============================================================================
 
 class TestExtractEntryPoints:
-    def test_extracts_entry_points(self):
+    def test_extracts_execution_paths(self):
         content = (
-            'This skill has multiple entry points:\n\n'
-            '- **Start at Step 1** if you need to create everything from scratch\n'
-            '  - You\'ll need: `apiUrl`\n'
-            '  - Steps: 1, 2, 3\n\n'
-            '- **Start at Step 3** if you already have an API instance\n'
+            'This skill has multiple execution paths:\n\n'
+            '- **Full setup**: Steps 1, 2, 3\n'
+            '  - When: You need to create everything from scratch\n'
+            '  - You\'ll need: `apiUrl`\n\n'
+            '- **Apply policy only**: Steps 2, 3\n'
+            '  - When: You already have an API instance\n'
             '  - You\'ll need: `organizationId`, `environmentId`, `environmentApiId`\n'
-            '  - Steps: 2, 3\n'
         )
         eps = _extract_entry_points(content)
         assert len(eps) == 2
+        assert eps[0]['name'] == 'Full setup'
         assert eps[0]['step'] == 1
-        assert eps[0]['condition'] == 'you need to create everything from scratch'
+        assert eps[0]['condition'] == 'You need to create everything from scratch'
         assert eps[0]['required_vars'] == ['apiUrl']
         assert eps[0]['steps'] == [1, 2, 3]
-        assert eps[1]['step'] == 3
+        assert eps[1]['name'] == 'Apply policy only'
+        assert eps[1]['step'] == 2
         assert eps[1]['required_vars'] == ['organizationId', 'environmentId', 'environmentApiId']
         assert eps[1]['steps'] == [2, 3]
 
@@ -677,24 +679,15 @@ class TestExtractEntryPoints:
         assert _extract_entry_points('') == []
 
     def test_no_matching_patterns(self):
-        assert _extract_entry_points('Just some text about starting points.') == []
+        assert _extract_entry_points('Just some text about execution paths.') == []
 
-    def test_entry_without_vars(self):
-        content = '- **Start at Step 2** if you have an Exchange asset\n'
+    def test_path_without_when(self):
+        content = '- **Quick path**: Steps 2, 4\n'
         eps = _extract_entry_points(content)
         assert len(eps) == 1
-        assert eps[0]['step'] == 2
-        assert eps[0]['required_vars'] == []
-        assert eps[0]['steps'] == []
-
-    def test_entry_with_steps_only(self):
-        content = (
-            '- **Start at Step 1** if you need everything\n'
-            '  - Steps: 1, 3, 5\n'
-        )
-        eps = _extract_entry_points(content)
-        assert len(eps) == 1
-        assert eps[0]['steps'] == [1, 3, 5]
+        assert eps[0]['name'] == 'Quick path'
+        assert eps[0]['steps'] == [2, 4]
+        assert eps[0]['condition'] == ''
         assert eps[0]['required_vars'] == []
 
 
@@ -703,12 +696,12 @@ class TestExtractEntryPoints:
 # ============================================================================
 
 class TestParseSkillConditional:
-    def test_parse_skill_with_starting_point(self, tmp_path):
+    def test_parse_skill_with_execution_paths(self, tmp_path):
         import textwrap
         skill_md = textwrap.dedent("""\
             ---
             name: conditional-skill
-            description: A skill with entry points
+            description: A skill with execution paths
             ---
             ## Overview
             Does things conditionally.
@@ -716,17 +709,17 @@ class TestParseSkillConditional:
             ## Prerequisites
             Need auth.
 
-            ## Starting Point
+            ## Execution Paths
 
-            This skill has multiple entry points:
+            This skill has multiple execution paths:
 
-            - **Start at Step 1** if you need everything
+            - **Full setup**: Steps 1, 2
+              - When: You need everything
               - You'll need: `apiUrl`
-              - Steps: 1, 2
 
-            - **Start at Step 2** if you already have an asset
+            - **From asset**: Steps 2
+              - When: You already have an asset
               - You'll need: `groupId`, `assetId`
-              - Steps: 2
 
             ## Step 1: Create Asset
 
@@ -760,11 +753,13 @@ class TestParseSkillConditional:
         result = parse_skill(skill_file)
         assert result is not None
 
-        # Starting point fields
+        # Execution paths fields
         assert result['starting_point_html'] != ''
         assert len(result['entry_points']) == 2
+        assert result['entry_points'][0]['name'] == 'Full setup'
         assert result['entry_points'][0]['step'] == 1
         assert result['entry_points'][0]['steps'] == [1, 2]
+        assert result['entry_points'][1]['name'] == 'From asset'
         assert result['entry_points'][1]['step'] == 2
         assert result['entry_points'][1]['required_vars'] == ['groupId', 'assetId']
         assert result['entry_points'][1]['steps'] == [2]

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -391,7 +391,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 - Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 6
 - Policy configuration based on the schema from Step 6's `policyConfiguration` output
 
-**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 6's configuration schema.
+**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names from Step 6's configuration schema. For each configuration property, present the user with the property name, its description, and the default value, then ask if they want to keep the default or provide a custom value. If a property has no default, always ask the user for a value.
 
 ```yaml
 api: urn:api:api-manager

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -12,9 +12,9 @@ description: |
 
 ## Overview
 
-Applies a security or traffic management policy to an API, walking through the full process from identifying the target API to selecting and configuring the policy. Supports multiple starting points depending on what the user already has set up — an API Manager instance, an Exchange asset, or just an API URL.
+Applies a security or traffic management policy to an API and deploys it to a self-managed Flex Gateway, walking through the full process from identifying the target API to selecting a policy, configuring it, and deploying. Supports multiple starting points depending on what the user already has set up — an API Manager instance, an Exchange asset, or just an API URL.
 
-**What you'll build:** A fully configured policy enforced on your API instance
+**What you'll build:** A fully configured policy enforced on your API instance, deployed to a Flex Gateway
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ Before starting, ensure you have:
    - This is used to list environments, browse the policy catalog, check Exchange, etc.
 
 3. **One of the following**
-   - An API instance already in API Manager (skip to Step 3)
+   - An API instance already in API Manager (skip to Step 5)
    - An Exchange asset ready to be promoted to API Manager (skip to Step 2)
    - An API specification or URL that needs to be published first (start at Step 1)
 
@@ -40,12 +40,15 @@ This skill has multiple entry points depending on what you already have:
 
 - **Start at Step 1** if you have an API specification file and need to publish it to Exchange first
   - You'll need: `organizationId`, API specification file
+  - Steps: 1, 2, 3, 4, 5, 6, 7
 
 - **Start at Step 2** if you already have an Exchange asset and need to create an API Manager instance
   - You'll need: `organizationId`, `groupId`, `assetId`, `assetVersion`
+  - Steps: 2, 3, 4, 5, 6, 7
 
-- **Start at Step 4** if you already have an API Manager instance and want to apply a policy
+- **Start at Step 5** if you already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
+  - Steps: 2, 4, 5, 6, 7
 
 
 ## Step 1: Publish API to Exchange
@@ -137,8 +140,9 @@ Creates a managed API instance in API Manager from your Exchange asset. This is 
 **What you'll need:**
 - Organization ID and Environment ID
 - Exchange asset coordinates (groupId, assetId, version)
+- Gateway technology type and instance label
 
-**Action:** Create an API instance in the target environment.
+**Action:** Create an API instance in the target environment. The `technology` field is required — without it the API returns a 500 error. Ask the user which gateway technology they use.
 
 ```yaml
 api: urn:api:api-manager
@@ -170,15 +174,64 @@ inputs:
       step: Publish API to Exchange
       output: assetVersion
     description: Exchange asset version from Step 1
+  instanceLabel:
+    userProvided: true
+    description: A human-readable label for this API instance (e.g., "cars-api-v1")
+    example: "cars-api-v1"
+  technology:
+    userProvided: true
+    description: "Gateway technology for this instance: flexGateway, mule4, or mule3"
+    example: "flexGateway"
+  endpoint.uri:
+    userProvided: true
+    optional: true
+    description: The upstream backend URL for the API. Ask the user if they want to provide it now or configure it later.
+    example: "https://backend.example.com/api/v1"
 outputs:
   - name: environmentApiId
     path: $.id
     description: The API instance ID in API Manager, used to apply policies
 ```
 
-**What happens next:** Your API is now managed in API Manager. You can apply policies to this instance to enforce security, rate limiting, and other controls.
+**What happens next:** Your API is now managed in API Manager. Next, you'll select a deployment target and apply policies before deploying.
 
-## Step 4: Browse Exchange Policy Catalog
+## Step 4: Select Deployment Target
+
+List available gateway targets registered in the environment. This identifies which self-managed Flex Gateway the API instance will be deployed to after policies are configured.
+
+**What you'll need:**
+- Organization ID and Environment ID
+
+**Action:** List gateway targets and select the Flex Gateway where the API will run.
+
+```yaml
+api: urn:api:api-portal-xapi
+operationId: getGatewayTargets
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+outputs:
+  - name: targetId
+    path: $.data[*].id
+    labels: $.data[*].name
+    description: Selected gateway target ID
+  - name: targetName
+    path: $.data[*].name
+    description: Name of the selected gateway target
+```
+
+**What happens next:** You have a deployment target selected. Next, browse the policy catalog to choose which policy to apply before deploying.
+
+## Step 5: Browse Exchange Policy Catalog
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
@@ -238,16 +291,16 @@ outputs:
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
 - **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
-## Step 5: Apply Policy to API Instance
+## Step 6: Apply Policy to API Instance
 
-Apply the selected policy to your API instance with the appropriate configuration. Use the Exchange coordinates and configuration property names from Step 4.
+Apply the selected policy to your API instance with the appropriate configuration. Use the Exchange coordinates and configuration property names from Step 5.
 
 **What you'll need:**
 - Organization ID, Environment ID, and API instance ID
-- Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 4
-- Policy configuration based on the schema from Step 4's `policyConfiguration` output
+- Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 5
+- Policy configuration based on the schema from Step 5's `policyConfiguration` output
 
-**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 4's configuration schema.
+**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 5's configuration schema.
 
 ```yaml
 api: urn:api:api-manager
@@ -273,35 +326,87 @@ inputs:
     from:
       step: Browse Exchange Policy Catalog
       output: policyGroupId
-    description: Policy Exchange group ID from Step 4
+    description: Policy Exchange group ID from Step 5
   assetId:
     from:
       step: Browse Exchange Policy Catalog
       output: policyAssetId
-    description: Policy Exchange asset ID from Step 4
+    description: Policy Exchange asset ID from Step 5
   assetVersion:
     from:
       step: Browse Exchange Policy Catalog
       output: policyAssetVersion
-    description: Policy Exchange version from Step 4
+    description: Policy Exchange version from Step 5
 outputs:
   - name: policyId
     path: $.id
     description: The ID of the applied policy instance
 ```
 
-**What happens next:** Your API is now protected with the selected policy. The policy is active and enforcing its rules on all incoming traffic.
+**What happens next:** The policy is configured on your API instance. Next, deploy the instance to your Flex Gateway so the policy starts enforcing.
 
 **Common issues:**
-- **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 4) to get these values.
-- **400 Bad Request — invalid configurationData**: The configuration property names differ between gateway types. Use the property names from Step 4's `policyConfiguration` output, not from the generic template endpoint. For example, Flex Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
+- **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 5) to get these values.
+- **400 Bad Request — invalid configurationData**: The configuration property names differ between gateway types. Use the property names from Step 5's `policyConfiguration` output, not from the generic template endpoint. For example, Flex Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
 - **409 Conflict**: A policy of this type may already be applied to the API instance. List existing policies first to check, or add `?allowDuplicated=true` to the request URL to apply a second instance of the same policy type.
 - **403 Forbidden**: You need **Manage Policies** permission in the target environment.
+
+## Step 7: Deploy API Instance to Flex Gateway
+
+Deploy the API instance to the selected Flex Gateway target. This activates the API and its policies so that incoming traffic is evaluated against them. Deploying after applying the policy ensures the policy is enforced from the first request.
+
+**What you'll need:**
+- Organization ID, Environment ID, and API instance ID
+- Deployment target ID from Step 4
+
+**Action:** Create a deployment for the API instance on the selected Flex Gateway target.
+
+```yaml
+api: urn:api:proxies-xapi
+operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+  environmentApiId:
+    from:
+      step: Create API Manager Instance
+      output: environmentApiId
+    description: API instance ID from Step 3 (or provided manually)
+  type:
+    value: "HY"
+    description: "Deployment type for self-managed Flex Gateway (HY = Hybrid)"
+  target.targetId:
+    from:
+      step: Select Deployment Target
+      output: targetId
+    description: Flex Gateway target ID from Step 4
+outputs:
+  - name: deploymentId
+    path: $.id
+    description: The ID of the proxy deployment
+```
+
+**What happens next:** Your API is now deployed and protected. Traffic hitting the Flex Gateway will be evaluated against the applied policies.
+
+**Common issues:**
+- **400 Bad Request — missing targetId**: The deployment requires a valid target. Make sure you selected a target in Step 4.
+- **409 Conflict**: The API may already be deployed to this target. List existing deployments first to check.
+- **No targets available**: Ensure at least one Flex Gateway is registered and running in the target environment. Use the Flex Gateway Manager API to verify gateway status.
 
 ## Completion Checklist
 
 After completing all steps, verify:
 
+- [ ] API instance is deployed to the Flex Gateway target
 - [ ] Policy appears in the API instance's policy list
 - [ ] Policy status shows as "Active"
 - [ ] API requests are being evaluated against the policy rules
@@ -314,6 +419,10 @@ Your API is now protected with:
 ✅ **Policy enforcement**
 - Selected policy is active on your API instance
 - All incoming traffic is evaluated against policy rules
+
+✅ **Deployed to Flex Gateway**
+- API instance is running on a self-managed Flex Gateway
+- Policies are enforced from the first request
 
 ✅ **Managed configuration**
 - Policy settings are version-controlled in API Manager

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: protect-api-with-policies
+description: |
+  Protect an API by applying a policy from the catalog. Handles multiple starting
+  points: from an existing API Manager instance, from an Exchange asset that needs
+  an instance, or from scratch. Use when the user wants to secure an API, add
+  rate limiting, apply OAuth2, enforce IP allowlisting, or protect any API with
+  a policy — regardless of where they are in the setup process.
+---
+
+# Protect an API with Policies
+
+## Overview
+
+Applies a security or traffic management policy to an API, walking through the full process from identifying the target API to selecting and configuring the policy. Supports multiple starting points depending on what the user already has set up — an API Manager instance, an Exchange asset, or just an API URL.
+
+**What you'll build:** A fully configured policy enforced on your API instance
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+1. **Authentication ready**
+   - Valid Bearer token for Anypoint Platform. If you only have username/password, call `createLogin` (`POST /accounts/login`) from the `urn:api:access-management` API with body `{"username":"...","password":"..."}` to obtain a Bearer token first.
+   - API Manager permissions: **View APIs Configuration** and **Manage Policies** scopes
+
+2. **Organization Id**
+   - Call `listMe` (`GET /accounts/api/me`) from `urn:api:access-management` to get your organization ID
+   - Extract `organizationId` from `$.user.organization.id` in the response
+   - This is used to list environments, browse the policy catalog, check Exchange, etc.
+
+3. **One of the following**
+   - An API instance already in API Manager (skip to Step 3)
+   - An Exchange asset ready to be promoted to API Manager (skip to Step 2)
+   - An API specification or URL that needs to be published first (start at Step 1)
+
+## Starting Point
+
+This skill has multiple entry points depending on what you already have:
+
+- **Start at Step 1** if you have an API specification file and need to publish it to Exchange first
+  - You'll need: `organizationId`, API specification file
+
+- **Start at Step 2** if you already have an Exchange asset and need to create an API Manager instance
+  - You'll need: `organizationId`, `groupId`, `assetId`, `assetVersion`
+
+- **Start at Step 4** if you already have an API Manager instance and want to apply a policy
+  - You'll need: `organizationId`, `environmentId`, `environmentApiId`
+
+
+## Step 1: Publish API to Exchange
+
+> **Skip if:** You already have an Exchange asset with a known `groupId`, `assetId`, and `assetVersion`.
+
+Publishes your API specification to Exchange as a reusable asset. This makes it available for API Manager to create managed instances from it.
+
+**What you'll need:**
+- Organization ID
+- API specification file (OAS or RAML)
+- Asset name, groupId, assetId, and version
+
+**Action:** Create a new asset in Exchange with your API specification.
+
+```yaml
+api: urn:api:exchange-experience
+operationId: createAssets
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Your organization's Business Group GUID
+  groupId:
+    userProvided: true
+    description: The group ID for the asset (typically matches your organization ID)
+    example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  assetId:
+    userProvided: true
+    description: A unique identifier for the asset in kebab-case
+    example: "inventory-api"
+  version:
+    userProvided: true
+    description: Semantic version for the asset
+    example: "1.0.0"
+outputs:
+  - name: groupId
+    path: $.groupId
+    description: The group ID of the published asset
+  - name: assetId
+    path: $.assetId
+    description: The asset ID of the published asset
+  - name: assetVersion
+    path: $.version
+    description: The version of the published asset
+```
+
+**What happens next:** Your API specification is now available in Exchange. Next, you'll create an API Manager instance from this asset so you can apply policies to it.
+
+
+## Step 2: List Environments
+
+> **Skip if:** You already know the `environmentId`.
+
+List all environments in the organization so you can confirm or select the one where your API instance lives.
+
+**What you'll need:**
+- Organization ID
+
+**Action:** List available environments and select the target.
+
+```yaml
+api: urn:api:access-management
+operationId: listEnvironments
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID from Prerequisites
+outputs:
+  - name: environmentId
+    path: $.data[*].id
+    labels: $.data[*].name
+    description: Selected environment ID (e.g., Production, Sandbox)
+```
+
+**What happens next:** With the environment selected, you can create an API instance or browse policies.
+
+## Step 3: Create API Manager Instance
+
+> **Skip if:** You already have an API Manager instance with a known `environmentApiId`.
+
+Creates a managed API instance in API Manager from your Exchange asset. This is the entity that policies are applied to.
+
+**What you'll need:**
+- Organization ID and Environment ID
+- Exchange asset coordinates (groupId, assetId, version)
+
+**Action:** Create an API instance in the target environment.
+
+```yaml
+api: urn:api:api-manager
+operationId: createOrganizationsEnvironmentsApis
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Your organization's Business Group GUID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Target environment ID from Step 2
+  groupId:
+    from:
+      step: Publish API to Exchange
+      output: groupId
+    description: Exchange asset group ID from Step 1
+  assetId:
+    from:
+      step: Publish API to Exchange
+      output: assetId
+    description: Exchange asset ID from Step 1
+  assetVersion:
+    from:
+      step: Publish API to Exchange
+      output: assetVersion
+    description: Exchange asset version from Step 1
+outputs:
+  - name: environmentApiId
+    path: $.id
+    description: The API instance ID in API Manager, used to apply policies
+```
+
+**What happens next:** Your API is now managed in API Manager. You can apply policies to this instance to enforce security, rate limiting, and other controls.
+
+## Step 4: Browse Exchange Policy Catalog
+
+List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
+
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+
+**What you'll need:**
+- Organization ID
+- Environment ID and API instance ID (to filter for compatible templates)
+
+**Action:** List Exchange policy templates and select the one to apply. Pass `apiInstanceId` and `environmentId` to filter for templates compatible with your API's gateway type (e.g., Flex Gateway, Mule Gateway).
+
+```yaml
+api: urn:api:api-portal-xapi
+operationId: getExchangePolicyTemplates
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  apiInstanceId:
+    from:
+      step: Create API Manager Instance
+      output: environmentApiId
+    description: API instance ID from Step 3 (filters for compatible templates)
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+  latest:
+    value: "true"
+    description: Return only the latest version of each template
+  includeConfiguration:
+    value: "true"
+    description: Include the configuration schema for each template
+outputs:
+  - name: policyGroupId
+    path: $[*].groupId
+    labels: $[*].assetId
+    description: Exchange group ID of the selected policy template
+  - name: policyAssetId
+    path: $[*].assetId
+    description: Exchange asset ID of the selected policy template
+  - name: policyAssetVersion
+    path: $[*].version
+    description: Exchange version of the selected policy template (gateway-compatible)
+  - name: policyConfiguration
+    path: $[*].configuration
+    description: Configuration schema with gateway-compatible property names and defaults
+```
+
+**What happens next:** You have the policy template's Exchange coordinates and its configuration schema with the correct property names for your gateway type. Review the `policyConfiguration` output to understand what settings the policy accepts before applying it.
+
+**Common issues:**
+- **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+
+## Step 5: Apply Policy to API Instance
+
+Apply the selected policy to your API instance with the appropriate configuration. Use the Exchange coordinates and configuration property names from Step 4.
+
+**What you'll need:**
+- Organization ID, Environment ID, and API instance ID
+- Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 4
+- Policy configuration based on the schema from Step 4's `policyConfiguration` output
+
+**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 4's configuration schema.
+
+```yaml
+api: urn:api:api-manager
+operationId: createOrganizationsEnvironmentsApisPolicies
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+  environmentApiId:
+    from:
+      step: Create API Manager Instance
+      output: environmentApiId
+    description: API instance ID from Step 3 (or provided manually)
+  groupId:
+    from:
+      step: Browse Exchange Policy Catalog
+      output: policyGroupId
+    description: Policy Exchange group ID from Step 4
+  assetId:
+    from:
+      step: Browse Exchange Policy Catalog
+      output: policyAssetId
+    description: Policy Exchange asset ID from Step 4
+  assetVersion:
+    from:
+      step: Browse Exchange Policy Catalog
+      output: policyAssetVersion
+    description: Policy Exchange version from Step 4
+outputs:
+  - name: policyId
+    path: $.id
+    description: The ID of the applied policy instance
+```
+
+**What happens next:** Your API is now protected with the selected policy. The policy is active and enforcing its rules on all incoming traffic.
+
+**Common issues:**
+- **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 4) to get these values.
+- **400 Bad Request — invalid configurationData**: The configuration property names differ between gateway types. Use the property names from Step 4's `policyConfiguration` output, not from the generic template endpoint. For example, Flex Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
+- **409 Conflict**: A policy of this type may already be applied to the API instance. List existing policies first to check, or add `?allowDuplicated=true` to the request URL to apply a second instance of the same policy type.
+- **403 Forbidden**: You need **Manage Policies** permission in the target environment.
+
+## Completion Checklist
+
+After completing all steps, verify:
+
+- [ ] Policy appears in the API instance's policy list
+- [ ] Policy status shows as "Active"
+- [ ] API requests are being evaluated against the policy rules
+- [ ] Policy configuration matches your requirements
+
+## What You've Built
+
+Your API is now protected with:
+
+✅ **Policy enforcement**
+- Selected policy is active on your API instance
+- All incoming traffic is evaluated against policy rules
+
+✅ **Managed configuration**
+- Policy settings are version-controlled in API Manager
+- Configuration can be updated without redeploying the API
+
+## Next Steps
+
+1. **Test the policy**
+   - Send test requests to verify the policy is enforcing correctly
+   - Check that authorized requests pass and unauthorized ones are blocked
+
+2. **Add more policies**
+   - Run this skill again to layer additional policies (e.g., rate limiting + OAuth2)
+   - Policy ordering matters — adjust priority in API Manager if needed
+
+3. **Monitor policy activity**
+   - Check API Manager analytics for policy enforcement metrics
+   - Set up alerts for unusual rejection patterns
+
+## Tips and Best Practices
+
+### Policy Selection
+- **Rate Limiting**: Use when you need to control traffic volume per client
+- **OAuth 2.0**: Use for token-based authentication and authorization
+- **IP Allowlist/Blocklist**: Use to restrict access by network origin
+- **Client ID Enforcement**: Use to require registered client applications
+
+### Policy Ordering
+- **Authentication policies** should be applied first (lowest order number)
+- **Rate limiting** should come after authentication
+- **Transformation policies** should be last
+
+### Gateway Compatibility
+- Always use `getExchangePolicyTemplates` with `apiInstanceId` to get gateway-compatible templates
+- Configuration property names and defaults vary by gateway type (Flex Gateway vs. Mule Gateway)
+- The Exchange template version may differ from the generic template version
+
+## Troubleshooting
+
+### Policy Not Enforcing
+
+**Symptoms:** Requests pass through without policy evaluation
+
+**Possible causes:**
+- API instance is not deployed or is in an error state
+- Policy configuration has a permissive default that allows all traffic
+- Policy is applied but not yet propagated (wait 1-2 minutes)
+
+**Solutions:**
+- Check API instance status in API Manager
+- Review policy configuration for overly permissive settings
+- Wait for propagation and retry
+
+### Policy Blocks All Requests
+
+**Symptoms:** All requests return 401 or 403, even legitimate ones
+
+**Possible causes:**
+- Policy configuration is too restrictive
+- Required credentials are not being sent correctly
+- Policy expects headers or parameters in a specific format
+
+**Solutions:**
+- Review the policy configuration schema for required fields
+- Check that client applications are sending credentials in the expected format
+- Temporarily disable the policy to isolate the issue
+
+### 400 Error When Applying Policy
+
+**Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
+
+**Possible causes:**
+- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+
+**Solutions:**
+- Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint
+
+## Related Jobs
+
+- **apply-policy-to-api-instance**: Apply a policy when you already have an API instance (simpler flow)
+- **deploy-api-with-rate-limiting**: Deploy an API with pre-configured rate limiting tiers

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -40,15 +40,15 @@ This skill has multiple entry points depending on what you already have:
 
 - **Start at Step 1** if you have an API specification file and need to publish it to Exchange first
   - You'll need: `organizationId`, API specification file
-  - Steps: 1, 2, 3, 4, 5, 6, 7
+  - Steps: 1, 2, 3, 4, 5, 6
 
 - **Start at Step 2** if you already have an Exchange asset and need to create an API Manager instance
   - You'll need: `organizationId`, `groupId`, `assetId`, `assetVersion`
-  - Steps: 2, 3, 4, 5, 6, 7
+  - Steps: 2, 3, 4, 5, 6
 
 - **Start at Step 5** if you already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
-  - Steps: 2, 4, 5, 6, 7
+  - Steps: 2, 5, 6
 
 
 ## Step 1: Publish API to Exchange
@@ -131,18 +131,59 @@ outputs:
 
 **What happens next:** With the environment selected, you can create an API instance or browse policies.
 
-## Step 3: Create API Manager Instance
+## Step 3: Select Deployment Target
+
+List available gateway targets registered in the environment. You need the target ID and gateway version before creating the API instance, because the instance creation request must include deployment information to properly bind it to the Flex Gateway.
+
+**What you'll need:**
+- Organization ID and Environment ID
+
+**Action:** List gateway targets and select the Flex Gateway where the API will run. Prefer a target with `status: "RUNNING"`.
+
+```yaml
+api: urn:api:api-portal-xapi
+operationId: getGatewayTargets
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+outputs:
+  - name: targetId
+    path: $.rows[*].id
+    labels: $.rows[*].name
+    description: Selected gateway target ID
+  - name: targetName
+    path: $.rows[*].name
+    description: Name of the selected gateway target
+  - name: gatewayVersion
+    path: $.rows[*].version
+    description: Runtime version of the selected Flex Gateway (e.g., "1.12.2")
+```
+
+**What happens next:** You have a deployment target and its gateway version. Next, create the API instance with this deployment information embedded.
+
+## Step 4: Create API Manager Instance
 
 > **Skip if:** You already have an API Manager instance with a known `environmentApiId`.
 
-Creates a managed API instance in API Manager from your Exchange asset. This is the entity that policies are applied to.
+Creates a managed API instance in API Manager from your Exchange asset, bound to the selected Flex Gateway target. The deployment information (target, gateway version, deployment type) must be included in the creation request — creating an instance without it leaves the API in an unregistered state that is difficult to deploy later.
+
+**Important:** For Flex Gateway instances, `isCloudHub` must be `null` (not `false`). Setting it to `false` causes a validation error.
 
 **What you'll need:**
 - Organization ID and Environment ID
 - Exchange asset coordinates (groupId, assetId, version)
-- Gateway technology type and instance label
+- Deployment target ID and gateway version from Step 3
 
-**Action:** Create an API instance in the target environment. The `technology` field is required — without it the API returns a 500 error. Ask the user which gateway technology they use.
+**Action:** Create an API instance in the target environment with embedded deployment configuration.
 
 ```yaml
 api: urn:api:api-manager
@@ -179,57 +220,44 @@ inputs:
     description: A human-readable label for this API instance (e.g., "cars-api-v1")
     example: "cars-api-v1"
   technology:
-    userProvided: true
-    description: "Gateway technology for this instance: flexGateway, mule4, or mule3"
-    example: "flexGateway"
+    value: "flexGateway"
+    description: Gateway technology — this skill targets Flex Gateway deployments
   endpoint.uri:
     userProvided: true
     optional: true
     description: The upstream backend URL for the API. Ask the user if they want to provide it now or configure it later.
     example: "https://backend.example.com/api/v1"
+  endpoint.deploymentType:
+    value: "HY"
+    description: "Deployment type for self-managed Flex Gateway (HY = Hybrid)"
+  endpoint.isCloudHub:
+    value: null
+    description: "Must be null for flexGateway technology (not false — false causes a validation error)"
+  deployment.targetId:
+    from:
+      step: Select Deployment Target
+      output: targetId
+    description: Flex Gateway target ID from Step 3
+  deployment.gatewayVersion:
+    from:
+      step: Select Deployment Target
+      output: gatewayVersion
+    description: Flex Gateway runtime version from Step 3 (e.g., "1.12.2")
+  deployment.environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID (required in the deployment object)
+  deployment.type:
+    value: "HY"
+    description: "Deployment type (must match endpoint.deploymentType)"
 outputs:
   - name: environmentApiId
     path: $.id
     description: The API instance ID in API Manager, used to apply policies
 ```
 
-**What happens next:** Your API is now managed in API Manager. Next, you'll select a deployment target and apply policies before deploying.
-
-## Step 4: Select Deployment Target
-
-List available gateway targets registered in the environment. This identifies which self-managed Flex Gateway the API instance will be deployed to after policies are configured.
-
-**What you'll need:**
-- Organization ID and Environment ID
-
-**Action:** List gateway targets and select the Flex Gateway where the API will run.
-
-```yaml
-api: urn:api:api-portal-xapi
-operationId: getGatewayTargets
-inputs:
-  organizationId:
-    from:
-      api: urn:api:access-management
-      operation: listMe
-      field: $.user.organization.id
-    description: Organization ID
-  environmentId:
-    from:
-      step: List Environments
-      output: environmentId
-    description: Environment ID from Step 2
-outputs:
-  - name: targetId
-    path: $.data[*].id
-    labels: $.data[*].name
-    description: Selected gateway target ID
-  - name: targetName
-    path: $.data[*].name
-    description: Name of the selected gateway target
-```
-
-**What happens next:** You have a deployment target selected. Next, browse the policy catalog to choose which policy to apply before deploying.
+**What happens next:** Your API instance is created and bound to the Flex Gateway target. Next, browse the policy catalog to select which policy to apply.
 
 ## Step 5: Browse Exchange Policy Catalog
 
@@ -257,7 +285,7 @@ inputs:
     from:
       step: Create API Manager Instance
       output: environmentApiId
-    description: API instance ID from Step 3 (filters for compatible templates)
+    description: API instance ID from Step 4 (filters for compatible templates)
   environmentId:
     from:
       step: List Environments
@@ -321,7 +349,7 @@ inputs:
     from:
       step: Create API Manager Instance
       output: environmentApiId
-    description: API instance ID from Step 3 (or provided manually)
+    description: API instance ID from Step 4 (or provided manually)
   groupId:
     from:
       step: Browse Exchange Policy Catalog
@@ -343,7 +371,7 @@ outputs:
     description: The ID of the applied policy instance
 ```
 
-**What happens next:** The policy is configured on your API instance. Next, deploy the instance to your Flex Gateway so the policy starts enforcing.
+**What happens next:** Your API is now protected with the selected policy. Since the API instance was created with deployment information in Step 4, the policy is active and enforcing on the Flex Gateway.
 
 **Common issues:**
 - **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 5) to get these values.
@@ -351,62 +379,11 @@ outputs:
 - **409 Conflict**: A policy of this type may already be applied to the API instance. List existing policies first to check, or add `?allowDuplicated=true` to the request URL to apply a second instance of the same policy type.
 - **403 Forbidden**: You need **Manage Policies** permission in the target environment.
 
-## Step 7: Deploy API Instance to Flex Gateway
-
-Deploy the API instance to the selected Flex Gateway target. This activates the API and its policies so that incoming traffic is evaluated against them. Deploying after applying the policy ensures the policy is enforced from the first request.
-
-**What you'll need:**
-- Organization ID, Environment ID, and API instance ID
-- Deployment target ID from Step 4
-
-**Action:** Create a deployment for the API instance on the selected Flex Gateway target.
-
-```yaml
-api: urn:api:proxies-xapi
-operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
-inputs:
-  organizationId:
-    from:
-      api: urn:api:access-management
-      operation: listMe
-      field: $.user.organization.id
-    description: Organization ID
-  environmentId:
-    from:
-      step: List Environments
-      output: environmentId
-    description: Environment ID from Step 2
-  environmentApiId:
-    from:
-      step: Create API Manager Instance
-      output: environmentApiId
-    description: API instance ID from Step 3 (or provided manually)
-  type:
-    value: "HY"
-    description: "Deployment type for self-managed Flex Gateway (HY = Hybrid)"
-  target.targetId:
-    from:
-      step: Select Deployment Target
-      output: targetId
-    description: Flex Gateway target ID from Step 4
-outputs:
-  - name: deploymentId
-    path: $.id
-    description: The ID of the proxy deployment
-```
-
-**What happens next:** Your API is now deployed and protected. Traffic hitting the Flex Gateway will be evaluated against the applied policies.
-
-**Common issues:**
-- **400 Bad Request — missing targetId**: The deployment requires a valid target. Make sure you selected a target in Step 4.
-- **409 Conflict**: The API may already be deployed to this target. List existing deployments first to check.
-- **No targets available**: Ensure at least one Flex Gateway is registered and running in the target environment. Use the Flex Gateway Manager API to verify gateway status.
-
 ## Completion Checklist
 
 After completing all steps, verify:
 
-- [ ] API instance is deployed to the Flex Gateway target
+- [ ] API instance is bound to the Flex Gateway target (deployment info visible in API Manager)
 - [ ] Policy appears in the API instance's policy list
 - [ ] Policy status shows as "Active"
 - [ ] API requests are being evaluated against the policy rules
@@ -420,9 +397,9 @@ Your API is now protected with:
 - Selected policy is active on your API instance
 - All incoming traffic is evaluated against policy rules
 
-✅ **Deployed to Flex Gateway**
-- API instance is running on a self-managed Flex Gateway
-- Policies are enforced from the first request
+✅ **Bound to Flex Gateway**
+- API instance is created with deployment configuration targeting a self-managed Flex Gateway
+- The Flex Gateway picks up the configuration automatically
 
 ✅ **Managed configuration**
 - Policy settings are version-controlled in API Manager

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -34,21 +34,21 @@ Before starting, ensure you have:
    - An Exchange asset ready to be promoted to API Manager (skip to Step 2)
    - An API specification or URL that needs to be published first (start at Step 1)
 
-## Starting Point
+## Execution Paths
 
-This skill has multiple entry points depending on what you already have:
+This skill has multiple execution paths depending on what you already have:
 
-- **Start at Step 1** if you have an API specification file and need to publish it to Exchange first
+- **Full setup**: Steps 1, 2, 3, 4, 5, 6, 7
+  - When: You have an API specification file and need to publish it to Exchange first
   - You'll need: `organizationId`, API specification file
-  - Steps: 1, 2, 3, 4, 5, 6, 7
 
-- **Start at Step 2** if you already have an Exchange asset and need to create an API Manager instance
+- **From Exchange asset**: Steps 2, 3, 4, 5, 6, 7
+  - When: You already have an Exchange asset and need to create an API Manager instance
   - You'll need: `organizationId`, `groupId`, `assetId`, `assetVersion`
-  - Steps: 2, 3, 4, 5, 6, 7
 
-- **Start at Step 6** if you already have an API Manager instance and want to apply a policy
+- **Apply policy only**: Steps 2, 6, 7
+  - When: You already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
-  - Steps: 2, 6, 7
 
 
 ## Step 1: Publish API to Exchange

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -30,7 +30,7 @@ Before starting, ensure you have:
    - This is used to list environments, browse the policy catalog, check Exchange, etc.
 
 3. **One of the following**
-   - An API instance already in API Manager (skip to Step 5)
+   - An API instance already in API Manager (skip to Step 6)
    - An Exchange asset ready to be promoted to API Manager (skip to Step 2)
    - An API specification or URL that needs to be published first (start at Step 1)
 
@@ -40,15 +40,15 @@ This skill has multiple entry points depending on what you already have:
 
 - **Start at Step 1** if you have an API specification file and need to publish it to Exchange first
   - You'll need: `organizationId`, API specification file
-  - Steps: 1, 2, 3, 4, 5, 6
+  - Steps: 1, 2, 3, 4, 5, 6, 7
 
 - **Start at Step 2** if you already have an Exchange asset and need to create an API Manager instance
   - You'll need: `organizationId`, `groupId`, `assetId`, `assetVersion`
-  - Steps: 2, 3, 4, 5, 6
+  - Steps: 2, 3, 4, 5, 6, 7
 
-- **Start at Step 5** if you already have an API Manager instance and want to apply a policy
+- **Start at Step 6** if you already have an API Manager instance and want to apply a policy
   - You'll need: `organizationId`, `environmentId`, `environmentApiId`
-  - Steps: 2, 5, 6
+  - Steps: 2, 6, 7
 
 
 ## Step 1: Publish API to Exchange
@@ -133,7 +133,7 @@ outputs:
 
 ## Step 3: Select Deployment Target
 
-List available gateway targets registered in the environment. You need the target ID and gateway version before creating the API instance, because the instance creation request must include deployment information to properly bind it to the Flex Gateway.
+List available gateway targets registered in the environment. You need the target ID and gateway version before creating the API instance, because the deployment configuration is set via a PATCH after creation.
 
 **What you'll need:**
 - Organization ID and Environment ID
@@ -164,26 +164,25 @@ outputs:
     path: $.rows[*].name
     description: Name of the selected gateway target
   - name: gatewayVersion
-    path: $.rows[*].version
-    description: Runtime version of the selected Flex Gateway (e.g., "1.12.2")
+    value: "1.0.0"
+    description: Gateway version to use for deployment. The targets response may return "-" instead of a real version; use "1.0.0" as the default.
 ```
 
-**What happens next:** You have a deployment target and its gateway version. Next, create the API instance with this deployment information embedded.
+**What happens next:** You have a deployment target and its gateway version. Next, create the API instance and then configure its deployment target.
 
 ## Step 4: Create API Manager Instance
 
 > **Skip if:** You already have an API Manager instance with a known `environmentApiId`.
 
-Creates a managed API instance in API Manager from your Exchange asset, bound to the selected Flex Gateway target. The deployment information (target, gateway version, deployment type) must be included in the creation request — creating an instance without it leaves the API in an unregistered state that is difficult to deploy later.
+Creates a managed API instance in API Manager from your Exchange asset. This creates the API configuration; deployment to the Flex Gateway happens in Step 5.
 
 **Important:** For Flex Gateway instances, `isCloudHub` must be `null` (not `false`). Setting it to `false` causes a validation error.
 
 **What you'll need:**
 - Organization ID and Environment ID
 - Exchange asset coordinates (groupId, assetId, version)
-- Deployment target ID and gateway version from Step 3
 
-**Action:** Create an API instance in the target environment with embedded deployment configuration.
+**Action:** Create an API instance in the target environment.
 
 ```yaml
 api: urn:api:api-manager
@@ -222,44 +221,108 @@ inputs:
   technology:
     value: "flexGateway"
     description: Gateway technology — this skill targets Flex Gateway deployments
+  endpoint.isCloudHub:
+    value: null
+    description: "Must be null for flexGateway technology (not false — false causes a validation error)"
+  endpoint.proxyUri:
+    userProvided: true
+    description: "The proxy listener URI. Ask the user which port the Flex Gateway should listen on, then use http://0.0.0.0:<port>/"
+    example: "http://0.0.0.0:8081/"
   endpoint.uri:
     userProvided: true
     optional: true
     description: The upstream backend URL for the API. Ask the user if they want to provide it now or configure it later.
     example: "https://backend.example.com/api/v1"
-  endpoint.deploymentType:
+outputs:
+  - name: environmentApiId
+    path: $.id
+    description: The API instance ID in API Manager
+```
+
+**What happens next:** The API instance exists but is not yet deployed. Next, deploy it to the Flex Gateway target selected in Step 3.
+
+## Step 5: Deploy to Flex Gateway
+
+Deploys the API instance to the selected Flex Gateway target. This uses the Proxies API deployment endpoint with flat top-level fields — do **not** use the nested `target` object, which requires additional fields that are not needed for self-managed Flex Gateway deployments.
+
+**What you'll need:**
+- Organization ID, Environment ID, and API instance ID from Step 4
+- Deployment target ID and gateway version from Step 3
+
+**Action:** Create a deployment for the API instance on the selected Flex Gateway.
+
+```yaml
+api: urn:api:proxies-xapi
+operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+inputs:
+  organizationId:
+    from:
+      api: urn:api:access-management
+      operation: listMe
+      field: $.user.organization.id
+    description: Organization ID
+  environmentId:
+    from:
+      step: List Environments
+      output: environmentId
+    description: Environment ID from Step 2
+  environmentApiId:
+    from:
+      step: Create API Manager Instance
+      output: environmentApiId
+    description: API instance ID from Step 4
+  type:
     value: "HY"
     description: "Deployment type for self-managed Flex Gateway (HY = Hybrid)"
-  endpoint.isCloudHub:
-    value: null
-    description: "Must be null for flexGateway technology (not false — false causes a validation error)"
-  deployment.targetId:
+  targetId:
     from:
       step: Select Deployment Target
       output: targetId
     description: Flex Gateway target ID from Step 3
-  deployment.gatewayVersion:
+  targetName:
     from:
       step: Select Deployment Target
-      output: gatewayVersion
-    description: Flex Gateway runtime version from Step 3 (e.g., "1.12.2")
-  deployment.environmentId:
+      output: targetName
+    description: Flex Gateway target name from Step 3
+  gatewayVersion:
+    value: "1.0.0"
+    description: "Gateway version for deployment. Use \"1.0.0\" as the default."
+  environmentId:
     from:
       step: List Environments
       output: environmentId
-    description: Environment ID (required in the deployment object)
-  deployment.type:
-    value: "HY"
-    description: "Deployment type (must match endpoint.deploymentType)"
+    description: Environment ID (required in the deployment body for HY type)
+  overwrite:
+    value: false
+    description: "Whether to overwrite an existing deployment"
 outputs:
-  - name: environmentApiId
+  - name: deploymentId
     path: $.id
-    description: The API instance ID in API Manager, used to apply policies
+    description: The ID of the proxy deployment
 ```
 
-**What happens next:** Your API instance is created and bound to the Flex Gateway target. Next, browse the policy catalog to select which policy to apply.
+**Request body structure:** Use flat top-level fields, not the nested `target` object:
 
-## Step 5: Browse Exchange Policy Catalog
+```json
+{
+  "type": "HY",
+  "targetId": "<from Step 3>",
+  "targetName": "<from Step 3>",
+  "gatewayVersion": "1.0.0",
+  "environmentId": "<from Step 2>",
+  "overwrite": false
+}
+```
+
+**What happens next:** The API instance is now deployed to the Flex Gateway. Next, browse the policy catalog to select which policy to apply.
+
+**Common issues:**
+- **`"Field environmentId is required for deployment type HY"`**: The `environmentId` must be in the request body, not just the URL path parameter.
+- **`"Field gatewayVersion is required for deployment type HY"`**: Use the version from the `getGatewayTargets` response (Step 3). Using an incorrect version causes policy implementation errors.
+- **`"Policy implementations cannot be set because runtime version is unknown"`**: The `gatewayVersion` value doesn't match a known Flex Gateway version. Verify the version from the target's actual runtime version in Step 3.
+- **409 Conflict**: The API may already be deployed to this target. List existing deployments with `GET .../deployments` first to check.
+
+## Step 6: Browse Exchange Policy Catalog
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
@@ -319,16 +382,16 @@ outputs:
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
 - **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
-## Step 6: Apply Policy to API Instance
+## Step 7: Apply Policy to API Instance
 
-Apply the selected policy to your API instance with the appropriate configuration. Use the Exchange coordinates and configuration property names from Step 5.
+Apply the selected policy to your API instance with the appropriate configuration. Use the Exchange coordinates and configuration property names from Step 6.
 
 **What you'll need:**
 - Organization ID, Environment ID, and API instance ID
-- Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 5
-- Policy configuration based on the schema from Step 5's `policyConfiguration` output
+- Policy Exchange coordinates (groupId, assetId, assetVersion) from Step 6
+- Policy configuration based on the schema from Step 6's `policyConfiguration` output
 
-**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 5's configuration schema.
+**Action:** Apply the policy to your API instance. Build the `configurationData` object using the property names and defaults from Step 6's configuration schema.
 
 ```yaml
 api: urn:api:api-manager
@@ -354,28 +417,28 @@ inputs:
     from:
       step: Browse Exchange Policy Catalog
       output: policyGroupId
-    description: Policy Exchange group ID from Step 5
+    description: Policy Exchange group ID from Step 6
   assetId:
     from:
       step: Browse Exchange Policy Catalog
       output: policyAssetId
-    description: Policy Exchange asset ID from Step 5
+    description: Policy Exchange asset ID from Step 6
   assetVersion:
     from:
       step: Browse Exchange Policy Catalog
       output: policyAssetVersion
-    description: Policy Exchange version from Step 5
+    description: Policy Exchange version from Step 6
 outputs:
   - name: policyId
     path: $.id
     description: The ID of the applied policy instance
 ```
 
-**What happens next:** Your API is now protected with the selected policy. Since the API instance was created with deployment information in Step 4, the policy is active and enforcing on the Flex Gateway.
+**What happens next:** Your API is now protected with the selected policy. Since the API instance was configured with deployment information in Step 5, the policy is active and enforcing on the Flex Gateway.
 
 **Common issues:**
-- **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 5) to get these values.
-- **400 Bad Request — invalid configurationData**: The configuration property names differ between gateway types. Use the property names from Step 5's `policyConfiguration` output, not from the generic template endpoint. For example, Flex Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
+- **400 Bad Request — missing groupId/assetId/assetVersion**: The apply endpoint requires full Exchange coordinates, not just a template ID. Make sure you used `getExchangePolicyTemplates` (Step 6) to get these values.
+- **400 Bad Request — invalid configurationData**: The configuration property names differ between gateway types. Use the property names from Step 6's `policyConfiguration` output, not from the generic template endpoint. For example, Flex Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
 - **409 Conflict**: A policy of this type may already be applied to the API instance. List existing policies first to check, or add `?allowDuplicated=true` to the request URL to apply a second instance of the same policy type.
 - **403 Forbidden**: You need **Manage Policies** permission in the target environment.
 


### PR DESCRIPTION
## Summary

  - New skill: protect-api-with-policies — 7-step JTBD for protecting APIs on self-managed Flex Gateway, covering Exchange publishing, API Manager instance creation, proxies-xapi deployment,
  policy catalog browsing, and policy application
  - Portal generator: Copy $ref-referenced subdirectories (schemas/, examples/, requests/) alongside api.yaml so agents can resolve external schema references from the docs site
  - AGENTS.md: Add "Internal APIs" section listing private APIs that aren't in the public catalog but are referenced by skills
  - JTBD format: Rename "Starting Point" to "Execution Paths" with named routes (**Full setup**: Steps 1, 2, 3) replacing the old Start at Step N pattern — better reflects non-contiguous step
  sequences

## Test plan

  - 241 unit/smoke/OAS parser tests passing
  - Smoke tests for $ref subdirectory copying (4 new tests)
  - Execution paths parser tests cover new format
  - Skill validated through 7 manual test runs with iterative fixes