### PR TITLE
@W-22137898 Add session TTL management with auto-expiration UI updates

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -534,6 +534,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
         });
 
         var data = await resp.json();
+        handleProxyResponse(data, fullUrl);
 
         // Restore button
         if (buttonEl) {
@@ -1832,6 +1833,7 @@ function setAuthStatus(authenticated, message, authMethod) {
         sessionStorage.removeItem('anypoint_auth_method');
         sessionStorage.removeItem('anypoint_identity');
         sessionStorage.removeItem('anypoint_token_expires_at');
+        stopTtlTimer();
     }
 
     updateAuthSummary();
@@ -1875,16 +1877,16 @@ async function loginBearer() {
             sessionStorage.setItem('anypoint_token', body.access_token);
             sessionStorage.setItem('anypoint_identity', username);
 
-            // Store token expiration time
-            if (body.expires_in) {
-                var expiresAt = Date.now() + (body.expires_in * 1000);
-                sessionStorage.setItem('anypoint_token_expires_at', expiresAt.toString());
+            var introspectResult = await introspectToken();
+            if (introspectResult && introspectResult.exp) {
+                setTokenExpiration(parseInt(introspectResult.exp, 10));
+            } else {
+                setTokenExpiration(Date.now() + _SESSION_TTL);
             }
 
             setAuthStatus(true, null, 'Bearer');
             showAuthMessage('Login successful!', false);
 
-            // Update playground panels with any environment variables that may have been set
             if (typeof updateAllPlaygroundPanelsFromEnvVars === 'function') {
                 updateAllPlaygroundPanelsFromEnvVars();
             }
@@ -1925,16 +1927,20 @@ async function loginOAuth2() {
             sessionStorage.setItem('anypoint_token', body.access_token);
             sessionStorage.setItem('anypoint_identity', clientId);
 
-            // Store token expiration time
             if (body.expires_in) {
-                var expiresAt = Date.now() + (body.expires_in * 1000);
-                sessionStorage.setItem('anypoint_token_expires_at', expiresAt.toString());
+                setTokenExpiration(Date.now() + (body.expires_in * 1000));
+            } else {
+                var introspectResult = await introspectToken();
+                if (introspectResult && introspectResult.exp) {
+                    setTokenExpiration(parseInt(introspectResult.exp, 10));
+                } else {
+                    setTokenExpiration(Date.now() + _SESSION_TTL);
+                }
             }
 
             setAuthStatus(true, null, 'OAuth2');
             showAuthMessage('Token obtained successfully!', false);
 
-            // Update playground panels with any environment variables that may have been set
             if (typeof updateAllPlaygroundPanelsFromEnvVars === 'function') {
                 updateAllPlaygroundPanelsFromEnvVars();
             }
@@ -1950,6 +1956,128 @@ function getAuthHeaders() {
     var token = sessionStorage.getItem('anypoint_token');
     if (token) return {'Authorization': 'Bearer ' + token};
     return {};
+}
+
+// ============================================================================
+// Try It Out — Session TTL Management
+// ============================================================================
+
+var _ttlTimerId = null;
+var _ttlExpirationTimerId = null;
+var _TTL_CHECK_INTERVAL = 30000;
+var _SESSION_TTL = 3600000;
+
+function isAccountsUrl(url) {
+    try {
+        var path = new URL(url).pathname;
+        return path.startsWith('/accounts/') || path === '/accounts';
+    } catch (e) {
+        return url.indexOf('/accounts/') !== -1 || url.indexOf('/accounts') === url.length - 9;
+    }
+}
+
+async function introspectToken() {
+    var token = sessionStorage.getItem('anypoint_token');
+    if (!token) return null;
+    var serverBase = getSelectedBaseUrl();
+    try {
+        var resp = await fetch(PROXY_URL, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                method: 'POST',
+                url: serverBase + '/accounts/oauth2/introspect',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + token
+                },
+                body: JSON.stringify({token: token, token_type_hint: 'access_token'})
+            })
+        });
+        var data = await resp.json();
+        if (data.error) return null;
+        var body = JSON.parse(data.body);
+        return body;
+    } catch (e) {
+        return null;
+    }
+}
+
+function setTokenExpiration(expMs) {
+    sessionStorage.setItem('anypoint_token_expires_at', String(expMs));
+    startTtlTimer();
+    scheduleExpirationCheck(expMs);
+}
+
+function scheduleExpirationCheck(expMs) {
+    if (_ttlExpirationTimerId !== null) {
+        clearTimeout(_ttlExpirationTimerId);
+        _ttlExpirationTimerId = null;
+    }
+    var delay = expMs - Date.now();
+    if (delay <= 0) {
+        checkTtlExpiration();
+        return;
+    }
+    _ttlExpirationTimerId = setTimeout(function() {
+        _ttlExpirationTimerId = null;
+        checkTtlExpiration();
+    }, delay);
+}
+
+function extendTokenExpiration() {
+    var token = sessionStorage.getItem('anypoint_token');
+    if (!token) return;
+    setTokenExpiration(Date.now() + _SESSION_TTL);
+}
+
+function markTokenExpired() {
+    sessionStorage.setItem('anypoint_token_expires_at', '0');
+    stopTtlTimer();
+    updateAuthSummary();
+}
+
+function startTtlTimer() {
+    stopTtlTimer();
+    _ttlTimerId = setInterval(checkTtlExpiration, _TTL_CHECK_INTERVAL);
+}
+
+function stopTtlTimer() {
+    if (_ttlTimerId !== null) {
+        clearInterval(_ttlTimerId);
+        _ttlTimerId = null;
+    }
+    if (_ttlExpirationTimerId !== null) {
+        clearTimeout(_ttlExpirationTimerId);
+        _ttlExpirationTimerId = null;
+    }
+}
+
+async function checkTtlExpiration() {
+    var token = sessionStorage.getItem('anypoint_token');
+    if (!token) {
+        stopTtlTimer();
+        return;
+    }
+    if (!isTokenExpired()) return;
+
+    var result = await introspectToken();
+    if (result && result.active === true && result.exp) {
+        setTokenExpiration(parseInt(result.exp, 10));
+        updateAuthSummary();
+    } else if (result && result.active === false) {
+        markTokenExpired();
+    }
+}
+
+function handleProxyResponse(data, requestUrl) {
+    if (data.status === 401) {
+        markTokenExpired();
+        return;
+    }
+    if (data.status >= 200 && data.status < 300 && requestUrl && !isAccountsUrl(requestUrl)) {
+        extendTokenExpiration();
+    }
 }
 
 // ============================================================================
