### PR TITLE
Fix dark mode flash by applying theme in blocking head script

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -7313,15 +7313,7 @@ function clearAllVariables(slug) {
 // ============================================================================
 
 (function initDarkMode() {
-    // Check for saved theme preference or default to system preference
-    var savedTheme = localStorage.getItem('theme');
-    var systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    var initialTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
-
-    // Apply initial theme
-    if (initialTheme === 'dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-    }
+    // Note: Initial theme is already applied in <head> to prevent flash
 
     // Create and inject dark mode toggle button
     var toggleButton = document.createElement('button');

--- a/scripts/portal_generator/templates/base.html
+++ b/scripts/portal_generator/templates/base.html
@@ -29,6 +29,18 @@
     <link rel="stylesheet" href="{{ css_path }}">
     {% block extra_styles %}{% endblock %}
 
+    <!-- Dark Mode: Apply theme before render to prevent flash -->
+    <script>
+        (function() {
+            var savedTheme = localStorage.getItem('theme');
+            var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var initialTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
+            if (initialTheme === 'dark') {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
+
     <!-- Ace Editor -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/ace.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-json.min.js"></script>


### PR DESCRIPTION
Moves theme detection from deferred JS to an inline script in <head> that executes before first paint. Prevents the flash of light mode when user prefers or has selected dark mode.