### PR TITLE
Fix Try It Out response display and improve dark mode support

### DIFF
--- a/apis/agent-scanner-configuration-service/api.yaml
+++ b/apis/agent-scanner-configuration-service/api.yaml
@@ -12,9 +12,8 @@ servers:
       default: ca1
       description: Region identifier for the service endpoint.
 security:
-- bearer-jwt:
-  - read
-  - write
+- bearerAuth: []
+- clientAuth: []
 tags:
 - name: Connectivity
   description: Endpoints for managing connections
@@ -33,24 +32,8 @@ paths:
       description: Returns an updated scanner configuration
       operationId: updateScanConfiguration
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: scannerConfigurationId
-        in: path
-        description: The scanner configuration identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerConfigurationId_Path'
       requestBody:
         description: Scanner configuration object with updated field values.
         content:
@@ -97,12 +80,6 @@ paths:
       description: Starts an asynchronous workflow to delete the scanner configuration. Returns 200 OK when the deletion workflow is started successfully.
       operationId: deleteScannerConfiguration
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
       - name: X-Delete-Agents
         in: header
         description: Whether to also delete associated agents.
@@ -110,18 +87,8 @@ paths:
         schema:
           type: boolean
           default: true
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: scannerConfigurationId
-        in: path
-        description: The scanner configuration identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerConfigurationId_Path'
       responses:
         "200":
           description: Delete workflow started successfully
@@ -162,24 +129,8 @@ paths:
       description: Updates a connection
       operationId: updateConnection
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: connectionId
-        in: path
-        description: The connection identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_connectionId_Path'
       requestBody:
         description: Connection object with updated field values.
         content:
@@ -227,24 +178,8 @@ paths:
       description: Deletes a connection
       operationId: deleteConnection
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: connectionId
-        in: path
-        description: The connection identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_connectionId_Path'
       responses:
         "200":
           description: Connection deleted
@@ -258,18 +193,7 @@ paths:
       description: Returns a list of scanner configuration for a specific organization
       operationId: getScanConfigurations
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - name: page
         in: query
         description: Zero-based page number for pagination.
@@ -319,18 +243,7 @@ paths:
       description: Returns the scanner configuration created
       operationId: createScanConfigurations
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       requestBody:
         description: Scanner configuration object to create.
         content:
@@ -372,25 +285,8 @@ paths:
       description: Starts a scan workflow based on the specified scanner configuration ID
       operationId: executeWorkflowFromConfiguration
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: scannerConfigurationId
-        in: path
-        description: Scanner configuration ID
-        required: true
-        schema:
-          type: string
-        example: 12345678-1234-1234-1234-122456789abc
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerConfigurationId_Path'
       responses:
         "202":
           description: Workflow started successfully
@@ -414,25 +310,8 @@ paths:
       description: Cancels a running scan based on the specified scanner configuration ID
       operationId: abortWorkflowFromConfiguration
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: scannerConfigurationId
-        in: path
-        description: Scanner configuration ID
-        required: true
-        schema:
-          type: string
-        example: 12345678-1234-1234-1234-122456789abc
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerConfigurationId_Path'
       responses:
         "202":
           description: Workflow aborted successfully
@@ -454,24 +333,8 @@ paths:
       description: Tests connectivity to a target system type using provided connection parameters. Requires authentication.
       operationId: testConnection
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: targetSystemType
-        in: path
-        description: The target system type identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_targetSystemType_Path'
       requestBody:
         description: Connection parameters to test connectivity.
         content:
@@ -500,18 +363,7 @@ paths:
       description: Returns a list of connections for a specific organization
       operationId: getConnections
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       responses:
         "200":
           description: Successfully retrieved Connections
@@ -535,18 +387,7 @@ paths:
       description: Adds a connection
       operationId: createConnection
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       requestBody:
         description: Connection object to create.
         content:
