### PR TITLE
@W-21859986 refactor skills

### DIFF
--- a/.agents/skills/jtbd-generator/README.md
+++ b/.agents/skills/jtbd-generator/README.md
@@ -171,7 +171,7 @@ inputs = parameter_analyzer.build_all_inputs(
 
 # Detect source for a specific parameter
 source = parameter_analyzer.detect_parameter_source('environmentApiId', param_def, previous_steps)
-# Returns: {'source_type': 'from_step', 'source_details': {...}, 'confidence': 'high'}
+# Returns: {'source_type': 'from_variable', 'source_details': {...}, 'confidence': 'high'}
 ```
 
 ### response_analyzer.py

--- a/.agents/skills/jtbd-generator/lib/parameter_analyzer.py
+++ b/.agents/skills/jtbd-generator/lib/parameter_analyzer.py
@@ -254,15 +254,15 @@ def detect_parameter_source(
     Returns:
         Source detection result:
         {
-            'source_type': 'from_step' | 'from_api' | 'user_provided' | 'literal',
+            'source_type': 'from_variable' | 'from_api' | 'user_provided' | 'literal',
             'source_details': {...},
             'confidence': 'high' | 'medium' | 'low'
         }
 
     Example:
         source = detect_parameter_source('environmentApiId', param_def, previous_steps)
-        if source['source_type'] == 'from_step':
-            print(f"Use output from step {source['source_details']['step']}")
+        if source['source_type'] == 'from_variable':
+            print(f"Use variable {source['source_details']['variable']}")
     """
     if previous_steps is None:
         previous_steps = []
@@ -281,10 +281,9 @@ def detect_parameter_source(
             # Exact match or fuzzy match
             if output_name == param_name or output_name == base_param_name:
                 return {
-                    'source_type': 'from_step',
+                    'source_type': 'from_variable',
                     'source_details': {
-                        'step': step.get('name', f'Step {step_idx + 1}'),
-                        'output': output_name
+                        'variable': output_name
                     },
                     'confidence': 'high'
                 }
@@ -297,10 +296,9 @@ def detect_parameter_source(
         if param_name in step['inputs'] or base_param_name in step['inputs']:
             input_key = param_name if param_name in step['inputs'] else base_param_name
             return {
-                'source_type': 'from_step',
+                'source_type': 'from_variable',
                 'source_details': {
-                    'step': step.get('name', f'Step {step_idx + 1}'),
-                    'input': input_key
+                    'variable': input_key
                 },
                 'confidence': 'high'
             }
@@ -398,20 +396,15 @@ def build_input_definition(
     # Base definition
     definition = {}
 
-    if source_type == 'from_step':
-        # From previous step
+    if source_type == 'from_variable':
+        # From a previous step's variable
         definition['from'] = {
-            'step': source_details['step']
+            'variable': source_details['variable']
         }
-
-        if 'output' in source_details:
-            definition['from']['output'] = source_details['output']
-        elif 'input' in source_details:
-            definition['from']['input'] = source_details['input']
 
         definition['description'] = (
             param_def.get('description') or
-            f"Value from {source_details['step']}"
+            f"Variable {source_details['variable']} from a previous step"
         )
 
     elif source_type == 'from_api':

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -124,7 +124,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     environment:
       name: test
-      url: https://test-api-portal.mulesoft.com
+      url: https://test-dev-portal.mulesoft.com
 
     steps:
       - name: Checkout code
@@ -142,7 +142,7 @@ jobs:
         run: pip3 install --no-cache-dir -r scripts/requirements.txt
 
       - name: Generate portal for test
-        run: 'make generate-portal BUILD_LABEL="${{ github.ref_name }}: ${{ github.sha }}" BASE_URL=https://test-api-portal.mulesoft.com'
+        run: 'make generate-portal BUILD_LABEL="${{ github.ref_name }}: ${{ github.sha }}" BASE_URL=https://test-dev-portal.mulesoft.com'
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           GIT_COMMIT: ${{ github.sha }}
@@ -164,7 +164,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/release/')
     environment:
       name: production
-      url: https://api-portal.mulesoft.com
+      url: https://dev-portal.mulesoft.com
 
     steps:
       - name: Checkout code
@@ -183,7 +183,7 @@ jobs:
         run: pip3 install --no-cache-dir -r scripts/requirements.txt
 
       - name: Generate portal for production
-        run: 'make generate-portal BUILD_LABEL="${{ github.ref_name }}: ${{ github.sha }}" BASE_URL=https://api-portal.mulesoft.com'
+        run: 'make generate-portal BUILD_LABEL="${{ github.ref_name }}: ${{ github.sha }}" BASE_URL=https://dev-portal.mulesoft.com'
         env:
           BRANCH_NAME: ${{ github.ref_name }}
           GIT_COMMIT: ${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ $(API_DIRS):
 	@$(MAKE) validate-api API=$@
 
 # Generate static API documentation portal
-# Usage: make generate-portal [BUILD_LABEL="branch: sha"] [BASE_URL=https://api-portal.mulesoft.com]
+# Usage: make generate-portal [BUILD_LABEL="branch: sha"] [BASE_URL=https://dev-portal.mulesoft.com]
 PORTAL_ARGS :=
 ifdef BUILD_LABEL
 PORTAL_ARGS += --build-label "$(BUILD_LABEL)"

--- a/docs/job-template.md
+++ b/docs/job-template.md
@@ -46,10 +46,6 @@ This skill has multiple execution paths depending on what you already have:
 
 ## Step 1: [Action-Oriented Step Name]
 
-> **Skip if:** [Condition when this step can be skipped. Include which variables the user should already have.]
-
-(Optional - include the skip annotation only for steps that can be skipped)
-
 [Prose explanation of what this step does and why it's needed. Provide context about when this would be used and what it accomplishes.]
 
 **What you'll need:**
@@ -75,19 +71,17 @@ inputs:
       - field: $.alternativeFieldPath
         description: Alternative source for this value
 
-  # From previous step output
+  # From a previous step (variable reference)
   anotherParameter:
     from:
-      step: [Previous Step Name]
-      output: outputVariableName
-    description: The value captured from previous step
+      variable: outputVariableName
+    description: The value captured from a previous step
 
-  # From previous step input (reuse)
+  # Reuse a variable from any earlier step
   reusedParameter:
     from:
-      step: [Previous Step Name]
-      input: inputParameterName
-    description: Same value as used in previous step
+      variable: inputParameterName
+    description: Same value as used in a previous step
 
   # Literal value
   constantParameter:

--- a/docs/x-jobs-to-be-done-schema.md
+++ b/docs/x-jobs-to-be-done-schema.md
@@ -149,21 +149,20 @@ parameterName:
       description: Alternative field option
 ```
 
-#### 2. From Previous Step
+#### 2. From Previous Step (Variable Reference)
 ```yaml
-# Reference step output
+# Reference a variable from any previous step
 parameterName:
   from:
-    step: Create API Instance
-    output: environmentApiId
-  description: API instance from step 1
+    variable: environmentApiId
+  description: API instance from a previous step
 
-# Reference step input (reuse)
+# With optional field navigation (JSONPath on the resolved value)
 parameterName:
   from:
-    step: Create API Instance
-    input: organizationId
-  description: Same organizationId as step 1
+    variable: tiers
+    field: $[0].id
+  description: First tier ID from the tiers list
 ```
 
 #### 3. Literal Value
@@ -276,28 +275,6 @@ This skill has multiple execution paths depending on what you already have:
 - Referenced step numbers must exist in the skill
 - The step sequence may not be strictly sequential — some paths skip steps or include earlier steps needed for context (e.g., listing environments)
 
-#### Skip Annotations
-
-Add a blockquote annotation at the top of a step's prose to indicate when it can be skipped:
-
-```markdown
-## Step 1: Create Exchange Asset
-
-> **Skip if:** You already have an Exchange asset with a known `groupId`, `assetId`, and `assetVersion`.
-
-Creates a new API asset in Exchange from your API specification...
-```
-
-**Format rules:**
-- Use the exact pattern: `> **Skip if:** <condition text>`
-- Place it as the first content after the step header
-- The condition text should clearly state what the user needs to already have
-- The parser extracts this into a separate `skip_condition` field and renders it as a banner
-- In playground mode, steps with skip annotations get a "Skip this step" button
-- When a step is skipped, the portal prompts users to manually provide any required variables
-
-**Example:** See `skills/protect-api-with-policies/SKILL.md` for a complete working example of conditional steps.
-
 ### Validation
 
 Use the validator to check:
@@ -317,7 +294,6 @@ python3 scripts/build/validate_jtbd.py job.md /path/to/api-specs-root
 - ✅ Step dependencies are valid
 - ✅ Input/output references are correct
 - ⚠️ Execution Paths step references are in range (warning)
-- ⚠️ Skip annotations on steps with downstream dependencies (warning)
 
 ### Creating a New Job
 
@@ -482,22 +458,21 @@ parameterName:
 
 **URN Format:** `urn:api:{folder-name}` where folder-name matches the API directory
 
-### From Previous Step
+### From Previous Step (Variable Reference)
 
 ```yaml
-# Output reference
+# Reference a variable from any previous step
 parameterName:
   from:
-    step: Create API Instance          # Step name
-    output: environmentApiId           # Output variable
-  description: API instance from step 1
+    variable: environmentApiId
+  description: API instance from a previous step
 
-# Input reuse
+# With optional field navigation
 parameterName:
   from:
-    step: Create API Instance
-    input: organizationId
-  description: Same organizationId as step 1
+    variable: tiers
+    field: $[0].id
+  description: First tier ID from the tiers list
 ```
 
 ### Literal Value

--- a/scripts/build/deploy-test.sh
+++ b/scripts/build/deploy-test.sh
@@ -17,7 +17,7 @@ export AKAMAI_USERNAME="API_Portal_Team"
 echo "=== Generating portal (${BRANCH_NAME}: ${GIT_COMMIT}) ==="
 make -C "$REPO_ROOT" generate-portal \
   BUILD_LABEL="${BRANCH_NAME}: ${GIT_COMMIT}" \
-  BASE_URL=https://test-api-portal.mulesoft.com
+  BASE_URL=https://test-dev-portal.mulesoft.com
 
 # Deploy
 echo "=== Deploying to TEST | Host=${AKAMAI_HOST} User=${AKAMAI_USERNAME} ==="

--- a/scripts/build/validate_jtbd.py
+++ b/scripts/build/validate_jtbd.py
@@ -215,68 +215,25 @@ class JobValidator:
         return True
 
     def validate_step_dependencies(self, steps: List[Dict[str, Any]]) -> bool:
-        """Validate that step references are correct."""
+        """Validate that input references use recognized formats."""
         is_valid = True
-        step_outputs = {}
 
-        # Build map of available outputs by step index
         for i, step in enumerate(steps, 1):
-            if 'outputs' in step:
-                step_outputs[i] = [
-                    out['name'] for out in step['outputs']
-                    if isinstance(out, dict) and 'name' in out
-                ]
-
-        # Check each step's inputs
-        for i, step in enumerate(steps, 1):
-            step_num = i
             inputs = step.get('inputs', {})
 
             for param_name, input_def in inputs.items():
                 if not isinstance(input_def, dict):
                     continue
 
-                # Check step references
                 if 'from' in input_def and isinstance(input_def['from'], dict):
                     from_def = input_def['from']
 
-                    if 'step' in from_def:
-                        ref_step_identifier = from_def['step']
-
-                        # Try to parse as step number if it's numeric
-                        try:
-                            ref_step_num = int(ref_step_identifier) if isinstance(ref_step_identifier, (int, str)) and str(ref_step_identifier).isdigit() else None
-                        except (ValueError, TypeError):
-                            ref_step_num = None
-
-                        # If not numeric, it's a reference we can't validate without step names
-                        if ref_step_num is not None:
-                            # Check step exists (by number)
-                            if ref_step_num < 1 or ref_step_num > len(steps):
-                                self.errors.append(
-                                    f"Step {step_num}, input '{param_name}': "
-                                    f"References unknown step number {ref_step_num}"
-                                )
-                                is_valid = False
-                            # Check step comes before current step
-                            elif ref_step_num >= step_num:
-                                self.errors.append(
-                                    f"Step {step_num}, input '{param_name}': "
-                                    f"References step {ref_step_num} which comes after "
-                                    f"or is the same step"
-                                )
-                                is_valid = False
-                            # Check output exists if referencing output
-                            elif 'output' in from_def:
-                                output_name = from_def['output']
-                                if ref_step_num in step_outputs:
-                                    if output_name not in step_outputs[ref_step_num]:
-                                        self.errors.append(
-                                            f"Step {step_num}, input '{param_name}': "
-                                            f"References unknown output '{output_name}' "
-                                            f"from step {ref_step_num}"
-                                        )
-                                        is_valid = False
+                    # Recognized formats: variable reference or API reference
+                    if 'variable' not in from_def and 'api' not in from_def:
+                        self.warnings.append(
+                            f"Step {i}, input '{param_name}': "
+                            f"'from' block has no 'variable' or 'api' key"
+                        )
 
         return is_valid
 
@@ -310,65 +267,6 @@ class JobValidator:
                     print(f"  ⚠️  Path \"{name}\": Step {sn} out of range (1-{total_steps})")
             if step_nums:
                 print(f"  ✅ Path \"{name}\": steps {step_nums} valid")
-
-    def validate_skip_annotations(self, content: str, steps: List[Dict[str, Any]]):
-        """Warn about skip annotations on steps that have downstream dependencies."""
-        # Find steps with skip annotations
-        skip_pattern = re.compile(
-            r'^## Step (\d+):.*?\n.*?>\s*\*\*Skip if:\*\*',
-            re.MULTILINE | re.DOTALL
-        )
-        skippable_steps = set()
-        for m in skip_pattern.finditer(content):
-            skippable_steps.add(int(m.group(1)))
-
-        if not skippable_steps:
-            return
-
-        print("\n⏭️  Validating skip annotations...")
-
-        # Build output names per step
-        step_outputs = {}
-        for i, step in enumerate(steps, 1):
-            if 'outputs' in step:
-                step_outputs[i] = [
-                    out['name'] for out in step['outputs']
-                    if isinstance(out, dict) and 'name' in out
-                ]
-
-        # Check if downstream steps depend on skippable step outputs
-        for skip_step in sorted(skippable_steps):
-            if skip_step not in step_outputs:
-                print(f"  ✅ Step {skip_step}: skippable (no outputs)")
-                continue
-
-            dependents = []
-            for i, step in enumerate(steps, 1):
-                if i <= skip_step:
-                    continue
-                inputs = step.get('inputs', {})
-                for param_name, input_def in inputs.items():
-                    if not isinstance(input_def, dict):
-                        continue
-                    from_def = input_def.get('from', {})
-                    if isinstance(from_def, dict) and 'step' in from_def:
-                        try:
-                            ref = int(from_def['step']) if str(from_def['step']).isdigit() else None
-                        except (ValueError, TypeError):
-                            ref = None
-                        if ref == skip_step:
-                            dependents.append(i)
-                            break
-
-            if dependents:
-                dep_str = ', '.join(f'Step {d}' for d in dependents)
-                self.warnings.append(
-                    f"Step {skip_step} has a skip annotation but {dep_str} "
-                    f"depend(s) on its outputs. Users must provide these values manually when skipping."
-                )
-                print(f"  ⚠️  Step {skip_step}: skippable, but {dep_str} depend on its outputs")
-            else:
-                print(f"  ✅ Step {skip_step}: skippable (no downstream dependencies)")
 
     def validate(self) -> bool:
         """Run all validations and return True if valid."""
@@ -463,9 +361,6 @@ class JobValidator:
 
         # 7. Validate Execution Paths section (optional)
         self.validate_execution_paths(content, len(steps))
-
-        # 8. Warn about skip annotations on steps with downstream dependencies
-        self.validate_skip_annotations(content, steps)
 
         # Print summary
         self.print_summary()

--- a/scripts/generate_portal.py
+++ b/scripts/generate_portal.py
@@ -40,8 +40,8 @@ def main():
                         help='Repository root (default: current directory)')
     parser.add_argument('--build-label', type=str, default=None,
                         help='Build label (default: auto-detect from git)')