@@ -2180,6 +2308,7 @@ async function loadXOriginValues(opId, paramName) {
         });
 
         var data = await resp.json();
+        handleProxyResponse(data, fullUrl);
 
         if (btn) {
             btn.disabled = false;
@@ -2380,6 +2509,7 @@ async function loadXOriginValuesForEnv(paramName) {
         });
 
         var data = await resp.json();
+        handleProxyResponse(data, fullUrl);
 
         if (btn) {
             btn.disabled = false;
@@ -3558,6 +3688,7 @@ async function sendRequest(opId, buttonEl) {
             })
         });
         var data = await resp.json();
+        handleProxyResponse(data, fullUrl);
 
         // Restore button
         if (buttonEl) {
@@ -5500,6 +5631,7 @@ async function executePlaygroundStep(sid, buttonEl) {
         });
 
         var result = await resp.json();
+        handleProxyResponse(result, fullUrl);
 
         // Restore button
         if (buttonEl) {
@@ -5641,6 +5773,9 @@ function canProceedToNextStep(skillSlug, currentStepIndex) {
         var authMethod = sessionStorage.getItem('anypoint_auth_method') || '';
         if (token && authMethod) {
             setAuthStatus(true, null, authMethod);
+            if (sessionStorage.getItem('anypoint_token_expires_at')) {
+                startTtlTimer();
+            }
         }
 
         // Render environment variables
@@ -6405,6 +6540,7 @@ async function runWorkflowStep(skillSlug, stepIndex) {
             })
         });
         var data = await resp.json();
+        handleProxyResponse(data, fullUrl);
 
         if (spinner) spinner.style.display = 'none';
         if (rightPanel) rightPanel.setAttribute('open', '');

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -534,7 +534,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
         });
 
         var data = await resp.json();