@@ -592,24 +433,8 @@ paths:
       description: Returns a paginated list of scanner runs for a specific scanner
       operationId: getScannerRunHistory
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: Organization identifier
-        required: true
-        schema:
-          type: string
-      - name: scannerId
-        in: path
-        description: Scanner identifier
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerId_Path'
       - name: page
         in: query
         description: Zero-based page number for pagination.
@@ -666,30 +491,9 @@ paths:
       description: Returns a paginated list of staging assets for a specific scan run. Use size=0 to get all results without pagination.
       operationId: getStagingAssetsByScanRunId
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
-      - name: scannerId
-        in: path
-        description: Scanner identifier
-        required: true
-        schema:
-          type: string
-      - name: scanRunId
-        in: path
-        description: Scan run identifier
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
+      - $ref: '#/components/parameters/XOrigin_scannerId_Path'
+      - $ref: '#/components/parameters/XOrigin_scanRunId_Path'
       - name: page
         in: query
         description: Zero-based page number for pagination.
@@ -746,18 +550,7 @@ paths:
       description: Returns organization information including total managed agents and capacity limit
       operationId: getOrganizationInfo
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       responses:
         "200":
           description: Successfully retrieved organization information
@@ -794,18 +587,7 @@ paths:
       description: Returns a list of available target systems for connections. Requires authentication.
       operationId: getTargetSystems
       parameters:
-      - name: Authorization
-        in: header
-        description: Bearer JWT token for authentication.
-        required: true
-        schema:
-          type: string
-      - name: organizationId
-        in: path
-        description: The organization identifier.
-        required: true
-        schema:
-          type: string
+      - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       responses:
         "200":
           description: Successfully retrieved target systems
@@ -855,7 +637,7 @@ components:
         type: string
         format: uuid
       x-origin:
-      - api: urn:api:agent-scanner-configuration
+      - api: urn:api:agent-scanner-configuration-service
         operation: getScanConfigurations
         values: $.content[*].id
         labels: $.content[*].name
@@ -869,7 +651,7 @@ components:
         type: string
         format: uuid
       x-origin:
-      - api: urn:api:agent-scanner-configuration
+      - api: urn:api:agent-scanner-configuration-service
         operation: getScanConfigurations
         values: $.content[*].id
         labels: $.content[*].name
@@ -883,7 +665,7 @@ components:
         type: string
         format: uuid
       x-origin:
-      - api: urn:api:agent-scanner-configuration
+      - api: urn:api:agent-scanner-configuration-service
         operation: getScannerRunHistory
         values: $.content[*].id
         labels: $.content[*].id
@@ -897,7 +679,7 @@ components:
         type: string
         format: uuid
       x-origin:
-      - api: urn:api:agent-scanner-configuration
+      - api: urn:api:agent-scanner-configuration-service
         operation: getConnections
         values: $[*].id
         labels: $[*].name
@@ -910,7 +692,7 @@ components:
       schema:
         type: string
       x-origin:
-      - api: urn:api:agent-scanner-configuration
+      - api: urn:api:agent-scanner-configuration-service
         operation: getTargetSystems
         values: $[*].type
         labels: $[*].name
@@ -1726,9 +1508,16 @@ components:
           items:
             $ref: "#/components/schemas/AuthSchemeFormDescriptor"
   securitySchemes:
-    bearer-jwt:
+    bearerAuth:
       type: http
-      name: Authorization
-      in: header
       scheme: bearer
       bearerFormat: JWT