-    parser.add_argument('--base-url', type=str, default='https://api-portal.mulesoft.com',
-                        help='Base URL of the deployed portal (default: https://api-portal.mulesoft.com)')
+    parser.add_argument('--base-url', type=str, default='https://dev-portal.mulesoft.com',
+                        help='Base URL of the deployed portal (default: https://dev-portal.mulesoft.com)')
 
     args = parser.parse_args()
 

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -3169,14 +3169,37 @@ function toggleSkillDropdown(slug) {
     if (toggle) toggle.setAttribute('aria-expanded', isVisible ? 'false' : 'true');
 }
 
-function copySkillInstallCommand(slug, buttonEl) {
-    var command = 'npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill ' + slug;
+function openInstallModal(slug) {
+    var modal = document.getElementById('install-modal-' + slug);
+    if (modal) modal.style.display = 'flex';
+    _closeAllSkillDropdowns();
+}
+
+function closeInstallModal(slug) {
+    var modal = document.getElementById('install-modal-' + slug);
+    if (modal) modal.style.display = 'none';
+}
+
+function copyInstallFromModal(slug, buttonEl) {
+    var codeEl = document.getElementById('install-cmd-' + slug);
+    if (!codeEl) return;
+    var command = codeEl.textContent;
     navigator.clipboard.writeText(command).then(function() {
-        _showSkillCopiedFeedback(buttonEl);
+        if (!buttonEl) return;
+        var label = buttonEl.querySelector('span');
+        if (!label) return;
+        var saved = label.textContent;
+        label.textContent = 'Copied!';
+        buttonEl.style.color = '#04844B';
+        buttonEl.style.borderColor = '#04844B';
+        setTimeout(function() {
+            label.textContent = saved;
+            buttonEl.style.color = '';
+            buttonEl.style.borderColor = '';
+        }, 1500);
     }).catch(function(err) {
         console.error('Failed to copy install command:', err);
     });
-    _closeAllSkillDropdowns();
 }
 
 function copySkillContent(slug, buttonEl) {

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -5715,9 +5715,8 @@ function renderWorkflowStepForms(skillSlug) {
 
                     // Source hint
                     var hint = '';
-                    if (hasFrom && bf.def.from.step) {
-                        var target = bf.def.from.output || bf.def.from.input || '';
-                        hint = 'from Step: ' + bf.def.from.step + (target ? ' → ' + target : '');
+                    if (hasFrom && bf.def.from.variable) {
+                        hint = 'from variable: ' + bf.def.from.variable;
                     } else if (isUserProvided) {
                         hint = 'user provided';
                     } else if (bf.def.value !== undefined) {
@@ -5918,31 +5917,34 @@ function resolveWorkflowInputs(skillSlug, stepIndex) {
             resolvedFrom = 'static';
         }
 
-        // 2. From previous step
-        if (source.from && typeof source.from === 'object' && source.from.step) {
-            var stepName = source.from.step;
-            var fromOutput = source.from.output;
-            var fromInput = source.from.input;
+        // 2. From variable (search previous steps in reverse order)
+        if (source.from && typeof source.from === 'object' && source.from.variable) {
+            var varName = source.from.variable;
             var field = source.from.field || '';
 
-            // Find the step index by title
-            var srcStepIdx = findStepByTitle(skillSlug, stepName);
-            if (srcStepIdx >= 0 && ctx.stepResults[srcStepIdx]) {
-                var srcResult = ctx.stepResults[srcStepIdx];
-                var val = null;
-                if (fromOutput && srcResult.outputs[fromOutput] !== undefined) {
-                    val = srcResult.outputs[fromOutput];
-                } else if (fromInput && srcResult.inputs[fromInput] !== undefined) {
-                    val = srcResult.inputs[fromInput];
+            // Search previous steps in reverse order (most recent first)
+            var val = null;
+            for (var s = stepIndex - 1; s >= 0; s--) {
+                if (!ctx.stepResults[s]) continue;
+                var srcResult = ctx.stepResults[s];
+                // Check outputs first (higher priority)
+                if (srcResult.outputs && srcResult.outputs[varName] !== undefined) {
+                    val = srcResult.outputs[varName];
+                    break;
                 }
-                // Apply field navigation if present
-                if (val != null && field) {
-                    val = extractByPath(val, field);
+                // Then check inputs
+                if (srcResult.inputs && srcResult.inputs[varName] !== undefined) {
+                    val = srcResult.inputs[varName];
+                    break;
                 }
-                if (val != null) {
-                    resolved = typeof val === 'object' ? JSON.stringify(val) : String(val);
-                    resolvedFrom = 'step';
-                }
+            }
+            // Apply field navigation if present
+            if (val != null && field) {
+                val = extractByPath(val, field);
+            }
+            if (val != null) {
+                resolved = typeof val === 'object' ? JSON.stringify(val) : String(val);
+                resolvedFrom = 'variable';
             }
         }
 

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -3180,11 +3180,11 @@ function copySkillInstallCommand(slug, buttonEl) {
 }
 
 function copySkillContent(slug, buttonEl) {
-    var tpl = document.getElementById('skill-raw-' + slug);
-    if (!tpl) return;
-    var content = tpl.content ? tpl.content.textContent : tpl.textContent;
-    navigator.clipboard.writeText(content).then(function() {
-        _showSkillCopiedFeedback(buttonEl);
+    var url = '../skills/' + slug + '/SKILL.md';
+    fetch(url).then(function(res) { return res.text(); }).then(function(content) {
+        navigator.clipboard.writeText(content).then(function() {
+            _showSkillCopiedFeedback(buttonEl);
+        });
     }).catch(function(err) {
         console.error('Failed to copy skill content:', err);
     });

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -3147,6 +3147,90 @@ function copyCurlFromTerminal(button) {
 }
 
 // ============================================================================
+// Skill Actions Dropdown
+// ============================================================================
+
+function toggleSkillDropdown(slug) {
+    var menu = document.getElementById('skill-dropdown-menu-' + slug);
+    if (!menu) return;
+    var toggle = menu.closest('.skill-split-btn').querySelector('.skill-split-toggle');
+
+    // Close any other open skill dropdowns
+    document.querySelectorAll('.skill-dropdown-menu').forEach(function(m) {
+        if (m !== menu && m.style.display !== 'none') {
+            m.style.display = 'none';
+            var t = m.closest('.skill-split-btn').querySelector('.skill-split-toggle');
+            if (t) t.setAttribute('aria-expanded', 'false');
+        }
+    });
+
+    var isVisible = menu.style.display !== 'none';
+    menu.style.display = isVisible ? 'none' : 'block';
+    if (toggle) toggle.setAttribute('aria-expanded', isVisible ? 'false' : 'true');
+}
+
+function copySkillInstallCommand(slug, buttonEl) {
+    var command = 'npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill ' + slug;
+    navigator.clipboard.writeText(command).then(function() {
+        _showSkillCopiedFeedback(buttonEl);
+    }).catch(function(err) {
+        console.error('Failed to copy install command:', err);
+    });
+    _closeAllSkillDropdowns();
+}
+
+function copySkillContent(slug, buttonEl) {
+    var tpl = document.getElementById('skill-raw-' + slug);
+    if (!tpl) return;
+    var content = tpl.content ? tpl.content.textContent : tpl.textContent;
+    navigator.clipboard.writeText(content).then(function() {
+        _showSkillCopiedFeedback(buttonEl);
+    }).catch(function(err) {
+        console.error('Failed to copy skill content:', err);
+    });
+    _closeAllSkillDropdowns();
+}
+
+function _showSkillCopiedFeedback(buttonEl) {
+    if (!buttonEl) return;
+    var splitBtn = buttonEl.closest('.skill-split-btn');
+    if (!splitBtn) return;
+    var mainBtn = splitBtn.querySelector('.skill-split-main');
+    if (!mainBtn) return;
+    var label = mainBtn.querySelector('span');
+    if (!label) return;
+    var saved = label.textContent;
+    label.textContent = 'Copied!';
+    mainBtn.style.background = '#04844B';
+    mainBtn.style.color = 'white';
+    mainBtn.style.borderColor = '#04844B';
+    setTimeout(function() {
+        label.textContent = saved;
+        mainBtn.style.background = '';
+        mainBtn.style.color = '';
+        mainBtn.style.borderColor = '';
+    }, 1500);
+}
+
+function _closeAllSkillDropdowns() {
+    document.querySelectorAll('.skill-dropdown-menu').forEach(function(m) {
+        m.style.display = 'none';
+        var splitBtn = m.closest('.skill-split-btn');
+        if (splitBtn) {
+            var t = splitBtn.querySelector('.skill-split-toggle');
+            if (t) t.setAttribute('aria-expanded', 'false');
+        }
+    });
+}
+
+// Close skill dropdown on outside click
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('.skill-split-btn')) {
+        _closeAllSkillDropdowns();
+    }
+});
+
+// ============================================================================
 // Response Status Selector
 // ============================================================================
 

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -3777,50 +3777,44 @@ details[open] .examples-toggle-icon {
 }
 
 .skill-split-main {
+    height: 32px;
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     gap: 0.375rem;
-    padding: 0.375rem 0.75rem;
-    font-size: var(--lume-font-size-3);
+    padding: 0 1rem;
+    font-size: var(--lume-font-size-2);
     font-family: var(--font-sans);
-    font-weight: 500;
-    color: #374151;
-    background: #ffffff;
-    border: 1px solid #d1d5db;
-    border-right: none;
-    border-radius: 6px 0 0 6px;
+    font-weight: var(--lume-font-weight-semibold);
+    color: #3289CE;
+    background: var(--lume-color-neutral-1);
+    border: 1px solid #5C5C5C;
+    border-radius: 16px 0 0 16px;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: opacity 0.15s;
     white-space: nowrap;
 }
 
 .skill-split-main:hover {
-    background: var(--lume-color-brand);
-    color: white;
-    border-color: var(--lume-color-brand);
+    opacity: 0.9;
 }
 
 .skill-split-toggle {
+    height: 32px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.375rem 0.5rem;
-    background: #ffffff;
-    border: 1px solid #d1d5db;
-    border-radius: 0 6px 6px 0;
-    color: #374151;
+    padding: 0 0.625rem;
+    background: white;
+    color: var(--lume-color-brand);
+    border: 1px solid #5C5C5C;
+    border-radius: 0 16px 16px 0;
     cursor: pointer;
     transition: all 0.2s ease;
 }
 
 .skill-split-toggle:hover {
-    background: var(--lume-color-brand);
-    color: white;
-    border-color: var(--lume-color-brand);
-}
-
-.skill-split-main:hover + .skill-split-toggle {
-    border-left-color: var(--lume-color-brand);
+    background: var(--lume-color-neutral-2);
 }
 
 .skill-split-toggle .chevron-icon {
@@ -3838,10 +3832,10 @@ details[open] .examples-toggle-icon {
     min-width: 210px;
     background: #ffffff;
     border: 1px solid #d1d5db;
-    border-radius: 8px;
+    border-radius: 16px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
     z-index: 100;
-    overflow: hidden;
+    padding: 4px;
 }
 
 .skill-dropdown-menu button,
@@ -3850,29 +3844,24 @@ details[open] .examples-toggle-icon {
     align-items: center;
     gap: 8px;
     width: 100%;
-    padding: 10px 14px;
-    font-size: var(--lume-font-size-3);
+    padding: 8px 16px;
+    font-size: var(--lume-font-size-2);
     font-family: var(--font-sans);
-    font-weight: 500;
-    color: #374151;
+    font-weight: var(--lume-font-weight-semibold);
+    color: #5A5A56;
     background: none;
     border: none;
+    border-radius: 15px;
     cursor: pointer;
     text-decoration: none;
     text-align: left;
-    transition: all 0.15s ease;
+    transition: all 0.2s ease;
 }
 
 .skill-dropdown-menu button:hover,
 .skill-dropdown-menu a:hover {
-    background: var(--lume-color-brand);
-    color: white;
-}
-
-.skill-dropdown-menu button + button,
-.skill-dropdown-menu button + a,
-.skill-dropdown-menu a + button {
-    border-top: 1px solid #e5e7eb;
+    background: var(--hover-bg);
+    color: var(--hover-text);
 }
 
 .skill-name-sidebar {

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -3789,6 +3789,7 @@ details[open] .examples-toggle-icon {
     color: #3289CE;
     background: var(--lume-color-neutral-1);
     border: 1px solid #5C5C5C;
+    border-right: none;
     border-radius: 16px 0 0 16px;
     cursor: pointer;
     transition: opacity 0.15s;
@@ -3862,6 +3863,131 @@ details[open] .examples-toggle-icon {
 .skill-dropdown-menu a:hover {
     background: var(--hover-bg);
     color: var(--hover-text);
+}
+
+/* Install Command Modal */
+.install-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.install-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.install-modal-content {
+    position: relative;
+    background: white;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    max-width: 560px;
+    width: 90%;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.install-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.install-modal-header h3 {
+    margin: 0;
+    font-size: var(--lume-font-size-6);
+    font-family: var(--font-sans);
+    font-weight: var(--lume-font-weight-semibold);
+    color: #1f2937;
+}
+
+.install-modal-body {
+    padding: 1.5rem;
+}
+
+.install-command-row {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    margin-bottom: 1.5rem;
+}
+
+.install-command-bracket {
+    font-size: 1.25rem;
+    font-weight: 300;
+    color: #9ca3af;
+    padding: 0 0.25rem;
+    user-select: none;
+}
+
+.install-command-code {
+    flex: 1;
+    padding: 0.625rem 0.75rem;
+    background: #F0F7FF;
+    border: none;
+    border-radius: 0;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: var(--lume-font-size-2);
+    color: #1f2937;
+    word-break: break-all;
+    user-select: all;
+}
+
+.btn-install-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-left: 0.5rem;
+    padding: 0.5rem 0.875rem;
+    font-size: var(--lume-font-size-2);
+    font-family: var(--font-sans);
+    font-weight: var(--lume-font-weight-semibold);
+    color: #3289CE;
+    background: white;
+    border: 1px solid #B3D2EC;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+}
+
+.btn-install-copy:hover {
+    background: #F0F7FF;
+}
+
+.install-prereqs h4 {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin: 0 0 0.75rem 0;
+    font-size: var(--lume-font-size-4);
+    font-family: var(--font-sans);
+    font-weight: var(--lume-font-weight-semibold);
+    color: #1f2937;
+}
+
+.install-prereqs h4 svg {
+    color: #9ca3af;
+}
+
+.install-prereqs p {
+    margin: 0;
+    font-size: var(--lume-font-size-3);
+    font-family: var(--font-sans);
+    color: #5A5A56;
+    line-height: 1.6;
 }
 
 .skill-name-sidebar {

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -3764,6 +3764,117 @@ details[open] .examples-toggle-icon {
     background: var(--lume-color-neutral-2);
 }
 
+/* Skill actions split button */
+.skill-actions-bar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--lume-space-medium);
+}
+
+.skill-split-btn {
+    position: relative;
+    display: inline-flex;
+}
+
+.skill-split-main {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.75rem;
+    font-size: var(--lume-font-size-3);
+    font-family: var(--font-sans);
+    font-weight: 500;
+    color: #374151;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-right: none;
+    border-radius: 6px 0 0 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.skill-split-main:hover {
+    background: var(--lume-color-brand);
+    color: white;
+    border-color: var(--lume-color-brand);
+}
+
+.skill-split-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.375rem 0.5rem;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 0 6px 6px 0;
+    color: #374151;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.skill-split-toggle:hover {
+    background: var(--lume-color-brand);
+    color: white;
+    border-color: var(--lume-color-brand);
+}
+
+.skill-split-main:hover + .skill-split-toggle {
+    border-left-color: var(--lume-color-brand);
+}
+
+.skill-split-toggle .chevron-icon {
+    transition: transform 0.2s;
+}
+
+.skill-split-toggle[aria-expanded="true"] .chevron-icon {
+    transform: rotate(180deg);
+}
+
+.skill-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 210px;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    z-index: 100;
+    overflow: hidden;
+}
+
+.skill-dropdown-menu button,
+.skill-dropdown-menu a {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 14px;
+    font-size: var(--lume-font-size-3);
+    font-family: var(--font-sans);
+    font-weight: 500;
+    color: #374151;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: left;
+    transition: all 0.15s ease;
+}
+
+.skill-dropdown-menu button:hover,
+.skill-dropdown-menu a:hover {
+    background: var(--lume-color-brand);
+    color: white;
+}
+
+.skill-dropdown-menu button + button,
+.skill-dropdown-menu button + a,
+.skill-dropdown-menu a + button {
+    border-top: 1px solid #e5e7eb;
+}
+
 .skill-name-sidebar {
     flex: 1;
 }

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -110,7 +110,7 @@ def _prepare_operations(apis: List[Dict]):
 
 class PortalGenerator:
     def __init__(self, output_dir: Path, proxy_url: str = 'http://localhost:8080/proxy',
-                 build_label: str = 'unknown', base_url: str = 'https://api-portal.mulesoft.com'):
+                 build_label: str = 'unknown', base_url: str = 'https://dev-portal.mulesoft.com'):
         self.output_dir = output_dir
         self.proxy_url = proxy_url
         self.build_label = build_label

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -41,12 +41,6 @@ def _extract_yaml_blocks(content: str) -> List[Dict]:
 
 _yaml_fence_pattern = re.compile(r'```ya?ml\s*\n.*?```', re.DOTALL)
 
-# Pattern for > **Skip if:** blockquote annotations in step prose
-_skip_annotation_pattern = re.compile(
-    r'^>\s*\*\*Skip if:\*\*\s*(.+?)(?:\n(?!>)|\Z)',
-    re.MULTILINE | re.DOTALL,
-)
-
 # Pattern for execution paths: - **Path name**: Steps N, N, N
 _exec_path_pattern = re.compile(
     r'^\- \*\*(.+?)\*\*:\s*Steps\s+(.+?)$',
@@ -68,21 +62,6 @@ def _strip_redundant_prose(text: str) -> str:
     for pattern in _redundant_prose_patterns:
         text = pattern.sub('', text)
     return text.strip()
-
-
-def _extract_skip_annotation(text: str) -> tuple:
-    """Extract '> **Skip if:**' blockquote from step prose.
-    Returns (skip_condition_text, cleaned_prose) or (None, original_text)."""
-    match = _skip_annotation_pattern.search(text)
-    if not match:
-        return None, text
-    condition = match.group(1).strip()
-    # Remove trailing > continuation lines that are part of the blockquote
-    # and clean up the annotation from the prose
-    cleaned = text[:match.start()] + text[match.end():]
-    # Remove any leftover blank lines from extraction
-    cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
-    return condition, cleaned.strip()
 
 
 def _extract_entry_points(content: str) -> List[Dict]:
@@ -156,15 +135,11 @@ def _extract_step_details(content: str) -> List[Dict]:
             prose_before = _strip_redundant_prose(body)
             prose_after = ''
 
-        # Extract skip annotation from prose_before
-        skip_condition, prose_before_clean = _extract_skip_annotation(prose_before)
-
         steps.append({
             'title': header,
             'yaml': yaml_data,
-            'prose_before_html': _md.render(prose_before_clean) if prose_before_clean else '',
+            'prose_before_html': _md.render(prose_before) if prose_before else '',
             'prose_after_html': _md.render(prose_after) if prose_after else '',
-            'skip_condition': skip_condition,
         })
         i += 2
 

--- a/scripts/portal_generator/template_env.py
+++ b/scripts/portal_generator/template_env.py
@@ -132,7 +132,7 @@ def _resolve_skill_inputs(inputs_dict, step_details):
     Converts:
         {
             'organizationId': {
-                'from': {'step': 'Get Current Organization', 'output': 'organizationId'},
+                'from': {'variable': 'organizationId'},
                 'description': '...'
             }
         }
@@ -167,10 +167,9 @@ def _resolve_skill_inputs(inputs_dict, step_details):
         if 'from' in param_config:
             from_ref = param_config['from']
             if isinstance(from_ref, dict):
-                # Check if it's a step reference (has 'step' key)
-                if 'step' in from_ref:
-                    # Try both 'output' and 'input' fields
-                    var_name = from_ref.get('output') or from_ref.get('input', '')
+                # Check if it's a variable reference (has 'variable' key)
+                if 'variable' in from_ref:
+                    var_name = from_ref['variable']
 
                     if var_name:
                         # Create the reference string - just ${variableName}

--- a/scripts/portal_generator/templates/agents_md.html
+++ b/scripts/portal_generator/templates/agents_md.html
@@ -120,7 +120,7 @@ Skills are multi-step API workflows in markdown. Each `SKILL.md` has:
 
 | Type | Key | Description |
 |---|---|---|
-| From previous step | `from.step` + `from.output` | Output from an earlier workflow step |
+| From previous step | `from.variable` | Variable from an earlier workflow step |
 | From API | `from.api` + `from.operation` + `from.field` | Value fetched from an API call |
 | User-provided | `userProvided: true` | Must be supplied by the user/agent |
 | Literal | `value: "..."` | Static constant |
@@ -150,7 +150,7 @@ Filter: entries where kind == "agent-skill" AND apis contains "{api-slug}"
 2. Parse YAML frontmatter and step blocks
 3. For each step, resolve the API spec: `GET {{ base_url }}/apis/{slug}/api.yaml`
 4. Find the operation by `operationId`, build the request from inputs
-5. Chain outputs from one step into the next step's inputs
+5. Chain variables between steps — outputs and resolved inputs become available to subsequent steps
 
 ### Resolve x-origin dynamic values
 

--- a/scripts/portal_generator/templates/skills/macros.html
+++ b/scripts/portal_generator/templates/skills/macros.html
@@ -4,10 +4,8 @@
 {% elif input_def is mapping %}
 {% if input_def['from'] is defined and input_def['from'] is mapping %}
 {% set src = input_def['from'] %}
-{% if src.step is defined %}
-{% set ref = 'Step: ' ~ src.step %}
-{% if src.output %}{% set ref = ref ~ ' → ' ~ src.output %}{% elif src.input %}{% set ref = ref ~ ' → ' ~ src.input %}{% endif %}
-<span class="input-from-step">{{ ref }}</span>
+{% if src.variable is defined %}
+<span class="input-from-variable">{{ src.variable }}</span>
 {% elif src.api is defined %}
 {% set api_name = src.api|default('')|replace('urn:api:', '') %}
 {% set op = src.operation|default('') %}
@@ -32,9 +30,8 @@
 {% if input_def is mapping %}
 {% if input_def['from'] is defined and input_def['from'] is mapping %}
 {% set src = input_def['from'] %}
-{% if src.step is defined %}
-{% set target = src.output|default('') or src.input|default('') %}
-from Step: {{ src.step }} → {{ target }}
+{% if src.variable is defined %}
+from variable: {{ src.variable }}
 {% elif src.api is defined %}
 {% set api_name = src.api|default('')|replace('urn:api:', '') %}
 from {{ api_name }}#{{ src.operation|default('') }}

--- a/scripts/portal_generator/templates/skills/skill_detail.html
+++ b/scripts/portal_generator/templates/skills/skill_detail.html
@@ -9,26 +9,25 @@
     {# Skill actions split button #}
     <div class="skill-actions-bar">
         <div class="skill-split-btn" id="skill-actions-{{ slug }}">
-            <button class="skill-split-main" onclick="copySkillInstallCommand('{{ slug }}', this)">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            <button class="skill-split-main" onclick="openInstallModal('{{ slug }}')">
                 <span>Install Command</span>
             </button>
             <button class="skill-split-toggle" onclick="toggleSkillDropdown('{{ slug }}')" aria-haspopup="true" aria-expanded="false">
                 <svg class="chevron-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
             </button>
             <div class="skill-dropdown-menu" id="skill-dropdown-menu-{{ slug }}" style="display:none">
-                <button onclick="copySkillInstallCommand('{{ slug }}', this)">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-                    Install Command
-                </button>
-                <button onclick="copySkillContent('{{ slug }}', this)">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
-                    Copy Skill
+                <button onclick="openInstallModal('{{ slug }}')">
+                    <svg width="12" height="13" viewBox="0 0 12 13" fill="none"><path d="M11 6.5L0.5 13V0.5L11 6.5Z" stroke="currentColor" stroke-linejoin="round"/></svg>
+                    Install Skill Command
                 </button>
                 <a href="../skills/{{ slug }}/SKILL.md" target="_blank" rel="noopener">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
-                    Open Markdown
+                    Open Skill Markdown
                 </a>
+                <button onclick="copySkillContent('{{ slug }}', this)">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                    Copy Skill
+                </button>
             </div>
         </div>
     </div>
@@ -141,6 +140,34 @@
         <div class="skill-view-markdown">{{ skill.completion_checklist_html|safe }}</div>
     </div>
     {% endif %}
+
+    {# Install Command Modal #}
+    <div class="install-modal" id="install-modal-{{ slug }}" style="display:none" role="dialog" aria-modal="true">
+        <div class="install-modal-overlay" onclick="closeInstallModal('{{ slug }}')"></div>
+        <div class="install-modal-content">
+            <div class="install-modal-header">
+                <h3>Install Command</h3>
+                <button class="btn-close-modal" onclick="closeInstallModal('{{ slug }}')" aria-label="Close modal">&times;</button>
+            </div>
+            <div class="install-modal-body">
+                <div class="install-command-row">
+                    <span class="install-command-bracket">[</span>
+                    <code class="install-command-code" id="install-cmd-{{ slug }}">npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill {{ slug }}</code>
+                    <span class="install-command-bracket">]</span>
+                    <button class="btn-install-copy" onclick="copyInstallFromModal('{{ slug }}', this)">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                        <span>Copy</span>
+                    </button>
+                </div>
+                <div class="install-prereqs">
+                    <h4>
+                        Pre requisites
+                    </h4>
+                    <p>Requires <strong>Node.js</strong> and <strong>npm</strong> installed on your system. The <code>npx</code> command (included with npm) will automatically download and run the skills CLI.</p>
+                </div>
+            </div>
+        </div>
+    </div>
 
 </section>
 {% endmacro %}

--- a/scripts/portal_generator/templates/skills/skill_detail.html
+++ b/scripts/portal_generator/templates/skills/skill_detail.html
@@ -11,7 +11,7 @@
         <div class="skill-split-btn" id="skill-actions-{{ slug }}">
             <button class="skill-split-main" onclick="copySkillInstallCommand('{{ slug }}', this)">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-                <span>Copy Install Command</span>
+                <span>Install Command</span>
             </button>
             <button class="skill-split-toggle" onclick="toggleSkillDropdown('{{ slug }}')" aria-haspopup="true" aria-expanded="false">
                 <svg class="chevron-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
@@ -19,7 +19,7 @@
             <div class="skill-dropdown-menu" id="skill-dropdown-menu-{{ slug }}" style="display:none">
                 <button onclick="copySkillInstallCommand('{{ slug }}', this)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-                    Copy Install Command
+                    Install Command
                 </button>
                 <button onclick="copySkillContent('{{ slug }}', this)">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
@@ -32,7 +32,6 @@
             </div>
         </div>
     </div>
-    <template id="skill-raw-{{ slug }}">{{ skill.raw_content }}</template>
 
     {# Overview and Prerequisites - Always visible in both modes #}
     {% if skill.overview_html or skill.description %}

--- a/scripts/portal_generator/templates/skills/skill_detail.html
+++ b/scripts/portal_generator/templates/skills/skill_detail.html
@@ -6,6 +6,34 @@
 {% set step_details = skill.step_details|default([]) %}
 
 <section id="skill-{{ slug }}" class="content-section skill-detail">
+    {# Skill actions split button #}
+    <div class="skill-actions-bar">
+        <div class="skill-split-btn" id="skill-actions-{{ slug }}">
+            <button class="skill-split-main" onclick="copySkillInstallCommand('{{ slug }}', this)">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+                <span>Copy Install Command</span>
+            </button>
+            <button class="skill-split-toggle" onclick="toggleSkillDropdown('{{ slug }}')" aria-haspopup="true" aria-expanded="false">
+                <svg class="chevron-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+            <div class="skill-dropdown-menu" id="skill-dropdown-menu-{{ slug }}" style="display:none">
+                <button onclick="copySkillInstallCommand('{{ slug }}', this)">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+                    Copy Install Command
+                </button>
+                <button onclick="copySkillContent('{{ slug }}', this)">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                    Copy Skill
+                </button>
+                <a href="../skills/{{ slug }}/SKILL.md" target="_blank" rel="noopener">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                    Open Markdown
+                </a>
+            </div>
+        </div>
+    </div>
+    <template id="skill-raw-{{ slug }}">{{ skill.raw_content }}</template>
+
     {# Overview and Prerequisites - Always visible in both modes #}
     {% if skill.overview_html or skill.description %}
     <div id="overview" class="skill-subsection">

--- a/scripts/portal_generator/templates/skills/step_documentation.html
+++ b/scripts/portal_generator/templates/skills/step_documentation.html
@@ -94,10 +94,8 @@
 {% macro render_input_value(defn) -%}
 {% if defn is mapping %}
 {% if defn.from is defined %}
-{% set from_step = defn.from.step|default('') %}
-{% set from_input = defn.from.input|default('') %}
-{% set from_output = defn.from.output|default('') %}
-{% if from_input %}{{ '{{' }}{{ from_step|slugify }}.{{ from_input }}{{ '}}' }}{% elif from_output %}{{ '{{' }}{{ from_step|slugify }}.{{ from_output }}{{ '}}' }}{% endif %}
+{% set from_variable = defn.from.variable|default('') %}
+{% if from_variable %}{{ '{{' }}{{ from_variable }}{{ '}}' }}{% endif %}
 {% elif defn.value is defined %}
 {{ defn.value }}
 {% else %}

--- a/scripts/portal_generator/templates/skills/step_unified.html
+++ b/scripts/portal_generator/templates/skills/step_unified.html
@@ -135,9 +135,8 @@
 {% macro render_input_value(defn) -%}
 {%- if defn is mapping -%}
 {%- if defn.from is defined -%}
-{%- set from_input = defn.from.input|default('') -%}
-{%- set from_output = defn.from.output|default('') -%}
-{%- if from_input -%}${{ '{' }}{{ from_input }}{{ '}' }}{%- elif from_output -%}${{ '{' }}{{ from_output }}{{ '}' }}{%- endif -%}
+{%- set from_variable = defn.from.variable|default('') -%}
+{%- if from_variable -%}${{ '{' }}{{ from_variable }}{{ '}' }}{%- endif -%}
 {%- elif defn.value is defined -%}
 {%- set val = defn.value|string|trim|lower -%}
 {%- if val == 'true' or val == 'false' -%}{{ val }}{%- else -%}{{ defn.value|trim }}{%- endif -%}

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -755,26 +755,61 @@ describe('toggleSkillDropdown', () => {
     });
 });
 
-describe('copySkillInstallCommand', () => {
+describe('openInstallModal / closeInstallModal', () => {
     afterEach(() => {
         document.body.innerHTML = '';
     });
 
-    test('copies correct command to clipboard', async () => {
-        let copied = '';
+    function buildModal(slug) {
+        const modal = document.createElement('div');
+        modal.id = 'install-modal-' + slug;
+        modal.style.display = 'none';
+        document.body.appendChild(modal);
+        return modal;
+    }
+
+    test('openInstallModal shows the modal', () => {
+        const modal = buildModal('test-skill');
+        openInstallModal('test-skill');
+        expect(modal.style.display).toBe('flex');
+    });
+
+    test('closeInstallModal hides the modal', () => {
+        const modal = buildModal('test-skill');
+        modal.style.display = 'flex';
+        closeInstallModal('test-skill');
+        expect(modal.style.display).toBe('none');
+    });
+
+    test('openInstallModal does nothing for non-existent slug', () => {
+        buildModal('real');
+        openInstallModal('fake');
+        expect(document.getElementById('install-modal-real').style.display).toBe('none');
+    });
+});
+
+describe('copyInstallFromModal', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('copies command text from code element', () => {
         Object.assign(navigator, {
-            clipboard: { writeText: jest.fn((text) => { copied = text; return Promise.resolve(); }) },
+            clipboard: { writeText: jest.fn(() => Promise.resolve()) },
         });
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'skill-split-btn';
-        const main = document.createElement('button');
-        main.className = 'skill-split-main';
-        main.innerHTML = '<span>Copy Install Command</span>';
-        wrapper.appendChild(main);
-        document.body.appendChild(wrapper);
+        const code = document.createElement('code');
+        code.id = 'install-cmd-my-skill';
+        code.textContent = 'npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill my-skill';
+        document.body.appendChild(code);
 
-        copySkillInstallCommand('my-skill', main);
+        const btn = document.createElement('button');
+        const span = document.createElement('span');
+        span.textContent = 'Copy';
+        btn.appendChild(span);
+        document.body.appendChild(btn);
+
+        copyInstallFromModal('my-skill', btn);
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
             'npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill my-skill'
         );

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -686,3 +686,160 @@ describe('renderOutputDropdownRow', () => {
         expect(html).not.toContain('data-row-index');
     });
 });
+
+// ===========================================================================
+// Skill Actions Dropdown
+// ===========================================================================
+describe('toggleSkillDropdown', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    function buildSplitBtn(slug) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'skill-split-btn';
+        wrapper.id = 'skill-actions-' + slug;
+
+        const main = document.createElement('button');
+        main.className = 'skill-split-main';
+        wrapper.appendChild(main);
+
+        const toggle = document.createElement('button');
+        toggle.className = 'skill-split-toggle';
+        toggle.setAttribute('aria-expanded', 'false');
+        wrapper.appendChild(toggle);
+
+        const menu = document.createElement('div');
+        menu.className = 'skill-dropdown-menu';
+        menu.id = 'skill-dropdown-menu-' + slug;
+        menu.style.display = 'none';
+        wrapper.appendChild(menu);
+
+        document.body.appendChild(wrapper);
+        return { wrapper, main, toggle, menu };
+    }
+
+    test('opens a closed dropdown', () => {
+        const { toggle, menu } = buildSplitBtn('test-skill');
+        toggleSkillDropdown('test-skill');
+        expect(menu.style.display).toBe('block');
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    test('closes an open dropdown', () => {
+        const { toggle, menu } = buildSplitBtn('test-skill');
+        menu.style.display = 'block';
+        toggle.setAttribute('aria-expanded', 'true');
+        toggleSkillDropdown('test-skill');
+        expect(menu.style.display).toBe('none');
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('closes other open dropdowns when opening a new one', () => {
+        const first = buildSplitBtn('skill-a');
+        const second = buildSplitBtn('skill-b');
+        first.menu.style.display = 'block';
+        first.toggle.setAttribute('aria-expanded', 'true');
+
+        toggleSkillDropdown('skill-b');
+        expect(first.menu.style.display).toBe('none');
+        expect(first.toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(second.menu.style.display).toBe('block');
+    });
+
+    test('does nothing for non-existent slug', () => {
+        buildSplitBtn('real');
+        toggleSkillDropdown('fake');
+        // No error thrown, real menu unchanged
+        expect(document.getElementById('skill-dropdown-menu-real').style.display).toBe('none');
+    });
+});
+
+describe('copySkillInstallCommand', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('copies correct command to clipboard', async () => {
+        let copied = '';
+        Object.assign(navigator, {
+            clipboard: { writeText: jest.fn((text) => { copied = text; return Promise.resolve(); }) },
+        });
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'skill-split-btn';
+        const main = document.createElement('button');
+        main.className = 'skill-split-main';
+        main.innerHTML = '<span>Copy Install Command</span>';
+        wrapper.appendChild(main);
+        document.body.appendChild(wrapper);
+
+        copySkillInstallCommand('my-skill', main);
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+            'npx skills add https://github.com/mulesoft/anypoint-dev-portal/ --skill my-skill'
+        );
+    });
+});
+
+describe('copySkillContent', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('copies template content to clipboard', async () => {
+        let copied = '';
+        Object.assign(navigator, {
+            clipboard: { writeText: jest.fn((text) => { copied = text; return Promise.resolve(); }) },
+        });
+
+        const tpl = document.createElement('template');
+        tpl.id = 'skill-raw-my-skill';
+        tpl.innerHTML = '---\nname: my-skill\n---\n# My Skill';
+        document.body.appendChild(tpl);
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'skill-split-btn';
+        const main = document.createElement('button');
+        main.className = 'skill-split-main';
+        main.innerHTML = '<span>Copy Install Command</span>';
+        wrapper.appendChild(main);
+        document.body.appendChild(wrapper);
+
+        copySkillContent('my-skill', main);
+        expect(navigator.clipboard.writeText).toHaveBeenCalled();
+        const arg = navigator.clipboard.writeText.mock.calls[0][0];
+        expect(arg).toContain('name: my-skill');
+    });
+});
+
+describe('_closeAllSkillDropdowns', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('closes all open dropdowns', () => {
+        function addMenu(slug) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'skill-split-btn';
+            const toggle = document.createElement('button');
+            toggle.className = 'skill-split-toggle';
+            toggle.setAttribute('aria-expanded', 'true');
+            wrapper.appendChild(toggle);
+            const menu = document.createElement('div');
+            menu.className = 'skill-dropdown-menu';
+            menu.id = 'skill-dropdown-menu-' + slug;
+            menu.style.display = 'block';
+            wrapper.appendChild(menu);
+            document.body.appendChild(wrapper);
+            return { toggle, menu };
+        }
+
+        const a = addMenu('a');
+        const b = addMenu('b');
+        _closeAllSkillDropdowns();
+        expect(a.menu.style.display).toBe('none');
+        expect(b.menu.style.display).toBe('none');
+        expect(a.toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(b.toggle.getAttribute('aria-expanded')).toBe('false');
+    });
+});

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -784,31 +784,33 @@ describe('copySkillInstallCommand', () => {
 describe('copySkillContent', () => {
     afterEach(() => {
         document.body.innerHTML = '';
+        globalThis.fetch = undefined;
     });
 
-    test('copies template content to clipboard', async () => {
-        let copied = '';
+    test('fetches SKILL.md and copies to clipboard', async () => {
+        const mdContent = '---\nname: my-skill\n---\n# My Skill';
+        globalThis.fetch = jest.fn(() => Promise.resolve({ text: () => Promise.resolve(mdContent) }));
         Object.assign(navigator, {
-            clipboard: { writeText: jest.fn((text) => { copied = text; return Promise.resolve(); }) },
+            clipboard: { writeText: jest.fn(() => Promise.resolve()) },
         });
-
-        const tpl = document.createElement('template');
-        tpl.id = 'skill-raw-my-skill';
-        tpl.innerHTML = '---\nname: my-skill\n---\n# My Skill';
-        document.body.appendChild(tpl);
 
         const wrapper = document.createElement('div');
         wrapper.className = 'skill-split-btn';
         const main = document.createElement('button');
         main.className = 'skill-split-main';
-        main.innerHTML = '<span>Copy Install Command</span>';
+        main.textContent = 'Copy Install Command';
+        const span = document.createElement('span');
+        span.textContent = 'Copy Install Command';
+        main.appendChild(span);
         wrapper.appendChild(main);
         document.body.appendChild(wrapper);
 
         copySkillContent('my-skill', main);
-        expect(navigator.clipboard.writeText).toHaveBeenCalled();
-        const arg = navigator.clipboard.writeText.mock.calls[0][0];
-        expect(arg).toContain('name: my-skill');
+        expect(globalThis.fetch).toHaveBeenCalledWith('../skills/my-skill/SKILL.md');
+
+        // Wait for promises to resolve
+        await new Promise((r) => setTimeout(r, 0));
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mdContent);
     });
 });
 

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -15,12 +15,15 @@ from portal_generator.parsers.skill_parser import (
     _extract_step_details,
     _extract_section,
     _extract_related_jobs,
-    _extract_skip_annotation,
     _extract_entry_points,
     _convert_to_plain,
     parse_skill,
 )
 from portal_generator.discovery import calculate_stats, _extract_api_refs, discover_skills
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'build'))
+from validate_jtbd import JobValidator
 
 
 # ============================================================================
@@ -598,57 +601,6 @@ class TestExtractSection:
 
 
 # ============================================================================
-# skill_parser._extract_skip_annotation
-# ============================================================================
-
-class TestExtractSkipAnnotation:
-    def test_extracts_skip_condition(self):
-        text = '> **Skip if:** You already have an Exchange asset.\n\nSome prose.'
-        condition, cleaned = _extract_skip_annotation(text)
-        assert condition == 'You already have an Exchange asset.'
-        assert 'Some prose' in cleaned
-        assert 'Skip if' not in cleaned
-
-    def test_no_annotation(self):
-        text = 'Just regular prose here.'
-        condition, cleaned = _extract_skip_annotation(text)
-        assert condition is None
-        assert cleaned == text
-
-    def test_annotation_with_backtick_vars(self):
-        text = '> **Skip if:** You have `groupId`, `assetId`, and `assetVersion`.\n\nNext.'
-        condition, cleaned = _extract_skip_annotation(text)
-        assert '`groupId`' in condition
-        assert 'Next' in cleaned
-
-    def test_annotation_is_entire_content(self):
-        text = '> **Skip if:** This step is optional.'
-        condition, cleaned = _extract_skip_annotation(text)
-        assert condition == 'This step is optional.'
-
-    def test_step_details_include_skip_condition(self):
-        content = (
-            '## Step 1: Optional step\n'
-            '> **Skip if:** Already done.\n\n'
-            'Some prose.\n\n'
-            '```yaml\napi: urn:api:test\noperation: op1\n```\n'
-        )
-        steps = _extract_step_details(content)
-        assert steps[0]['skip_condition'] == 'Already done.'
-        assert 'Skip if' not in steps[0]['prose_before_html']
-        assert 'Some prose' in steps[0]['prose_before_html']
-
-    def test_step_without_skip_has_none(self):
-        content = (
-            '## Step 1: Normal step\n'
-            'Regular prose.\n\n'
-            '```yaml\napi: urn:api:test\noperation: op1\n```\n'
-        )
-        steps = _extract_step_details(content)
-        assert steps[0]['skip_condition'] is None
-
-
-# ============================================================================
 # skill_parser._extract_entry_points
 # ============================================================================
 
@@ -764,12 +716,8 @@ class TestParseSkillConditional:
         assert result['entry_points'][1]['required_vars'] == ['groupId', 'assetId']
         assert result['entry_points'][1]['steps'] == [2]
 
-        # Skip condition on step 1
-        assert result['step_details'][0]['skip_condition'] is not None
-        assert 'Exchange asset' in result['step_details'][0]['skip_condition']
-
-        # No skip condition on step 2
-        assert result['step_details'][1]['skip_condition'] is None
+        # Step details are present
+        assert len(result['step_details']) == 2
 
     def test_parse_skill_without_conditionals(self, tmp_path):
         from tests.conftest import MINIMAL_SKILL_MD
@@ -781,7 +729,7 @@ class TestParseSkillConditional:
         assert result is not None
         assert result['starting_point_html'] == ''
         assert result['entry_points'] == []
-        assert result['step_details'][0]['skip_condition'] is None
+        assert len(result['step_details']) >= 1
 
 
 class TestConvertToPlain:
@@ -1148,3 +1096,67 @@ class TestDiscoverSkills:
         (skills_dir / 'some-dir').mkdir()
         # Dir without SKILL.md
         assert discover_skills(tmp_path) == {}
+
+
+# ============================================================================
+# validate_jtbd.JobValidator.validate_step_dependencies
+# ============================================================================
+
+class TestValidateStepDependencies:
+    def test_variable_reference_accepted(self):
+        """from.variable is accepted as valid syntax."""
+        validator = JobValidator(Path('fake.md'), Path('.'))
+        steps = [
+            {'api': 'urn:api:test', 'operationId': 'op1',
+             'inputs': {'orgId': {'from': {'api': 'urn:api:am', 'operation': 'getOrgs', 'field': '$.id'}}},
+             'outputs': [{'name': 'envApiId', 'path': '$.id'}]},
+            {'api': 'urn:api:test', 'operationId': 'op2',
+             'inputs': {'apiId': {'from': {'variable': 'envApiId'}, 'description': 'test'}}},
+        ]
+        assert validator.validate_step_dependencies(steps) is True
+        assert len(validator.errors) == 0
+        assert len(validator.warnings) == 0
+
+    def test_api_reference_still_accepted(self):
+        """from.api references are still accepted (no regression)."""
+        validator = JobValidator(Path('fake.md'), Path('.'))
+        steps = [
+            {'api': 'urn:api:test', 'operationId': 'op1',
+             'inputs': {'orgId': {'from': {'api': 'urn:api:am', 'operation': 'getOrgs', 'field': '$.id'}}}},
+        ]
+        assert validator.validate_step_dependencies(steps) is True
+        assert len(validator.errors) == 0
+        assert len(validator.warnings) == 0
+
+    def test_malformed_from_warns(self):
+        """from block with neither variable nor api produces a warning."""
+        validator = JobValidator(Path('fake.md'), Path('.'))
+        steps = [
+            {'api': 'urn:api:test', 'operationId': 'op1',
+             'inputs': {'orgId': {'from': {'unknown': 'something'}}}},
+        ]
+        assert validator.validate_step_dependencies(steps) is True
+        assert len(validator.warnings) == 1
+        assert 'variable' in validator.warnings[0]
+
+    def test_non_dict_inputs_skipped(self):
+        """Simple string inputs are skipped without error."""
+        validator = JobValidator(Path('fake.md'), Path('.'))
+        steps = [
+            {'api': 'urn:api:test', 'operationId': 'op1',
+             'inputs': {'orgId': 'simple-value'}},
+        ]
+        assert validator.validate_step_dependencies(steps) is True
+        assert len(validator.errors) == 0
+
+    def test_variable_with_field_accepted(self):
+        """from.variable with field sub-key is accepted."""
+        validator = JobValidator(Path('fake.md'), Path('.'))
+        steps = [
+            {'api': 'urn:api:test', 'operationId': 'op1',
+             'outputs': [{'name': 'tiers', 'path': '$'}]},
+            {'api': 'urn:api:test', 'operationId': 'op2',
+             'inputs': {'tierId': {'from': {'variable': 'tiers', 'field': '$[0].id'}}}},
+        ]
+        assert validator.validate_step_dependencies(steps) is True
+        assert len(validator.warnings) == 0

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -64,8 +64,7 @@ operationId: listEnvironments
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
 outputs:
   - name: environmentId
@@ -92,13 +91,11 @@ operationId: listOrganizationsEnvironmentsApis
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
 outputs:
   - name: environmentApiId
@@ -130,18 +127,15 @@ operationId: getExchangePolicyTemplates
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
   apiInstanceId:
     from:
-      step: List API Instances
-      output: environmentApiId
+      variable: environmentApiId
     description: Filters templates to those compatible with this API instance
   includeConfiguration:
     value: true
@@ -190,38 +184,32 @@ operationId: createOrganizationsEnvironmentsApisPolicies
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
 
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
 
   environmentApiId:
     from:
-      step: List API Instances
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 3
 
   groupId:
     from:
-      step: Get Policy Templates with Configuration
-      output: policyGroupId
+      variable: policyGroupId
     description: Exchange groupId of the policy asset
 
   assetId:
     from:
-      step: Get Policy Templates with Configuration
-      output: policyAssetId
+      variable: policyAssetId
     description: Exchange assetId of the policy asset
 
   assetVersion:
     from:
-      step: Get Policy Templates with Configuration
-      output: policyAssetVersion
+      variable: policyAssetVersion
     description: Version of the policy asset
 
   configurationData:

--- a/skills/deploy-api-to-managed-flex-gateway-from-exchange/SKILL.md
+++ b/skills/deploy-api-to-managed-flex-gateway-from-exchange/SKILL.md
@@ -138,28 +138,23 @@ operationId: createOrganizationsEnvironmentsApis
 inputs:
   organizationId:
     from:
-      step: List Flex Gateway Targets
-      input: organizationId
+      variable: organizationId
     description: Same organization ID from Step 2
   environmentId:
     from:
-      step: List Flex Gateway Targets
-      input: environmentId
+      variable: environmentId
     description: Same environment ID from Step 2
   spec.groupId:
     from:
-      step: Search Assets in Exchange
-      output: groupId
+      variable: groupId
     description: Asset group ID from Step 1
   spec.assetId:
     from:
-      step: Search Assets in Exchange
-      output: assetId
+      variable: assetId
     description: Asset ID from Step 1
   spec.version:
     from:
-      step: Search Assets in Exchange
-      output: version
+      variable: version
     description: Asset version from Step 1
   endpoint.deploymentType:
     value: HY
@@ -180,8 +175,7 @@ inputs:
     description: Mutual TLS not enabled by default
   endpoint.targetId:
     from:
-      step: List Flex Gateway Targets
-      output: targetId
+      variable: targetId
     description: Flex Gateway target ID from Step 2
   deployment.expectedStatus:
     value: deployed

--- a/skills/deploy-api-with-rate-limiting/SKILL.md
+++ b/skills/deploy-api-with-rate-limiting/SKILL.md
@@ -126,20 +126,17 @@ operationId: createOrganizationsEnvironmentsApisTiers
 inputs:
   organizationId:
     from:
-      step: Create API Instance
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: Create API Instance
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: Create API Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: The API instance ID from Step 1
 
   name:
@@ -185,20 +182,17 @@ operationId: createOrganizationsEnvironmentsApisTiers
 inputs:
   organizationId:
     from:
-      step: Create API Instance
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: Create API Instance
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: Create API Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: The API instance ID from Step 1
 
   name:
@@ -239,20 +233,17 @@ operationId: createOrganizationsEnvironmentsApisTiers
 inputs:
   organizationId:
     from:
-      step: Create API Instance
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: Create API Instance
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: Create API Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: The API instance ID from Step 1
 
   name:
@@ -302,20 +293,17 @@ operationId: createOrganizationsEnvironmentsApisPolicies
 inputs:
   organizationId:
     from:
-      step: Create API Instance
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: Create API Instance
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: Create API Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: The API instance ID from Step 1
 
   policyTemplateId:

--- a/skills/list-organization-api-instances/SKILL.md
+++ b/skills/list-organization-api-instances/SKILL.md
@@ -64,8 +64,7 @@ operationId: listEnvironments
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
 outputs:
 - name: environmentId
@@ -95,13 +94,11 @@ operationId: listOrganizationsEnvironmentsApis
 inputs:
   organizationId:
     from:
-      step: Get Current Organization
-      input: organizationId
+      variable: organizationId
     description: Organization ID from Step 1
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
 outputs:
 - name: apiInstances

--- a/skills/manage-consumer-contracts/SKILL.md
+++ b/skills/manage-consumer-contracts/SKILL.md
@@ -95,20 +95,17 @@ operationId: createOrganizationsEnvironmentsApisContracts
 inputs:
   organizationId:
     from:
-      step: List Existing Tiers
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: List Existing Tiers
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: List Existing Tiers
-      input: environmentApiId
+      variable: environmentApiId
     description: Same API instance as Step 1
 
   applicationId:
@@ -122,8 +119,7 @@ inputs:
 
   requestedTierId:
     from:
-      step: List Existing Tiers
-      output: tiers
+      variable: tiers
       field: $[0].id
     description: Bronze tier ID from Step 1 (select appropriate tier from list)
 
@@ -155,20 +151,17 @@ operationId: listOrganizationsEnvironmentsApisContracts
 inputs:
   organizationId:
     from:
-      step: List Existing Tiers
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: List Existing Tiers
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: List Existing Tiers
-      input: environmentApiId
+      variable: environmentApiId
     description: Same API instance as Step 1
 
 outputs:
@@ -196,32 +189,27 @@ operationId: updateOrganizationsEnvironmentsApisContracts
 inputs:
   organizationId:
     from:
-      step: List Existing Tiers
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 1
 
   environmentId:
     from:
-      step: List Existing Tiers
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 1
 
   environmentApiId:
     from:
-      step: List Existing Tiers
-      input: environmentApiId
+      variable: environmentApiId
     description: Same API instance as Step 1
 
   contractId:
     from:
-      step: Create Contract for Bronze Tier
-      output: contractId
+      variable: contractId
     description: Contract ID from Step 2
 
   requestedTierId:
     from:
-      step: List Existing Tiers
-      output: tiers
+      variable: tiers
       field: $[1].id
     description: Silver tier ID from Step 1 (select appropriate tier from list)
 

--- a/skills/protect-api-with-policies/SKILL.md
+++ b/skills/protect-api-with-policies/SKILL.md
@@ -53,8 +53,6 @@ This skill has multiple execution paths depending on what you already have:
 
 ## Step 1: Publish API to Exchange
 
-> **Skip if:** You already have an Exchange asset with a known `groupId`, `assetId`, and `assetVersion`.
-
 Publishes your API specification to Exchange as a reusable asset. This makes it available for API Manager to create managed instances from it.
 
 **What you'll need:**
@@ -103,8 +101,6 @@ outputs:
 
 ## Step 2: List Environments
 
-> **Skip if:** You already know the `environmentId`.
-
 List all environments in the organization so you can confirm or select the one where your API instance lives.
 
 **What you'll need:**
@@ -152,8 +148,7 @@ inputs:
     description: Organization ID
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
 outputs:
   - name: targetId
@@ -171,8 +166,6 @@ outputs:
 **What happens next:** You have a deployment target and its gateway version. Next, create the API instance and then configure its deployment target.
 
 ## Step 4: Create API Manager Instance
-
-> **Skip if:** You already have an API Manager instance with a known `environmentApiId`.
 
 Creates a managed API instance in API Manager from your Exchange asset. This creates the API configuration; deployment to the Flex Gateway happens in Step 5.
 
@@ -196,23 +189,19 @@ inputs:
     description: Your organization's Business Group GUID
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Target environment ID from Step 2
   groupId:
     from:
-      step: Publish API to Exchange
-      output: groupId
+      variable: groupId
     description: Exchange asset group ID from Step 1
   assetId:
     from:
-      step: Publish API to Exchange
-      output: assetId
+      variable: assetId
     description: Exchange asset ID from Step 1
   assetVersion:
     from:
-      step: Publish API to Exchange
-      output: assetVersion
+      variable: assetVersion
     description: Exchange asset version from Step 1
   instanceLabel:
     userProvided: true
@@ -263,34 +252,29 @@ inputs:
     description: Organization ID
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
   environmentApiId:
     from:
-      step: Create API Manager Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 4
   type:
     value: "HY"
     description: "Deployment type for self-managed Flex Gateway (HY = Hybrid)"
   targetId:
     from:
-      step: Select Deployment Target
-      output: targetId
+      variable: targetId
     description: Flex Gateway target ID from Step 3
   targetName:
     from:
-      step: Select Deployment Target
-      output: targetName
+      variable: targetName
     description: Flex Gateway target name from Step 3
   gatewayVersion:
     value: "1.0.0"
     description: "Gateway version for deployment. Use \"1.0.0\" as the default."
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID (required in the deployment body for HY type)
   overwrite:
     value: false
@@ -346,13 +330,11 @@ inputs:
     description: Organization ID
   apiInstanceId:
     from:
-      step: Create API Manager Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 4 (filters for compatible templates)
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
   latest:
     value: "true"
@@ -405,28 +387,23 @@ inputs:
     description: Organization ID
   environmentId:
     from:
-      step: List Environments
-      output: environmentId
+      variable: environmentId
     description: Environment ID from Step 2
   environmentApiId:
     from:
-      step: Create API Manager Instance
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 4 (or provided manually)
   groupId:
     from:
-      step: Browse Exchange Policy Catalog
-      output: policyGroupId
+      variable: policyGroupId
     description: Policy Exchange group ID from Step 6
   assetId:
     from:
-      step: Browse Exchange Policy Catalog
-      output: policyAssetId
+      variable: policyAssetId
     description: Policy Exchange asset ID from Step 6
   assetVersion:
     from:
-      step: Browse Exchange Policy Catalog
-      output: policyAssetVersion
+      variable: policyAssetVersion
     description: Policy Exchange version from Step 6
 outputs:
   - name: policyId

--- a/skills/run-agent-scan-and-view-results/SKILL.md
+++ b/skills/run-agent-scan-and-view-results/SKILL.md
@@ -79,13 +79,11 @@ operationId: getScannerRunHistory
 inputs:
   organizationId:
     from:
-      step: Execute the Scanner
-      input: organizationId
+      variable: organizationId
     description: Same organization ID as Step 1
   scannerId:
     from:
-      step: Execute the Scanner
-      input: scannerConfigurationId
+      variable: scannerConfigurationId
     description: The scanner configuration ID (used as scanner ID)
   page:
     value: "0"
@@ -132,13 +130,11 @@ operationId: getStagingAssetsByScanRunId
 inputs:
   scannerId:
     from:
-      step: Get Scanner Run History
-      input: scannerId
+      variable: scannerId
     description: The scanner ID
   scanRunId:
     from:
-      step: Get Scanner Run History
-      output: scanRunId
+      variable: scanRunId
     description: The scan run ID from Step 2
   page:
     value: "0"

--- a/skills/setup-agent-scanner/SKILL.md
+++ b/skills/setup-agent-scanner/SKILL.md
@@ -81,8 +81,7 @@ operationId: createConnection
 inputs:
   organizationId:
     from:
-      step: Get Available Target Systems
-      input: organizationId
+      variable: organizationId
     description: Same organization ID as Step 1
   requestBody:
     userProvided: true
@@ -127,8 +126,7 @@ operationId: createScanConfigurations
 inputs:
   organizationId:
     from:
-      step: Get Available Target Systems
-      input: organizationId
+      variable: organizationId
     description: Same organization ID as previous steps
   requestBody:
     userProvided: true

--- a/skills/setup-multi-upstream-routing/SKILL.md
+++ b/skills/setup-multi-upstream-routing/SKILL.md
@@ -119,20 +119,17 @@ inputs:
 
   spec.groupId:
     from:
-      step: Search Assets in Exchange
-      output: groupId
+      variable: groupId
     description: Exchange asset group ID from Step 1
 
   spec.assetId:
     from:
-      step: Search Assets in Exchange
-      output: assetId
+      variable: assetId
     description: Exchange asset ID from Step 1
 
   spec.version:
     from:
-      step: Search Assets in Exchange
-      output: version
+      variable: version
     description: Asset version from Step 1
 
   endpoint.uri:
@@ -176,20 +173,17 @@ operationId: createOrganizationsEnvironmentsApisUpstreams
 inputs:
   organizationId:
     from:
-      step: Create API Instance Without Endpoint
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 2
 
   environmentId:
     from:
-      step: Create API Instance Without Endpoint
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 2
 
   environmentApiId:
     from:
-      step: Create API Instance Without Endpoint
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 2
 
   label:
@@ -227,20 +221,17 @@ operationId: createOrganizationsEnvironmentsApisUpstreams
 inputs:
   organizationId:
     from:
-      step: Create API Instance Without Endpoint
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 2
 
   environmentId:
     from:
-      step: Create API Instance Without Endpoint
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 2
 
   environmentApiId:
     from:
-      step: Create API Instance Without Endpoint
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 2
 
   label:
@@ -278,26 +269,22 @@ operationId: updateOrganizationsEnvironmentsApis
 inputs:
   organizationId:
     from:
-      step: Create API Instance Without Endpoint
-      input: organizationId
+      variable: organizationId
     description: Same organizationId as Step 2
 
   environmentId:
     from:
-      step: Create API Instance Without Endpoint
-      input: environmentId
+      variable: environmentId
     description: Same environmentId as Step 2
 
   environmentApiId:
     from:
-      step: Create API Instance Without Endpoint
-      output: environmentApiId
+      variable: environmentApiId
     description: API instance ID from Step 2
 
   routing[0].upstream.id:
     from:
-      step: Create First Upstream
-      output: upstreamId1
+      variable: upstreamId1
     description: Production upstream ID from Step 3
 
   routing[0].upstream.weight:
@@ -306,8 +293,7 @@ inputs:
 
   routing[1].upstream.id:
     from:
-      step: Create Second Upstream
-      output: upstreamId2
+      variable: upstreamId2
     description: Canary upstream ID from Step 4
 
   routing[1].upstream.weight:


### PR DESCRIPTION
  - Refactor JTBD skill inputs: Replace from: step: references with from: variable: across all 9 skill files (82 occurrences). Removes tight coupling between steps
  — inputs now declare which variable they need, not which step provides it. Removes > **Skip if:** annotations and all related code (validator, parser, templates).
  - Update portal URLs: Public-facing URLs changed from api-portal.mulesoft.com / test-api-portal.mulesoft.com to dev-portal.mulesoft.com /  test-dev-portal.mulesoft.com.
  - Add skill actions split button: Each skill page gets a pill-shaped split button with "Install Command" (opens modal) and a dropdown chevron with three options: Install Skill Command, Open Skill Markdown, Copy Skill.
  - Install command modal: Shows the npx skills add command in a bracketed code block with a Copy button and Node.js/npm prerequisites section.