-        handleProxyResponse(data, fullUrl);
+        handleProxyResponse(data);
 
         // Restore button
         if (buttonEl) {
@@ -1967,15 +1967,6 @@ var _ttlExpirationTimerId = null;
 var _TTL_CHECK_INTERVAL = 30000;
 var _SESSION_TTL = 3600000;
 
-function isAccountsUrl(url) {
-    try {
-        var path = new URL(url).pathname;
-        return path.startsWith('/accounts/') || path === '/accounts';
-    } catch (e) {
-        return url.indexOf('/accounts/') !== -1 || url.indexOf('/accounts') === url.length - 9;
-    }
-}
-
 async function introspectToken() {
     var token = sessionStorage.getItem('anypoint_token');
     if (!token) return null;
@@ -2025,12 +2016,6 @@ function scheduleExpirationCheck(expMs) {
     }, delay);
 }
 
-function extendTokenExpiration() {
-    var token = sessionStorage.getItem('anypoint_token');
-    if (!token) return;
-    setTokenExpiration(Date.now() + _SESSION_TTL);
-}
-
 function markTokenExpired() {
     sessionStorage.setItem('anypoint_token_expires_at', '0');
     stopTtlTimer();
@@ -2070,13 +2055,9 @@ async function checkTtlExpiration() {
     }
 }
 
-function handleProxyResponse(data, requestUrl) {
+function handleProxyResponse(data) {
     if (data.status === 401) {
         markTokenExpired();
-        return;
-    }
-    if (data.status >= 200 && data.status < 300 && requestUrl && !isAccountsUrl(requestUrl)) {
-        extendTokenExpiration();
     }
 }
 
@@ -2308,7 +2289,7 @@ async function loadXOriginValues(opId, paramName) {
         });
 
         var data = await resp.json();
-        handleProxyResponse(data, fullUrl);
+        handleProxyResponse(data);
 
         if (btn) {
             btn.disabled = false;
@@ -2509,7 +2490,7 @@ async function loadXOriginValuesForEnv(paramName) {
         });
 
         var data = await resp.json();
-        handleProxyResponse(data, fullUrl);
+        handleProxyResponse(data);
 
         if (btn) {
             btn.disabled = false;
@@ -3688,7 +3669,7 @@ async function sendRequest(opId, buttonEl) {
             })
         });
         var data = await resp.json();
-        handleProxyResponse(data, fullUrl);
+        handleProxyResponse(data);
 
         // Restore button
         if (buttonEl) {
@@ -5631,7 +5612,7 @@ async function executePlaygroundStep(sid, buttonEl) {
         });
 
         var result = await resp.json();
-        handleProxyResponse(result, fullUrl);
+        handleProxyResponse(result);
 
         // Restore button
         if (buttonEl) {
@@ -6540,7 +6521,7 @@ async function runWorkflowStep(skillSlug, stepIndex) {
             })
         });
         var data = await resp.json();
-        handleProxyResponse(data, fullUrl);
+        handleProxyResponse(data);
 
         if (spinner) spinner.style.display = 'none';
         if (rightPanel) rightPanel.setAttribute('open', '');

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -1518,6 +1518,15 @@ code {
     background: rgba(46, 160, 67, 0.25);
 }
 
+[data-theme="dark"] .auth-status-container.expired {
+    background: rgba(227, 179, 65, 0.15);
+    border-color: #e3b341;
+}
+
+[data-theme="dark"] .auth-panel-status:hover .auth-status-container.expired {
+    background: rgba(227, 179, 65, 0.25);
+}
+
 [data-theme="dark"] .badge-security {
     background: rgba(110, 118, 129, 0.1);
     color: #8b949e;

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -880,3 +880,147 @@ describe('_closeAllSkillDropdowns', () => {
         expect(b.toggle.getAttribute('aria-expanded')).toBe('false');
     });
 });