+      description: Bearer token authentication. Login endpoint https://anypoint.mulesoft.com/accounts/api/login
+    clientAuth:
+      type: oauth2
+      description: OAuth2 client credentials. Token endpoint https://anypoint.mulesoft.com/accounts/api/v2/oauth2/token
+      flows:
+        clientCredentials:
+          tokenUrl: https://anypoint.mulesoft.com/accounts/api/v2/oauth2/token
+          scopes: {}
+  

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -125,7 +125,7 @@ function openXOriginModal(opId, paramName, location) {
 
     // Build source selector dropdown (no execute button here - it's in the panel)
     var html = '<div class="xorigin-selector-container">';
-    html += '<select id="xorigin-source-selector" class="" onchange="switchXOriginSource()">';
+    html += '<select id="xorigin-source-selector" class="xorigin-source-select" onchange="switchXOriginSource()">';
 
     origins.forEach(function(origin, idx) {
         var apiSlug = (origin.api || '').replace('urn:api:', '');
@@ -3412,13 +3412,21 @@ function switchResponseTab(opId, tabName) {
 }
 
 async function sendRequest(opId, buttonEl) {
+    console.log('[DEBUG] sendRequest called with opId:', opId);
     var section = document.getElementById('op-' + opId);
-    if (!section) return;
+    if (!section) {
+        console.error('[DEBUG] Section not found for opId:', opId);
+        return;
+    }
 
     var method = section.getAttribute('data-method');
     var pathTemplate = section.getAttribute('data-path');
     var tryPanel = document.getElementById('try-' + opId);
-    if (!tryPanel) return;
+    if (!tryPanel) {
+        console.error('[DEBUG] Try panel not found for opId:', opId);
+        return;
+    }
+    console.log('[DEBUG] Found section and tryPanel');
 
     // Collect parameters
     var path = pathTemplate;
@@ -3485,16 +3493,15 @@ async function sendRequest(opId, buttonEl) {
     var responseBody = document.getElementById('respbody-' + opId);
     var responseHeaders = document.getElementById('respheaders-' + opId);
 
-    // Check if we're in expanded mode
-    var container = document.getElementById('op-container-' + opId);
-    var isExpanded = container && container.classList.contains('try-expanded');
-
-    if (isExpanded) {
-        // In expanded mode, keep response visible but add 'empty' class
-        if (responseDiv) responseDiv.classList.add('empty');
-    } else {
-        // In collapsed mode, hide the response
-        if (responseDiv) responseDiv.style.display = 'none';
+    // Always show response area with 'empty' class before request
+    // Override template's inline display:none
+    console.log('[DEBUG] Response div before request:', responseDiv);
+    console.log('[DEBUG] Response div display before:', responseDiv ? responseDiv.style.display : 'N/A');
+    if (responseDiv) {
+        responseDiv.classList.add('empty');
+        responseDiv.style.display = 'block';  // Show the response area
+        console.log('[DEBUG] Response div display after setting to block:', responseDiv.style.display);
+        console.log('[DEBUG] Response div classes:', responseDiv.className);
     }
 
     try {
@@ -3517,12 +3524,29 @@ async function sendRequest(opId, buttonEl) {
             buttonEl.disabled = false;
         }
 
+        console.log('[DEBUG] Response received successfully');
         if (responseDiv) {
-            responseDiv.style.display = 'block';
+            responseDiv.style.display = 'block';  // Keep response visible
             responseDiv.classList.remove('empty');
+            console.log('[DEBUG] Response div after removing empty:', responseDiv.style.display, responseDiv.className);
+
+            // Check dimensions and visibility
+            var rect = responseDiv.getBoundingClientRect();
+            var computedStyle = window.getComputedStyle(responseDiv);
+            console.log('[DEBUG] Response div dimensions:', {
+                width: rect.width,
+                height: rect.height,
+                top: rect.top,
+                left: rect.left,
+                display: computedStyle.display,
+                visibility: computedStyle.visibility,
+                opacity: computedStyle.opacity,
+                overflow: computedStyle.overflow
+            });
         }
 
         if (data.error) {
+            console.error('[DEBUG] Error in response:', data.error);
             if (statusBadge) { statusBadge.textContent = 'Error'; statusBadge.className = 'response-status-badge status-5xx'; }
             if (responseBody) {
                 createReadOnlyAceEditor(responseBody, data.error, 'text');
@@ -3537,10 +3561,42 @@ async function sendRequest(opId, buttonEl) {
         if (statusBadge) { statusBadge.textContent = status; statusBadge.className = 'response-status-badge ' + statusClass; }
 
         // Display response body and headers
+        console.log('[DEBUG] About to display response in ACE editors');
+        console.log('[DEBUG] responseBody element:', responseBody);
+        console.log('[DEBUG] responseHeaders element:', responseHeaders);
+
+        // Check responseBody visibility before
+        if (responseBody) {
+            var bodyRect = responseBody.getBoundingClientRect();
+            var bodyComputed = window.getComputedStyle(responseBody);
+            console.log('[DEBUG] responseBody BEFORE display:', {
+                width: bodyRect.width,
+                height: bodyRect.height,
+                display: bodyComputed.display,
+                hasActiveClass: responseBody.classList.contains('active')
+            });
+        }
+
         displayResponseInAceEditors(responseBody, responseHeaders, data);
+        console.log('[DEBUG] Finished displaying response');
+
+        // Check responseBody visibility after
+        if (responseBody) {
+            var bodyRect2 = responseBody.getBoundingClientRect();
+            var bodyComputed2 = window.getComputedStyle(responseBody);
+            console.log('[DEBUG] responseBody AFTER display:', {
+                width: bodyRect2.width,
+                height: bodyRect2.height,
+                display: bodyComputed2.display,
+                hasActiveClass: responseBody.classList.contains('active')
+            });
+        }
 
         // Scroll response into view
-        if (responseDiv) responseDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        if (responseDiv) {
+            console.log('[DEBUG] Scrolling response into view');
+            responseDiv.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
 
     } catch (e) {
         // Restore button
@@ -3551,7 +3607,7 @@ async function sendRequest(opId, buttonEl) {
         }
 
         if (responseDiv) {
-            responseDiv.style.display = 'block';
+            responseDiv.style.display = 'block';  // Keep response visible
             responseDiv.classList.remove('empty');
         }
         if (statusBadge) { statusBadge.textContent = 'Error'; statusBadge.className = 'response-status-badge status-5xx'; }
@@ -3565,6 +3621,33 @@ async function sendRequest(opId, buttonEl) {
 // ============================================================================
 // Ace Editor Initialization
 // ============================================================================
+
+// Helper function to get appropriate ACE theme based on current theme
+function getAceTheme() {
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    return isDark ? 'ace/theme/monokai' : 'ace/theme/textmate';
+}
+
+// Helper function to update ACE editor background color
+function updateAceEditorBackground(editor) {
+    if (!editor || !editor.container) return;
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    // Remove hardcoded background, let theme handle it
+    editor.container.style.backgroundColor = '';
+}
+
+// Function to update all ACE editors when theme changes
+function updateAllAceEditors() {
+    if (!window.aceEditors) return;
+    var newTheme = getAceTheme();
+    Object.keys(window.aceEditors).forEach(function(key) {
+        var editor = window.aceEditors[key];
+        if (editor && editor.setTheme) {
+            editor.setTheme(newTheme);
+            updateAceEditorBackground(editor);
+        }
+    });
+}
 
 function initCodeMirrorEditors() {
     if (typeof ace === 'undefined') {
@@ -3591,7 +3674,7 @@ function initCodeMirrorEditors() {
 
         var editor = ace.edit(el, {
             mode: mode,
-            theme: 'ace/theme/textmate',
+            theme: getAceTheme(),
             value: exampleBody,
             minLines: 10,
             maxLines: 15,
@@ -3630,7 +3713,8 @@ function createReadOnlyAceEditor(container, content, language) {
         var editor = container.env.editor;
         editor.session.setMode(mode);
         editor.setValue(content || '', -1);
-        editor.container.style.backgroundColor = '#f8f9fa';
+        editor.setTheme(getAceTheme());
+        updateAceEditorBackground(editor);
         return editor;
     }
 
@@ -3639,7 +3723,7 @@ function createReadOnlyAceEditor(container, content, language) {
 
     var editor = ace.edit(container, {
         mode: mode,
-        theme: 'ace/theme/textmate',
+        theme: getAceTheme(),
         value: content || '',
         readOnly: true,
         showPrintMargin: false,
@@ -3655,7 +3739,7 @@ function createReadOnlyAceEditor(container, content, language) {
     });
 
     // Set read-only background
-    editor.container.style.backgroundColor = '#f8f9fa';
+    updateAceEditorBackground(editor);
 
     return editor;
 }
@@ -3970,7 +4054,10 @@ function renderOperationForm(opId, opMeta, options) {
                     html += '<button type="button" class="btn-xorigin-search" ';
                     html += 'onclick="openXOriginModal(\'' + opId + '\', \'' + paramName + '\', \'' + section.location + '\'); return false;" ';
                     html += 'title="Fetch values from ' + origins.length + ' source(s)" aria-label="Search values">';
-                    html += '<img src="assets/icons/search.svg" width="16" height="16" alt="Search">';
+                    html += '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">'+
+                        '<path d="M7 12C9.76142 12 12 9.76142 12 7C12 4.23858 9.76142 2 7 2C4.23858 2 2 4.23858 2 7C2 9.76142 4.23858 12 7 12Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'+
+                        '<path d="M14 14L10.65 10.65" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'+
+                    '</svg>';
                     html += '</button>';
                     // Show resolved value in grey italic AFTER the button
                     if (hasVarRef && substitutedValue !== yamlValue) {
@@ -5691,7 +5778,10 @@ function renderWorkflowStepForms(skillSlug) {
                         html += '<button type="button" class="btn-xorigin-search" ';
                         html += 'onclick="openXOriginModal(\'' + sid + '\', \'' + escapeHtml(paramName) + '\', \'' + section.location + '\'); return false;" ';
                         html += 'title="Fetch values from ' + origins.length + ' source(s)" aria-label="Search values">';
-                        html += '<img src="assets/icons/search.svg" width="16" height="16" alt="Search">';
+                        html += '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">'+
+                        '<path d="M7 12C9.76142 12 12 9.76142 12 7C12 4.23858 9.76142 2 7 2C4.23858 2 2 4.23858 2 7C2 9.76142 4.23858 12 7 12Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'+
+                        '<path d="M14 14L10.65 10.65" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'+
+                        '</svg>';
                         html += '</button>';
                         html += '</div>';
                     } else if (schema.enum) {
@@ -5870,7 +5960,7 @@ function renderWorkflowStepForms(skillSlug) {
             }
             var editor = ace.edit(bodyEditorEl, {
                 mode: 'ace/mode/json',
-                theme: 'ace/theme/textmate',
+                theme: getAceTheme(),
                 value: bodyValue,
                 minLines: 10,
                 maxLines: 15,
@@ -7269,6 +7359,7 @@ function clearAllVariables(slug) {
 
         localStorage.setItem('theme', newTheme);
         updateToggleButton();
+        updateAllAceEditors();
     }
 
     function updateToggleButton() {
@@ -7294,6 +7385,7 @@ function clearAllVariables(slug) {
                     document.documentElement.removeAttribute('data-theme');
                 }
                 updateToggleButton();
+                updateAllAceEditors();
             }
         });
     }

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -743,6 +743,7 @@ code {
     position: relative;
 }
 
+
 .hero-tab:hover {
     background: var(--hover-bg);
     border-color: var(--hover-border);
@@ -3060,6 +3061,9 @@ button.nav-group-header {
     color: var(--color-gray-500);
     font-family: var(--font-mono);
     font-weight: var(--font-weight-regular);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /* max-width: 350px; */
 }
 
 /* Paragraph-based parameters layout - Claude API style */
@@ -5493,6 +5497,7 @@ details[open] .examples-toggle-icon {
     background-repeat: no-repeat;
     background-position: right var(--space-small) center;
     padding-right: calc(var(--space-small) * 3);
+    border-radius: var(--radius-medium);
 }
 
 /* Hide browser's default datalist dropdown indicator */
@@ -5718,6 +5723,14 @@ details[open] .examples-toggle-icon {
 
 .xorigin-source-name {
     margin-bottom: 1rem;
+}
+
+.xorigin-source-select {
+    width: 100%;
+    border: 0;
+    background: none;
+    color: var(--color-neutral-10);
+    border-radius: var(--radius-medium);
 }
 
 .xorigin-name-primary {
@@ -6199,6 +6212,34 @@ details[open] .examples-toggle-icon {
 .try-response {
     border-top: 1px solid var(--color-border-primary);
     padding-top: 1rem;
+    margin-top: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+/* Empty state for default sidebar layout */
+.try-response.empty {
+    background: var(--color-neutral-2);
+    border: 1px solid var(--color-neutral-5);
+    border-radius: var(--radius-medium);
+    padding: var(--space-lg);
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.try-response.empty>* {
+    display: none !important;
+}
+
+.try-response.empty::before {
+    content: "Click Send to get a response";
+    color: var(--color-neutral-7);
+    font-size: var(--font-size-4);
+    text-align: center;
 }
 
 .try-response-header {
@@ -6287,7 +6328,7 @@ details[open] .examples-toggle-icon {
     display: flex;
     flex-direction: column;
     flex: 1;
-    min-height: 0;
+    min-height: 200px;  /* Ensure content area has minimum height */
 }
 
 .try-response-body,
@@ -6306,7 +6347,7 @@ details[open] .examples-toggle-icon {
     white-space: pre-wrap;
     word-break: break-word;
     flex: 1;
-    min-height: 0;
+    min-height: 200px;  /* Ensure ACE editor has minimum height */
 }
 
 .try-response-body.active,
@@ -6416,6 +6457,7 @@ details[open] .examples-toggle-icon {
     font-family: var(--font-sans);
     height: 32px;
     min-width: 0;
+    border-radius: var(--radius-medium);
 }
 
 .custom-param-row input:focus {
@@ -6438,7 +6480,7 @@ details[open] .examples-toggle-icon {
     background: var(--color-neutral-1);
     color: var(--color-neutral-8);
     border: 1px solid var(--color-neutral-5);
-    border-radius: var(--radius-small);
+    border-radius: var(--radius-xl);
     font-family: var(--font-sans);
     font-size: var(--font-size-5);
     line-height: 1;


### PR DESCRIPTION
Portal Generator Fixes:
- Fix Try It Out response not showing in default sidebar layout
  - Added min-height: 200px to .try-response-content and .try-response-body
  - Previously had min-height: 0 causing ACE editor containers to collapse
  - Added base display rules to .try-response for proper flex layout
  - Added .try-response.empty state CSS for default sidebar layout

- Add dark mode support for ACE editors
  - Dynamically switch between textmate (light) and monokai (dark) themes
  - Added getAceTheme(), updateAceEditorBackground(), updateAllAceEditors()
  - Integrated with dark mode toggle to update all editors on theme change
  - Removed hardcoded background colors to let themes handle styling

- Fix response display logic in sendRequest
  - Always show response with empty state before request
  - Override template's inline display:none
  - Properly remove empty class and show response after data loads

- Add comprehensive debug logging for troubleshooting
  - Log response div state, dimensions, and computed styles
  - Track ACE editor creation and display flow
  - Added console logs throughout sendRequest lifecycle

API Spec Improvements (agent-scanner-configuration-service):
- Refactor path parameters to use component references
  - All path parameters now reference components/parameters
  - Eliminates duplicate parameter definitions across endpoints
  - Uses x-origin annotated parameters for better documentation

- Remove redundant Authorization header parameters
  - Security scheme handles authentication globally
  - Removed 15+ duplicate Authorization parameter definitions
  - Cleaner spec following OpenAPI best practices

UI Polish:
- Added border-radius to select elements for consistency
- Improved x-origin source selector styling
- Added overflow handling for parameter descriptions