+
+// ===========================================================================
+// Session TTL Management
+// ===========================================================================
+
+describe('isAccountsUrl', () => {
+    test('returns true for /accounts/ paths', () => {
+        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/login')).toBe(true);
+        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/api/me')).toBe(true);
+        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/oauth2/introspect')).toBe(true);
+    });
+
+    test('returns false for non-accounts paths', () => {
+        expect(isAccountsUrl('https://anypoint.mulesoft.com/apimanager/api/v1/organizations/123/apis')).toBe(false);
+        expect(isAccountsUrl('https://anypoint.mulesoft.com/exchange/api/v2/assets')).toBe(false);
+    });
+
+    test('handles malformed URLs gracefully', () => {
+        expect(isAccountsUrl('not-a-url-with-/accounts/')).toBe(true);
+        expect(isAccountsUrl('not-a-url')).toBe(false);
+    });
+});
+
+describe('setTokenExpiration', () => {
+    beforeEach(() => sessionStorage.clear());
+
+    test('stores expiration in sessionStorage', () => {
+        setTokenExpiration(1777057512412);
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe('1777057512412');
+    });
+});
+
+describe('extendTokenExpiration', () => {
+    beforeEach(() => sessionStorage.clear());
+
+    test('does nothing when no token exists', () => {
+        extendTokenExpiration();
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBeNull();
+    });
+
+    test('sets expiration to ~1h from now when token exists', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        var before = Date.now();
+        extendTokenExpiration();
+        var stored = parseInt(sessionStorage.getItem('anypoint_token_expires_at'), 10);
+        expect(stored).toBeGreaterThanOrEqual(before + 3600000 - 100);
+        expect(stored).toBeLessThanOrEqual(Date.now() + 3600000 + 100);
+    });
+});
+
+describe('markTokenExpired', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        // Set up minimal DOM elements for updateAuthSummary
+        ['authStatusDot', 'authStatusText', 'authLockIcon'].forEach(id => {
+            if (!document.getElementById(id)) {
+                const el = document.createElement(id === 'authStatusText' ? 'span' : 'img');
+                el.id = id;
+                if (el.tagName === 'IMG') el.src = 'assets/icons/placeholder.svg';
+                document.body.appendChild(el);
+            }
+        });
+    });
+
+    test('sets expiration to 0', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+        markTokenExpired();
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe('0');
+    });
+
+    test('keeps the token itself (amber state, not red)', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        markTokenExpired();
+        expect(sessionStorage.getItem('anypoint_token')).toBe('test-token');
+    });
+});
+
+describe('handleProxyResponse', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+        // Minimal DOM for updateAuthSummary
+        ['authStatusDot', 'authStatusText', 'authLockIcon'].forEach(id => {
+            if (!document.getElementById(id)) {
+                const el = document.createElement(id === 'authStatusText' ? 'span' : 'img');
+                el.id = id;
+                if (el.tagName === 'IMG') el.src = 'assets/icons/placeholder.svg';
+                document.body.appendChild(el);
+            }
+        });
+    });
+
+    test('marks token expired on 401', () => {
+        handleProxyResponse({ status: 401 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe('0');
+    });
+
+    test('extends TTL on 2xx non-accounts response', () => {
+        var before = Date.now();
+        handleProxyResponse({ status: 200 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
+        var stored = parseInt(sessionStorage.getItem('anypoint_token_expires_at'), 10);
+        expect(stored).toBeGreaterThanOrEqual(before + 3600000 - 100);
+    });
+
+    test('does NOT extend TTL on 2xx accounts response', () => {
+        var original = sessionStorage.getItem('anypoint_token_expires_at');
+        handleProxyResponse({ status: 200 }, 'https://anypoint.mulesoft.com/accounts/api/me');
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe(original);
+    });
+
+    test('does nothing on non-401 error responses', () => {
+        var original = sessionStorage.getItem('anypoint_token_expires_at');
+        handleProxyResponse({ status: 500 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
+        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe(original);
+    });
+});
+
+describe('isTokenExpired (with TTL)', () => {
+    beforeEach(() => sessionStorage.clear());
+
+    test('returns true when no token', () => {
+        expect(isTokenExpired()).toBe(true);
+    });
+
+    test('returns false when token exists with future expiration', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+        expect(isTokenExpired()).toBe(false);
+    });
+
+    test('returns true when token exists with past expiration', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() - 1000));
+        expect(isTokenExpired()).toBe(true);
+    });
+
+    test('returns true when expiration is 0 (marked expired)', () => {
+        sessionStorage.setItem('anypoint_token', 'test-token');
+        sessionStorage.setItem('anypoint_token_expires_at', '0');
+        expect(isTokenExpired()).toBe(true);
+    });
+});

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -885,48 +885,12 @@ describe('_closeAllSkillDropdowns', () => {
 // Session TTL Management
 // ===========================================================================
 
-describe('isAccountsUrl', () => {
-    test('returns true for /accounts/ paths', () => {
-        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/login')).toBe(true);
-        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/api/me')).toBe(true);
-        expect(isAccountsUrl('https://anypoint.mulesoft.com/accounts/oauth2/introspect')).toBe(true);
-    });
-
-    test('returns false for non-accounts paths', () => {
-        expect(isAccountsUrl('https://anypoint.mulesoft.com/apimanager/api/v1/organizations/123/apis')).toBe(false);
-        expect(isAccountsUrl('https://anypoint.mulesoft.com/exchange/api/v2/assets')).toBe(false);
-    });
-
-    test('handles malformed URLs gracefully', () => {
-        expect(isAccountsUrl('not-a-url-with-/accounts/')).toBe(true);
-        expect(isAccountsUrl('not-a-url')).toBe(false);
-    });
-});
-
 describe('setTokenExpiration', () => {
     beforeEach(() => sessionStorage.clear());
 
     test('stores expiration in sessionStorage', () => {
         setTokenExpiration(1777057512412);
         expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe('1777057512412');
-    });
-});
-
-describe('extendTokenExpiration', () => {
-    beforeEach(() => sessionStorage.clear());
-
-    test('does nothing when no token exists', () => {
-        extendTokenExpiration();
-        expect(sessionStorage.getItem('anypoint_token_expires_at')).toBeNull();
-    });
-
-    test('sets expiration to ~1h from now when token exists', () => {
-        sessionStorage.setItem('anypoint_token', 'test-token');
-        var before = Date.now();
-        extendTokenExpiration();
-        var stored = parseInt(sessionStorage.getItem('anypoint_token_expires_at'), 10);
-        expect(stored).toBeGreaterThanOrEqual(before + 3600000 - 100);
-        expect(stored).toBeLessThanOrEqual(Date.now() + 3600000 + 100);
     });
 });
 
@@ -975,26 +939,19 @@ describe('handleProxyResponse', () => {
     });
 
     test('marks token expired on 401', () => {
-        handleProxyResponse({ status: 401 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
+        handleProxyResponse({ status: 401 });
         expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe('0');
     });
 
-    test('extends TTL on 2xx non-accounts response', () => {
-        var before = Date.now();
-        handleProxyResponse({ status: 200 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
-        var stored = parseInt(sessionStorage.getItem('anypoint_token_expires_at'), 10);
-        expect(stored).toBeGreaterThanOrEqual(before + 3600000 - 100);
-    });
-
-    test('does NOT extend TTL on 2xx accounts response', () => {
+    test('does nothing on non-401 responses', () => {
         var original = sessionStorage.getItem('anypoint_token_expires_at');
-        handleProxyResponse({ status: 200 }, 'https://anypoint.mulesoft.com/accounts/api/me');
+        handleProxyResponse({ status: 200 });
         expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe(original);
     });
 
-    test('does nothing on non-401 error responses', () => {
+    test('does nothing on server error responses', () => {
         var original = sessionStorage.getItem('anypoint_token_expires_at');
-        handleProxyResponse({ status: 500 }, 'https://anypoint.mulesoft.com/apimanager/api/v1/orgs');
+        handleProxyResponse({ status: 500 });
         expect(sessionStorage.getItem('anypoint_token_expires_at')).toBe(original);
     });
 });


### PR DESCRIPTION
- Add automatic UI update when session token expires — a precise setTimeout fires at the exact expiration moment, so the status flips to amber without any user interaction
- Integrate server-side token introspection: when the local TTL expires, the portal checks /accounts/oauth2/introspect to confirm — if the server says the token is still active, the local expiration is updated with the real exp value and the timer is rescheduled
- Hook handleProxyResponse into all proxy call sites to detect 401 responses and immediately mark the token as expired
- Fix dark mode contrast for the "Token Expired" amber status indicator