### PR TITLE
Add API Experience Hub APIs and fix portal rendering of internal $ref schemas and array bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__
 node_modules/
 .coverage
 *.log
+
+.idea
+.idea/**

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ anypoint-cli-v4 plugins:install anypoint-cli-api-project-plugin
 pip3 install -r scripts/requirements.txt
 ```
 
+> **Using a Homebrew-managed Python (macOS)?** Homebrew's Python is marked as an "externally-managed" environment (PEP 668), so a bare `pip3 install` will refuse to write into it. Use a local virtual environment instead (see [Generating the Portal with Homebrew-managed Python](#generating-the-portal-with-homebrew-managed-python-macos) below).
+
 **3. Install API Spec Validation Skills:**
 ```bash
 # In Claude Code CLI
@@ -306,6 +308,60 @@ open portal/index.html
 ```
 
 The portal features API browsing, operation details with "Try It Out" panels, skill workflow execution, and authentication management.
+
+### Generating the Portal with Homebrew-managed Python (macOS)
+
+If your `python3` comes from Homebrew, it is an **externally-managed environment** (PEP 668) and the standard `pip3 install -r scripts/requirements.txt` will fail with:
+
+```
+error: externally-managed-environment
+× This environment is externally managed
+```
+
+The portal generator depends on `ruamel.yaml`, `Jinja2`, `markdown-it-py`, `beautifulsoup4`, and `pytest`, so these must be installable. Use a local virtual environment in the repo root to avoid touching the system interpreter.
+
+**One-time setup:**
+
+```bash
+# From the repository root
+python3 -m venv .venv                          # create a local venv
+source .venv/bin/activate                      # activate it for this shell
+pip install --upgrade pip                      # (optional) refresh pip itself
+pip install -r scripts/requirements.txt        # install portal generator deps
+deactivate                                     # leave the venv (optional)
+```
+
+The venv is created at `.venv/` (already covered by `.gitignore` in most setups — add it if not).
+
+**Every time you build or test the portal**, put the venv's `bin` on `PATH` for the current shell so `make` picks up the venv's `python3` transparently:
+
+```bash
+# From the repository root
+export PATH="$PWD/.venv/bin:$PATH"
+
+make generate-portal            # builds to portal/
+make test-portal                # runs the portal test suite
+python3 scripts/build/validate_jtbd.py skills/<skill-name>/SKILL.md .   # validate a JTBD
+```
+
+Equivalently you can `source .venv/bin/activate` instead of exporting `PATH` — both approaches shadow the Homebrew `python3` with the venv's.
+
+**Serving the generated portal locally:**
+
+After `make generate-portal`, start a simple HTTP server so relative links and `fetch()` calls resolve correctly:
+
+```bash
+cd portal
+python3 -m http.server 8000     # works with venv or Homebrew Python — no extra deps
+```
+
+Then open http://localhost:8000 in your browser. Opening `portal/index.html` via `file://` also works for basic browsing, but some dynamic features (registry JSON loading, iframe previews) require the HTTP origin.
+
+**Troubleshooting:**
+
+- `ruamel.yaml not installed`: the shell is still using the Homebrew `python3` — re-run `export PATH="$PWD/.venv/bin:$PATH"` or re-activate the venv.
+- `pip install -r ... : error: externally-managed-environment`: you forgot to activate the venv; `pip` is resolving to Homebrew. Activate the venv (or use `.venv/bin/pip install ...` directly) and re-run.
+- `pipx install -r requirements.txt` fails: `pipx` is for installing individual CLI apps, not bulk-installing libraries. Use the venv approach above.
 
 ### Running Tests
 

--- a/apis/api-experience-hub-consumer/api.yaml
+++ b/apis/api-experience-hub-consumer/api.yaml
@@ -287,104 +287,6 @@ paths:
               schema:
                 type: object
               example: {}
-  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/model:
-    post:
-      tags:
-      - Asset Discovery
-      summary: Get API console model
-      description: Returns the AMF model for rendering the API console for a specific asset.
-      operationId: getAssetModel
-      parameters:
-      - name: minorVersion
-        in: path
-        description: Minor version of the asset (e.g. 1.0)
-        required: true
-        schema:
-          type: string
-          pattern: ^v?\d+$
-        x-origin:
-        - api: urn:api:api-experience-hub-consumer
-          operation: getAssetDetails
-          values: $.minorVersion
-          description: Minor version published for the selected asset
-      - name: assetId
-        in: path
-        description: Exchange asset ID
-        required: true
-        schema:
-          type: string
-        x-origin:
-        - api: urn:api:api-experience-hub-consumer
-          operation: listAssetsCommunityAsset
-          values: $[*].assetId
-          labels: $[*].name
-          description: Exchange asset published in the portal
-      - name: groupId
-        in: path
-        description: Exchange group ID of the asset
-        required: true
-        schema:
-          type: string
-        x-origin:
-        - api: urn:api:api-experience-hub-consumer
-          operation: listAssetsCommunityAsset
-          values: $[*].groupId
-          description: Exchange group identifier for the selected asset
-      - name: targetPortalId
-        in: path
-        description: Unique identifier of the portal
-        required: true
-        schema:
-          type: string
-        x-origin:
-        - api: urn:api:api-experience-hub-management
-          operation: getAllApiPortalByConnectionId
-          values: $[*].targetPortalId
-          labels: $[*].name
-          description: Portal identifier from the management API's portal list for the active connection
-      - name: targetOrganizationId
-        in: path
-        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
-        required: true
-        schema:
-          type: string
-          format: uuid
-        x-origin:
-        - api: urn:api:api-experience-hub-management
-          operation: getConnections
-          values: $[*].targetOrganizationId
-          labels: $[*].targetOrganizationDomain
-          description: External organization identifier for the connection (e.g. Salesforce org ID)
-      requestBody:
-        description: Shape selection for the API console model
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SelectedShapeDTO"
-            example:
-              selectedShape: "/payments"
-              selectedShapeType: "ENDPOINT"
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/ErrorResponseDTO"
-        "401":
-          description: Unauthorized
-          content:
-            '*/*':
-              schema:
-                $ref: "#/components/schemas/ErrorResponseDTO"
-        "200":
-          description: OK
-          content:
-            '*/*':
-              schema:
-                type: string
-              example: "{\"@context\":{\"@base\":\"amf://id\"},\"@graph\":[{\"@id\":\"#/web-api\"}]}"
   /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/search:
     post:
       tags:
@@ -2206,25 +2108,6 @@ components:
           type: string
           description: Client provider type
       description: Client identity provider associated with this application
-    SelectedShapeDTO:
-      required:
-      - selectedShapeType
-      type: object
-      properties:
-        selectedShape:
-          type: string
-          description: Name or identifier of the selected API shape
-        selectedShapeType:
-          type: string
-          description: Type of the selected shape
-          enum:
-          - SUMMARY
-          - TYPE
-          - ENDPOINT
-          - OPERATION
-          - DOCUMENTATION
-          - SECURITY
-          - METHOD
     ConsumerAssetsSearchRequest:
       type: object
       properties:

--- a/apis/api-experience-hub-consumer/api.yaml
+++ b/apis/api-experience-hub-consumer/api.yaml
@@ -1,0 +1,2465 @@
+openapi: 3.0.1
+info:
+  title: API Experience Hub Consumer API
+  description: API Experience Hub API
+  version: 1.0.0
+servers:
+- url: https://anypoint.mulesoft.com/api-experience-hub
+  description: US
+- url: https://eu1.anypoint.mulesoft.com/api-experience-hub
+  description: EU
+- url: https://ca1.platform.mulesoft.com/api-experience-hub
+  description: CA
+- url: https://jp1.platform.mulesoft.com/api-experience-hub
+  description: JP
+security:
+- bearerAuth: []
+tags:
+- name: Asset Discovery
+  description: Search and browse API assets published in a portal
+- name: Application Management
+  description: "Create, update and delete client applications and credentials"
+- name: Request Access
+  description: "Request API access through instances, tiers, providers and contracts"
+paths:
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/{applicationId}:
+    get:
+      tags:
+      - Application Management
+      summary: Get application details
+      description: Returns detailed information about a specific application including credentials.
+      operationId: getApplicationDetailById
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiManagerApplicationDTO"
+              example:
+                id: "12345"
+                name: "My API Client"
+                description: "Client application for accessing the Payment API"
+                clientId: "3dbce73b-b8fa-4b39-b4bd-b7fa7a6e9e0f"
+                clientSecret: "secretValue123"
+                grantTypes:
+                - client_credentials
+                redirectUri:
+                - "https://example.com/callback"
+                url: "https://example.com"
+                lastUpdateDate: "2024-01-15T10:30:00Z"
+                clientProvider:
+                  name: "Default"
+                  providerId: "33333333-3333-3333-3333-333333333333"
+                  type: "openid_connect"
+    put:
+      tags:
+      - Application Management
+      summary: Update an application
+      description: Updates the details of an existing client application.
+      operationId: updateApplication
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "Application update request with new name, description or OAuth settings"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApplicationUpsertDTO"
+            example:
+              name: "My API Client"
+              description: "Client application for accessing the Payment API"
+              url: "https://example.com"
+              redirectUri:
+              - "https://example.com/callback"
+              grantTypes:
+              - client_credentials
+              apiEndpoints: false
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiManagerApplicationDTO"
+              example:
+                id: "12345"
+                name: "My API Client"
+                description: "Client application for accessing the Payment API"
+                clientId: "3dbce73b-b8fa-4b39-b4bd-b7fa7a6e9e0f"
+                clientSecret: "secretValue123"
+                grantTypes:
+                - client_credentials
+                redirectUri:
+                - "https://example.com/callback"
+                url: "https://example.com"
+                lastUpdateDate: "2024-01-15T10:30:00Z"
+                clientProvider:
+                  name: "Default"
+                  providerId: "33333333-3333-3333-3333-333333333333"
+                  type: "openid_connect"
+    delete:
+      tags:
+      - Application Management
+      summary: Delete an application
+      description: Permanently deletes a client application.
+      operationId: deleteApplication
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: object
+              example: {}
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/model:
+    post:
+      tags:
+      - Asset Discovery
+      summary: Get API console model
+      description: Returns the AMF model for rendering the API console for a specific asset.
+      operationId: getAssetModel
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: Shape selection for the API console model
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SelectedShapeDTO"
+            example:
+              selectedShape: "/payments"
+              selectedShapeType: "ENDPOINT"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+              example: "{\"@context\":{\"@base\":\"amf://id\"},\"@graph\":[{\"@id\":\"#/web-api\"}]}"
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/search:
+    post:
+      tags:
+      - Asset Discovery
+      summary: Search portal assets
+      description: "Searches for API assets published in a portal by keyword, categories, tags or asset types."
+      operationId: searchCommunityAssets
+      parameters:
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: x-limit
+        in: header
+        description: Maximum number of search results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        description: "Search criteria including keywords, categories, tags and asset types"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConsumerAssetsSearchRequest"
+            example:
+              searchTerm: "payment"
+              assetTypes:
+              - rest-api
+              - http-api
+              categories:
+              - "Department:Finance"
+              sort:
+                direction: DESC
+                criteria: LAST_UPDATED
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ConsumerAssetSearchResult"
+              example:
+                assets:
+                - assetId: "payment-api"
+                  groupId: "com.example"
+                  name: "Payment API"
+                  description: "API for processing payments"
+                  type: "rest-api"
+                  minorVersion: "v1"
+                  latestPatchVersion: "1.0.2"
+                  icon: "https://example.com/icon.png"
+                  tags:
+                  - payments
+                  - finance
+                  categories:
+                  - "Department:Finance"
+                  updatedDate: "2024-01-15T10:30:00Z"
+                facets:
+                - "Department:Finance"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/assets/{groupId}/{assetId}/{minorVersion}/applications:
+    post:
+      tags:
+      - Application Management
+      summary: Create an application
+      description: Creates a new client application for requesting API access.
+      operationId: createApplication
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "Application creation request with name, instance ID and optional OAuth settings"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApplicationCreateDTO"
+            example:
+              name: "My API Client"
+              description: "Client application for the Payment API"
+              instanceId: "22222222-2222-2222-2222-222222222222"
+              url: "https://example.com"
+              redirectUri:
+              - "https://example.com/callback"
+              grantTypes:
+              - client_credentials
+              apiEndpoints: false
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApplicationCreatedResponseDTO"
+              example:
+                id: "12345"
+                name: "My API Client"
+                description: "Client application for the Payment API"
+                clientId: "3dbce73b-b8fa-4b39-b4bd-b7fa7a6e9e0f"
+                clientSecret: "secretValue123"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/assets/{groupId}/{assetId}/{minorVersion}/contracts:
+    post:
+      tags:
+      - Request Access
+      summary: Create a contract
+      description: Creates an API access contract between an application and an API instance.
+      operationId: createContract
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "Contract creation request with application ID, instance ID and accepted terms"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContractCreateDTO"
+            example:
+              applicationId: "11111111-1111-1111-1111-111111111111"
+              instanceId: "22222222-2222-2222-2222-222222222222"
+              acceptedTerms: true
+              tierId: 1
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ContractCreatedResponseDTO"
+              example:
+                id: "67890"
+                clientId: "3dbce73b-b8fa-4b39-b4bd-b7fa7a6e9e0f"
+                clientSecret: "secretValue123"
+                status: "APPROVED"
+                requestedTier:
+                  id: "1"
+                  name: "Gold"
+                  description: "Gold tier with 1000 req/min"
+                  status: "ACTIVE"
+                  active: true
+                  autoApprove: true
+                  limits:
+                  - maximumRequests: "1000"
+                    timePeriodInMilliseconds: 60000
+                    timePeriod: 60000
+                    timeUnit: "Minute"
+                    visible: true
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/{applicationId}/secret/reset:
+    post:
+      tags:
+      - Application Management
+      summary: Reset client secret
+      description: Generates a new client secret for the specified application.
+      operationId: resetClientSecretForApplication
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiManagerSecretResetResponseDTO"
+              example:
+                clientSecret: "newSecretValue456"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/{applicationId}/contracts/{contractId}/tiers/{tierId}:
+    patch:
+      tags:
+      - Request Access
+      summary: Update contract SLA tier
+      description: Changes the SLA tier assigned to an existing contract.
+      operationId: assignSlaTierToContract
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: contractId
+        in: path
+        description: Unique identifier of the contract
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: tierId
+        in: path
+        description: ID of the SLA tier to assign
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ContractDTO"
+              example:
+                id: "67890"
+                applicationId: "11111111-1111-1111-1111-111111111111"
+                instanceId: "22222222-2222-2222-2222-222222222222"
+                status: "APPROVED"
+                requestedTier:
+                  id: "2"
+                  name: "Silver"
+                  description: "Silver tier with 500 req/min"
+                  status: "ACTIVE"
+                  active: true
+                  autoApprove: false
+                  limits: []
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets:
+    get:
+      tags:
+      - Asset Discovery
+      summary: List portal assets
+      description: "Returns a paginated list of assets published in the portal, sorted by recently added."
+      operationId: listAssetsCommunityAsset
+      parameters:
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: limit
+        in: query
+        description: Maximum number of assets to return (max 250)
+        required: false
+        schema:
+          maximum: 250
+          type: integer
+          format: int32
+          default: 5
+      - name: offset
+        in: query
+        description: Number of results to skip for pagination
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConsumerCommunityAsset"
+              example:
+              - assetId: "payment-api"
+                groupId: "com.example"
+                name: "Payment API"
+                description: "API for processing payments"
+                type: "rest-api"
+                minorVersion: "v1"
+                latestPatchVersion: "1.0.2"
+                tags:
+                - payments
+                categories:
+                - "Department:Finance"
+                updatedDate: "2024-01-15T10:30:00Z"
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/terms:
+    get:
+      tags:
+      - Asset Discovery
+      summary: Get terms and conditions
+      description: Returns the terms and conditions in markdown format for a specific asset.
+      operationId: getTermsAndConditions
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+              example: "# Terms and Conditions\n\nBy using this API, you agree to..."
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/resources/{resourceId}:
+    get:
+      tags:
+      - Asset Discovery
+      summary: Get asset resource
+      description: Returns a binary resource file associated with an asset's documentation.
+      operationId: getAssetResource
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: resourceId
+        in: path
+        description: Unique identifier of the asset resource file
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+                format: byte
+              example: "iVBORw0KGgoAAAANSUhEUg..."
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/pages/**:
+    get:
+      tags:
+      - Asset Discovery
+      summary: Get documentation page
+      description: Returns a documentation page in markdown format for a specific asset.
+      operationId: getAssetPages
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+              example: "# Getting Started\n\nWelcome to the API documentation..."
+  /xapi/v1/portals/{targetOrganizationId}/{targetPortalId}/assets/{groupId}/{assetId}/{minorVersion}/details:
+    get:
+      tags:
+      - Asset Discovery
+      summary: Get asset details
+      description: "Returns detailed information about a specific API asset including instances, categories and documentation pages."
+      operationId: getAssetDetails
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: targetPortalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/AssetDetailDTO"
+              example:
+                assetId: "payment-api"
+                groupId: "com.example"
+                name: "Payment API"
+                description: "API for processing payments"
+                type: "rest-api"
+                apiVersion: "v1"
+                organizationId: "88888888-8888-8888-8888-888888888888"
+                minorVersion: "v1"
+                latestPatchVersion: "1.0.2"
+                versionGroup: "v1"
+                icon: "https://example.com/icon.png"
+                tags:
+                - payments
+                categories:
+                - displayName: "Department"
+                  key: "department"
+                  values:
+                  - "Finance"
+                pages:
+                - name: "Getting Started"
+                  path: "/getting-started"
+                instances:
+                - id: "inst-001"
+                  name: "Production"
+                  endpointUri: "https://api.example.com/v1"
+                  environmentId: "99999999-9999-9999-9999-999999999999"
+                  environmentName: "Production"
+                  isPublic: true
+                  type: "rest-api"
+                  minorVersion: "v1"
+                  contractsCount: 5
+                  providerId: "33333333-3333-3333-3333-333333333333"
+                files:
+                - label: "API Specification"
+                  externalLink: "https://example.com/spec.yaml"
+                  isGenerated: false
+                updatedDate: "2024-01-15T10:30:00Z"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/assets/{groupId}/{assetId}/{minorVersion}/instances/{instanceId}/tiers:
+    get:
+      tags:
+      - Request Access
+      summary: List SLA tiers
+      description: Returns the available SLA tiers for an API instance.
+      operationId: getTiers
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: instanceId
+        in: path
+        description: Unique identifier of the API instance
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TierDTO"
+              example:
+              - id: "1"
+                name: "Gold"
+                description: "Gold tier with 1000 req/min"
+                status: "ACTIVE"
+                active: true
+                autoApprove: true
+                limits:
+                - maximumRequests: "1000"
+                  timePeriodInMilliseconds: 60000
+                  timePeriod: 60000
+                  timeUnit: "Minute"
+                  visible: true
+              - id: "2"
+                name: "Silver"
+                description: "Silver tier with 500 req/min"
+                status: "ACTIVE"
+                active: true
+                autoApprove: false
+                limits: []
+  ? /xapi/v1/portals/{targetOrganizationId}/{portalId}/assets/{groupId}/{assetId}/{minorVersion}/instances/{instanceId}/provider/grantTypes
+  : get:
+      tags:
+      - Request Access
+      summary: Get grant types by instance
+      description: Returns the available OAuth grant types for an API instance's provider.
+      operationId: getGrantTypesByInstanceId
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: instanceId
+        in: path
+        description: Unique identifier of the API instance
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/GrantTypeResponseDTO"
+              example:
+                grantTypes:
+                - name: "client_credentials"
+                  label: "Client Credentials"
+                  required: false
+                  depends: []
+                  exclude: []
+                - name: "authorization_code"
+                  label: "Authorization Code"
+                  required: false
+                  depends: []
+                  exclude: []
+                type:
+                  name: "openid_connect"
+                  description: "OpenID Connect Provider"
+  ? /xapi/v1/portals/{targetOrganizationId}/{portalId}/assets/{groupId}/{assetId}/{minorVersion}/contracts/{applicationId}/{instanceId}
+  : get:
+      tags:
+      - Request Access
+      summary: Get contract details
+      description: Returns a specific contract for an application and instance.
+      operationId: getContract
+      parameters:
+      - name: minorVersion
+        in: path
+        description: Minor version of the asset (e.g. 1.0)
+        required: true
+        schema:
+          type: string
+          pattern: ^v?\d+$
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: instanceId
+        in: path
+        description: Unique identifier of the API instance
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ContractDTO"
+              example:
+                id: "67890"
+                applicationId: "11111111-1111-1111-1111-111111111111"
+                instanceId: "22222222-2222-2222-2222-222222222222"
+                status: "APPROVED"
+                requestedTier:
+                  id: "2"
+                  name: "Silver"
+                  description: "Silver tier with 500 req/min"
+                  status: "ACTIVE"
+                  active: true
+                  autoApprove: false
+                  limits: []
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications:
+    get:
+      tags:
+      - Application Management
+      summary: List applications
+      description: Returns applications with optional filtering by instance and name.
+      operationId: getApplications
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: instanceId
+        in: query
+        description: Filter applications by API instance ID
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: query
+        in: query
+        description: Filter applications by name
+        required: false
+        schema:
+          type: string
+          default: ""
+      - name: limit
+        in: query
+        description: Maximum number of results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: offset
+        in: query
+        description: Number of results to skip for pagination
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApplicationDTO"
+              example:
+              - id: "12345"
+                name: "My API Client"
+                description: "Client application for the Payment API"
+              - id: "67890"
+                name: "Test Client"
+                description: "Testing application"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/{applicationId}/provider/grantTypes:
+    get:
+      tags:
+      - Request Access
+      summary: Get grant types by application
+      description: Returns the available OAuth grant types for an application's provider.
+      operationId: getGrantTypesByApplicationId
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/GrantTypeResponseDTO"
+              example:
+                grantTypes:
+                - name: "client_credentials"
+                  label: "Client Credentials"
+                  required: false
+                  depends: []
+                  exclude: []
+                - name: "authorization_code"
+                  label: "Authorization Code"
+                  required: false
+                  depends: []
+                  exclude: []
+                type:
+                  name: "openid_connect"
+                  description: "OpenID Connect Provider"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/{applicationId}/contracts:
+    get:
+      tags:
+      - Request Access
+      summary: List contracts for application
+      description: Returns all contracts associated with a specific application.
+      operationId: getContractsByApplicationId
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: applicationId
+        in: path
+        description: Unique identifier of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: limit
+        in: query
+        description: Maximum number of results to return
+        required: false
+        schema:
+          maximum: 250
+          type: integer
+          format: int32
+          default: 100
+      - name: offset
+        in: query
+        description: Number of results to skip for pagination
+        required: false
+        schema:
+          minimum: 0
+          type: integer
+          format: int32
+          default: 0
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApplicationContractResponseDTO"
+              example:
+              - contractId: 67890
+                assetId: "payment-api"
+                assetName: "Payment API"
+                groupId: "com.example"
+                instanceId: "22222222-2222-2222-2222-222222222222"
+                instanceName: "Production"
+                environmentId: "99999999-9999-9999-9999-999999999999"
+                environmentName: "Production"
+                minorVersion: "v1"
+                status: "APPROVED"
+  /xapi/v1/portals/{targetOrganizationId}/{portalId}/applications/exists:
+    get:
+      tags:
+      - Application Management
+      summary: Check application name availability
+      description: Checks whether a given application name is already in use.
+      operationId: checkExistenceApplicationName
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetOrganizationId
+        in: path
+        description: Anypoint Platform organization ID that owns the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: appName
+        in: query
+        description: Application name to check for availability
+        required: true
+        schema:
+          maxLength: 151
+          minLength: 0
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApplicationExistsDTO"
+              example:
+                exists: true
+components:
+  schemas:
+    ErrorDetail:
+      type: object
+      required:
+      - message
+      properties:
+        message:
+          type: string
+          description: Detailed error message
+        code:
+          type: string
+          description: Machine-readable error code
+        arguments:
+          type: array
+          description: Additional context for the error
+          items:
+            type: object
+    ErrorResponseDTO:
+      type: object
+      required:
+      - name
+      - status
+      - message
+      properties:
+        name:
+          type: string
+          description: Error name
+        status:
+          type: integer
+          description: HTTP status code
+          format: int32
+        message:
+          type: string
+          description: Human-readable error message
+        details:
+          type: array
+          description: List of error details
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+    ApplicationUpsertDTO:
+      required:
+      - name
+      type: object
+      properties:
+        apiEndpoints:
+          type: boolean
+          description: Whether to use API endpoint URIs as redirect URIs
+        description:
+          maxLength: 4096
+          minLength: 0
+          type: string
+          description: Application description
+        grantTypes:
+          type: array
+          description: OAuth grant types for the application
+          example:
+          - client_credentials
+          items:
+            type: string
+            description: OAuth grant types for the application
+            example: "[\"client_credentials\"]"
+        name:
+          maxLength: 151
+          minLength: 0
+          type: string
+          description: Application name
+          example: My API Client
+        redirectUri:
+          type: array
+          description: OAuth redirect URIs for the application
+          items:
+            type: string
+            description: OAuth redirect URIs for the application
+        url:
+          type: string
+          description: Application URL
+          format: uri
+      description: Application creation or update request
+    ApiManagerApplicationDTO:
+      required:
+      - clientId
+      - id
+      - name
+      type: object
+      properties:
+        clientId:
+          type: string
+          description: OAuth client ID for the application
+          format: uuid
+        clientProvider:
+          $ref: "#/components/schemas/ApiManagerClientProviderDTO"
+        clientSecret:
+          type: string
+          description: OAuth client secret for the application
+        description:
+          type: string
+          description: Human-readable description of the application
+        grantTypes:
+          type: array
+          description: OAuth grant types enabled for the application
+          items:
+            type: string
+            description: OAuth grant types enabled for the application
+        id:
+          type: string
+          description: Unique application identifier
+        lastUpdateDate:
+          type: string
+          description: Timestamp of the last update to the application
+          format: date-time
+        name:
+          type: string
+          description: Application name
+        redirectUri:
+          type: array
+          description: OAuth redirect URIs registered for the application
+          items:
+            type: string
+            description: OAuth redirect URIs registered for the application
+        url:
+          type: string
+          description: Application URL
+          format: uri
+    ApiManagerClientProviderDTO:
+      type: object
+      required:
+      - providerId
+      properties:
+        name:
+          type: string
+          description: Client provider name
+        providerId:
+          type: string
+          description: Unique identifier of the client provider
+          format: uuid
+        type:
+          type: string
+          description: Client provider type
+      description: Client identity provider associated with this application
+    SelectedShapeDTO:
+      required:
+      - selectedShapeType
+      type: object
+      properties:
+        selectedShape:
+          type: string
+          description: Name or identifier of the selected API shape
+        selectedShapeType:
+          type: string
+          description: Type of the selected shape
+          enum:
+          - SUMMARY
+          - TYPE
+          - ENDPOINT
+          - OPERATION
+          - DOCUMENTATION
+          - SECURITY
+          - METHOD
+    ConsumerAssetsSearchRequest:
+      type: object
+      properties:
+        assetTypes:
+          type: array
+          description: Filter by asset types
+          example:
+          - rest-api
+          - http-api
+          items:
+            type: string
+            description: Filter by asset types
+            example: "[\"rest-api\",\"http-api\"]"
+        categories:
+          type: array
+          description: Filter by categories in key:value format
+          example:
+          - Department:Finance
+          items:
+            type: string
+            description: Filter by categories in key:value format
+            example: "[\"Department:Finance\"]"
+        searchTerm:
+          type: string
+          description: Text to search for in asset names and descriptions
+        sort:
+          $ref: "#/components/schemas/SearchSort"
+      description: Search criteria for portal assets
+    SearchSort:
+      type: object
+      required:
+      - criteria
+      - direction
+      properties:
+        direction:
+          type: string
+          description: Sort direction
+          enum:
+          - ASC
+          - DESC
+        criteria:
+          type: string
+          description: Sort criteria field
+          enum:
+          - LAST_UPDATED
+          - NAME
+          - CREATED_AT
+      description: Sort configuration for search results
+    ConsumerAssetSearchResult:
+      required:
+      - assets
+      type: object
+      properties:
+        assets:
+          type: array
+          description: List of assets matching the search criteria
+          items:
+            $ref: "#/components/schemas/ConsumerCommunityAsset"
+        facets:
+          type: array
+          description: Available facets for filtering search results
+          items:
+            type: string
+            description: Available facets for filtering search results
+    ConsumerCommunityAsset:
+      required:
+      - assetId
+      - groupId
+      - name
+      - type
+      type: object
+      properties:
+        major:
+          type: integer
+          description: Major version number
+          format: int32
+        minor:
+          type: integer
+          description: Minor version number
+          format: int32
+        mayorComponent:
+          type: integer
+          description: "Major version component (legacy field name)"
+          format: int32
+        minorComponent:
+          type: integer
+          description: Minor version component
+          format: int32
+        minorVersionComponents:
+          type: array
+          description: List of minor version component strings
+          items:
+            type: string
+        assetId:
+          type: string
+          description: Asset identifier within the organization
+        description:
+          type: string
+          description: Human-readable description of the asset
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        icon:
+          type: string
+          description: URL or encoded content of the asset icon
+          format: uri
+        tags:
+          uniqueItems: true
+          type: array
+          description: Tags associated with the asset
+          items:
+            type: string
+            description: Tags associated with the asset
+        categories:
+          uniqueItems: true
+          type: array
+          description: Categories assigned to the asset in key:value format
+          items:
+            type: string
+            description: Categories assigned to the asset in key:value format
+        latestPatchVersion:
+          type: string
+          description: Latest patch version string
+          example: "1.0.1"
+        minorVersion:
+          type: string
+          description: Current minor version
+          example: "v1"
+          pattern: ^v?\d+$
+        minorVersions:
+          type: array
+          description: All available minor versions for this asset
+          items:
+            type: string
+            description: All available minor versions for this asset
+        name:
+          type: string
+          description: Display name of the asset
+        type:
+          type: string
+          description: Asset type classifier
+          example: rest-api
+        updatedDate:
+          type: string
+          description: Timestamp of the last update to the asset
+          format: date-time
+      description: List of assets matching the search criteria
+    ApplicationCreateDTO:
+      required:
+      - instanceId
+      - name
+      type: object
+      properties:
+        apiEndpoints:
+          type: boolean
+          description: Whether to use API endpoint URIs as redirect URIs
+        description:
+          maxLength: 4096
+          minLength: 0
+          type: string
+          description: Application description
+        grantTypes:
+          type: array
+          description: OAuth grant types for the application
+          example:
+          - client_credentials
+          items:
+            type: string
+            description: OAuth grant types for the application
+            example: "[\"client_credentials\"]"
+        name:
+          maxLength: 151
+          minLength: 0
+          type: string
+          description: Application name
+          example: My API Client
+        redirectUri:
+          type: array
+          description: OAuth redirect URIs for the application
+          items:
+            type: string
+            description: OAuth redirect URIs for the application
+        url:
+          type: string
+          description: Application URL
+          format: uri
+        instanceId:
+          type: string
+          description: API instance ID to associate the application with
+          format: uuid
+      description: Request body for creating a new client application
+    ApplicationCreatedResponseDTO:
+      required:
+      - id
+      - name
+      type: object
+      properties:
+        clientId:
+          type: string
+          description: OAuth client ID assigned to the application
+          format: uuid
+        clientSecret:
+          type: string
+          description: OAuth client secret assigned to the application
+        description:
+          type: string
+          description: Application description
+        id:
+          type: string
+          description: Unique application identifier
+        name:
+          type: string
+          description: Application name
+    ContractCreateDTO:
+      required:
+      - acceptedTerms
+      - applicationId
+      - instanceId
+      type: object
+      properties:
+        acceptedTerms:
+          type: boolean
+          description: Whether the user has accepted the API terms and conditions
+        applicationId:
+          type: string
+          description: ID of the application requesting access
+          format: uuid
+        instanceId:
+          type: string
+          description: ID of the API instance to create a contract with
+          format: uuid
+        tierId:
+          type: integer
+          description: ID of the SLA tier to request
+          format: int32
+          nullable: true
+      description: Request body for creating an API access contract
+    ContractCreatedResponseDTO:
+      type: object
+      required:
+      - id
+      - status
+      properties:
+        clientId:
+          type: string
+          description: OAuth client ID of the application
+          format: uuid
+        clientSecret:
+          type: string
+          description: OAuth client secret of the application
+        id:
+          type: string
+          description: Unique contract identifier
+        requestedTier:
+          $ref: "#/components/schemas/TierDTO"
+        status:
+          type: string
+          description: Contract status
+          example: APPROVED
+    TierDTO:
+      type: object
+      required:
+      - id
+      - name
+      - status
+      properties:
+        active:
+          type: boolean
+          description: Whether the tier is currently active (derived from status == ACTIVE)
+        autoApprove:
+          type: boolean
+          description: Whether contracts with this tier are automatically approved
+        description:
+          type: string
+          description: Human-readable description of the tier
+        id:
+          type: string
+          description: Unique tier identifier
+        limits:
+          type: array
+          description: Rate limit definitions for this tier
+          items:
+            $ref: "#/components/schemas/TierLimitDTO"
+        name:
+          type: string
+          description: Tier name
+          example: Gold
+        status:
+          type: string
+          description: Tier status
+          example: ACTIVE
+      description: SLA tier defining rate limits for API access
+    TierLimitDTO:
+      type: object
+      required:
+      - maximumRequests
+      - timePeriod
+      - timeUnit
+      properties:
+        maximumRequests:
+          type: string
+          description: Maximum number of requests allowed in the time period
+          example: "100"
+        visible:
+          type: boolean
+          description: Whether this limit is visible to API consumers
+        timePeriodInMilliseconds:
+          type: integer
+          description: Duration of the rate limit window in milliseconds
+          format: int64
+        timePeriod:
+          type: integer
+          description: Duration of the rate limit window in the specified time unit
+          format: int64
+        timeUnit:
+          type: string
+          description: Time unit for the rate limit period
+          example: Hours
+      description: Rate limit definitions for this tier
+    ApiManagerSecretResetResponseDTO:
+      required:
+      - clientSecret
+      type: object
+      properties:
+        clientSecret:
+          type: string
+          description: Newly generated client secret
+    ContractDTO:
+      type: object
+      required:
+      - id
+      - applicationId
+      - status
+      properties:
+        applicationId:
+          type: string
+          description: ID of the application holding the contract
+          format: uuid
+        id:
+          type: string
+          description: Unique contract identifier
+        instanceId:
+          type: string
+          description: API instance ID the contract is associated with
+          format: uuid
+        requestedTier:
+          $ref: "#/components/schemas/TierDTO"
+        status:
+          type: string
+          description: Contract status
+          example: APPROVED
+    AssetCategoryDTO:
+      type: object
+      required:
+      - key
+      - displayName
+      properties:
+        displayName:
+          type: string
+          description: Human-readable category name
+        key:
+          type: string
+          description: Unique category key
+        values:
+          type: array
+          description: List of values for this category
+          items:
+            type: string
+            description: List of values for this category
+      description: Categories assigned to the asset
+    AssetDetailDTO:
+      required:
+      - assetId
+      - groupId
+      - name
+      type: object
+      properties:
+        tags:
+          type: array
+          description: Tags associated with the asset
+          items:
+            type: string
+            description: Tags associated with the asset
+        major:
+          type: integer
+          description: Major version number
+          format: int32
+        minor:
+          type: integer
+          description: Minor version number
+          format: int32
+        mayorComponent:
+          type: integer
+          description: "Major version component (legacy field name)"
+          format: int32
+        minorComponent:
+          type: integer
+          description: Minor version component
+          format: int32
+        minorVersionComponents:
+          type: array
+          description: List of minor version component strings
+          items:
+            type: string
+        apiVersion:
+          type: string
+          description: API version identifier
+        assetId:
+          type: string
+          description: Asset identifier within the organization
+        categories:
+          type: array
+          description: Categories assigned to the asset
+          items:
+            $ref: "#/components/schemas/AssetCategoryDTO"
+        customFields:
+          type: array
+          description: Custom fields defined for the asset
+          items:
+            $ref: "#/components/schemas/GraphQLCustomFieldDTO"
+        description:
+          type: string
+          description: Human-readable description of the asset
+        files:
+          type: array
+          description: Downloadable files attached to this asset version
+          items:
+            $ref: "#/components/schemas/AssetFileDTO"
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        icon:
+          type: string
+          description: URL or encoded content of the asset icon
+          format: uri
+        instances:
+          type: array
+          description: API instances deployed for this asset version
+          items:
+            $ref: "#/components/schemas/AssetInstanceDTO"
+        labels:
+          type: array
+          description: Labels attached to the asset
+          items:
+            type: string
+            description: Labels attached to the asset
+        latestPatchVersion:
+          type: string
+          description: Latest patch version string
+          example: "1.0.1"
+        lifeCycleState:
+          type: string
+          description: Current lifecycle state of the asset
+        minorVersion:
+          type: string
+          description: Current minor version
+          example: "v1"
+          pattern: ^v?\d+$
+        minorVersions:
+          uniqueItems: true
+          type: array
+          description: All available minor versions for this asset
+          items:
+            type: string
+            description: All available minor versions for this asset
+        name:
+          type: string
+          description: Display name of the asset
+        organizationId:
+          type: string
+          description: Anypoint Platform organization ID
+          format: uuid
+        owner:
+          $ref: "#/components/schemas/AssetOwnerDTO"
+        pages:
+          type: array
+          description: Documentation pages for this asset version
+          items:
+            $ref: "#/components/schemas/AssetPageDTO"
+        type:
+          type: string
+          description: Asset type classifier
+          example: rest-api
+        updatedDate:
+          type: string
+          description: Timestamp of the last update to the asset
+          format: date-time
+        versionGroup:
+          type: string
+          description: Version group identifier for the asset
+    AssetFileDTO:
+      type: object
+      required:
+      - label
+      properties:
+        externalLink:
+          type: string
+          description: URL to the external file resource
+          format: uri
+        isGenerated:
+          type: boolean
+          description: Whether the file was auto-generated
+        label:
+          type: string
+          description: Display label for the file
+      description: Downloadable files attached to this asset version
+    AssetInstanceDTO:
+      type: object
+      required:
+      - id
+      - name
+      - minorVersion
+      properties:
+        contractsCount:
+          type: integer
+          description: Number of active contracts for this instance
+          format: int32
+        endpointUri:
+          type: string
+          description: API endpoint URL
+          format: uri
+        environmentId:
+          type: string
+          description: Anypoint environment ID
+          format: uuid
+        environmentName:
+          type: string
+          description: Anypoint environment name
+        id:
+          type: string
+          description: Unique instance identifier
+        isPublic:
+          type: boolean
+          description: Whether the instance is publicly accessible
+        minorVersion:
+          type: string
+          description: Minor version of the API instance
+          pattern: ^v?\d+$
+        name:
+          type: string
+          description: Instance name
+        providerId:
+          type: string
+          description: Client provider ID
+          format: uuid
+        type:
+          type: string
+          description: Instance type
+      description: API instances deployed for this asset version
+    AssetOwnerDTO:
+      type: object
+      required:
+      - contactEmail
+      properties:
+        contactEmail:
+          type: string
+          description: Owner's contact email address
+          format: email
+        contactName:
+          type: string
+          description: Owner's contact name
+      description: Owner contact information for the asset
+    AssetPageDTO:
+      type: object
+      required:
+      - name
+      - path
+      properties:
+        name:
+          type: string
+          description: Page name
+        path:
+          type: string
+          description: URL path to the documentation page
+      description: Documentation pages for this asset version
+    GraphQLCustomFieldDTO:
+      type: object
+      required:
+      - key
+      - dataType
+      properties:
+        dataType:
+          type: string
+          description: Data type of the custom field
+        dateValue:
+          type: string
+          description: Date value when data type is date
+        displayName:
+          type: string
+          description: Human-readable display name
+        enumValue:
+          type: array
+          description: Enum values when data type is enum
+          items:
+            type: string
+            description: Enum values when data type is enum
+        key:
+          type: string
+          description: Unique custom field key
+        numberValue:
+          type: integer
+          description: Numeric value when data type is number
+          format: int32
+        numericListValue:
+          type: array
+          description: List of numeric values
+          items:
+            type: string
+            description: List of numeric values
+        textListValue:
+          type: array
+          description: List of text values
+          items:
+            type: string
+            description: List of text values
+        textValue:
+          type: string
+          description: Text value when data type is text
+      description: Custom fields defined for the asset
+    GrantTypeDTO:
+      type: object
+      required:
+      - name
+      properties:
+        depends:
+          type: array
+          description: Grant types that this grant type depends on
+          items:
+            type: string
+            description: Grant types that this grant type depends on
+        exclude:
+          type: array
+          description: Grant types that are mutually exclusive with this one
+          items:
+            type: string
+            description: Grant types that are mutually exclusive with this one
+        label:
+          type: string
+          description: Human-readable label for the grant type
+        name:
+          type: string
+          description: Grant type name identifier
+          example: client_credentials
+        required:
+          type: boolean
+          description: Whether this grant type is mandatory
+      description: Available OAuth grant types for the provider
+    GrantTypeResponseDTO:
+      type: object
+      required:
+      - type
+      - grantTypes
+      properties:
+        grantTypes:
+          type: array
+          description: Available OAuth grant types for the provider
+          items:
+            $ref: "#/components/schemas/GrantTypeDTO"
+        type:
+          $ref: "#/components/schemas/ProviderDTO"
+    ProviderDTO:
+      type: object
+      required:
+      - name
+      properties:
+        description:
+          type: string
+          description: Human-readable description of the provider type
+        name:
+          type: string
+          description: Provider type name identifier
+      description: Identity provider type information
+    ApplicationDTO:
+      required:
+      - id
+      - name
+      type: object
+      properties:
+        description:
+          type: string
+          description: Application description
+        id:
+          type: string
+          description: Unique application identifier
+        name:
+          type: string
+          description: Application name
+    ApplicationContractResponseDTO:
+      required:
+      - assetId
+      - contractId
+      - instanceId
+      type: object
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier
+        assetName:
+          type: string
+          description: Display name of the API asset
+        contractId:
+          type: integer
+          description: Unique contract identifier
+          format: int32
+        environmentId:
+          type: string
+          description: Environment ID where the API instance is deployed
+          format: uuid
+        environmentName:
+          type: string
+          description: Environment name where the API instance is deployed
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        instanceId:
+          type: string
+          description: API instance identifier
+          format: uuid
+        instanceName:
+          type: string
+          description: API instance name
+        minorVersion:
+          type: string
+          description: Minor version of the contracted API
+          example: "v1"
+          pattern: ^v?\d+$
+        requestedTier:
+          $ref: "#/components/schemas/TierDTO"
+        status:
+          type: string
+          description: Contract status
+          example: APPROVED
+        tier:
+          $ref: "#/components/schemas/TierDTO"
+    ApplicationExistsDTO:
+      required:
+      - exists
+      type: object
+      properties:
+        exists:
+          type: boolean
+          description: Whether an application with the given name already exists
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: Anypoint Platform bearer token obtained from Access Management
+      scheme: bearer

--- a/apis/api-experience-hub-consumer/api.yaml
+++ b/apis/api-experience-hub-consumer/api.yaml
@@ -1,7 +1,28 @@
 openapi: 3.0.1
 info:
   title: API Experience Hub Consumer API
-  description: API Experience Hub API
+  description: |
+    Discover APIs and request access from a published API Experience Hub portal.
+
+    Use this API to act on behalf of an authenticated portal consumer (developer) browsing a
+    Salesforce-hosted developer portal that exposes assets from Anypoint Exchange. The
+    consumer surface covers three jobs:
+
+    - **Asset discovery** — list, search and inspect API assets published in the portal,
+      including documentation pages, terms and conditions, and downloadable resources.
+    - **Application management** — create, update and delete client applications, manage
+      OAuth credentials and rotate client secrets.
+    - **Request access** — request an API contract for an application, choose an SLA tier,
+      and inspect available grant types and instances for an asset.
+
+    Every path is scoped by `targetOrganizationId` (the external organization id tied to
+    the connection — for SALESFORCE connections this is the Salesforce organization id,
+    obtained from `GET /connections` on the Management API) and a portal id
+    (`portalId` / `targetPortalId`). The portal id and connection are managed through the
+    companion API Experience Hub Management API.
+
+    Authentication is via bearer token. Endpoints return Anypoint-style JSON error bodies
+    on 4xx; responses are paginated where applicable using `limit` and `offset`.
   version: 1.0.0
 servers:
 - url: https://anypoint.mulesoft.com/api-experience-hub
@@ -37,13 +58,24 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections).
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -51,6 +83,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       responses:
         "400":
           description: Bad Request
@@ -100,13 +138,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -114,6 +164,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       requestBody:
         description: "Application update request with new name, description or OAuth settings"
         content:
@@ -179,13 +235,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -193,6 +261,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       responses:
         "400":
           description: Bad Request
@@ -228,32 +302,59 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: targetPortalId
         in: path
         description: Unique identifier of the portal
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       requestBody:
         description: Shape selection for the API console model
         content:
@@ -298,14 +399,25 @@ paths:
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: x-limit
         in: header
         description: Maximum number of search results to return
@@ -382,18 +494,34 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -401,13 +529,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       requestBody:
         description: "Application creation request with name, instance ID and optional OAuth settings"
         content:
@@ -465,18 +605,34 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -484,13 +640,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       requestBody:
         description: "Contract creation request with application ID, instance ID and accepted terms"
         content:
@@ -555,13 +723,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -569,6 +749,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       responses:
         "400":
           description: Bad Request
@@ -605,13 +791,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -619,6 +817,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       - name: contractId
         in: path
         description: Unique identifier of the contract
@@ -626,6 +830,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getContractsByApplicationId
+          values: $[*].contractId
+          labels: $[*].assetName
+          description: Contract belonging to the selected application
       - name: tierId
         in: path
         description: ID of the SLA tier to assign
@@ -633,6 +843,12 @@ paths:
         schema:
           type: integer
           format: int32
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getTiers
+          values: $[*].id
+          labels: $[*].name
+          description: SLA tier available on the API instance
       responses:
         "400":
           description: Bad Request
@@ -679,14 +895,25 @@ paths:
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: limit
         in: query
         description: Maximum number of assets to return (max 250)
@@ -753,32 +980,59 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: targetPortalId
         in: path
         description: Unique identifier of the portal
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       responses:
         "400":
           description: Bad Request
@@ -814,32 +1068,59 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: targetPortalId
         in: path
         description: Unique identifier of the portal
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: resourceId
         in: path
         description: Unique identifier of the asset resource file
@@ -847,6 +1128,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.files[*].externalLink
+          labels: $.files[*].label
+          description: Resource file attached to the asset's documentation
       responses:
         "400":
           description: Bad Request
@@ -883,32 +1170,59 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: targetPortalId
         in: path
         description: Unique identifier of the portal
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       responses:
         "400":
           description: Bad Request
@@ -944,32 +1258,59 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: targetPortalId
         in: path
         description: Unique identifier of the portal
         required: true
         schema:
           type: string
-          format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       responses:
         "400":
           description: Bad Request
@@ -1042,18 +1383,34 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -1061,13 +1418,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: instanceId
         in: path
         description: Unique identifier of the API instance
@@ -1075,6 +1444,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.instances[*].id
+          labels: $.instances[*].name
+          description: API instance defined for the selected asset
       responses:
         "400":
           description: Bad Request
@@ -1131,18 +1506,34 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -1150,13 +1541,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: instanceId
         in: path
         description: Unique identifier of the API instance
@@ -1164,6 +1567,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.instances[*].id
+          labels: $.instances[*].name
+          description: API instance defined for the selected asset
       responses:
         "400":
           description: Bad Request
@@ -1213,18 +1622,34 @@ paths:
         schema:
           type: string
           pattern: ^v?\d+$
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.minorVersion
+          description: Minor version published for the selected asset
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].assetId
+          labels: $[*].name
+          description: Exchange asset published in the portal
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: listAssetsCommunityAsset
+          values: $[*].groupId
+          description: Exchange group identifier for the selected asset
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -1232,13 +1657,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -1246,6 +1683,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       - name: instanceId
         in: path
         description: Unique identifier of the API instance
@@ -1253,6 +1696,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getAssetDetails
+          values: $.instances[*].id
+          labels: $.instances[*].name
+          description: API instance defined for the selected asset
       responses:
         "400":
           description: Bad Request
@@ -1300,13 +1749,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: instanceId
         in: query
         description: Filter applications by API instance ID
@@ -1379,13 +1840,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -1393,6 +1866,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       responses:
         "400":
           description: Bad Request
@@ -1442,13 +1921,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: applicationId
         in: path
         description: Unique identifier of the application
@@ -1456,6 +1947,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-consumer
+          operation: getApplications
+          values: $[*].id
+          labels: $[*].name
+          description: Application owned by the caller within the selected portal
       - name: limit
         in: query
         description: Maximum number of results to return
@@ -1521,13 +2018,25 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal identifier from the management API's portal list for the active connection
       - name: targetOrganizationId
         in: path
-        description: Anypoint Platform organization ID that owns the portal
+        description: External organization ID tied to the connection (e.g. Salesforce organization ID for SALESFORCE connections). Obtained from the connection record, not from Anypoint access-management.
         required: true
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].targetOrganizationId
+          labels: $[*].targetOrganizationDomain
+          description: External organization identifier for the connection (e.g. Salesforce org ID)
       - name: appName
         in: query
         description: Application name to check for availability

--- a/apis/api-experience-hub-consumer/exchange.json
+++ b/apis/api-experience-hub-consumer/exchange.json
@@ -1,0 +1,12 @@
+{
+  "main": "api.yaml",
+  "name": "API Experience Hub Consumer API",
+  "classifier": "oas",
+  "tags": [],
+  "groupId": "f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform",
+  "assetId": "api-experience-hub-consumer",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "originalFormatVersion": "3.0",
+  "organizationId": "8bfc8bbf-5508-419e-aadc-77dfe18a8172"
+}

--- a/apis/api-experience-hub-management/api.yaml
+++ b/apis/api-experience-hub-management/api.yaml
@@ -1,0 +1,2165 @@
+openapi: 3.0.1
+info:
+  title: API Experience Hub Management API
+  description: API Experience Hub API
+  version: 1.0.0
+servers:
+- url: https://anypoint.mulesoft.com/api-experience-hub
+  description: US
+- url: https://eu1.anypoint.mulesoft.com/api-experience-hub
+  description: EU
+- url: https://ca1.platform.mulesoft.com/api-experience-hub
+  description: CA
+- url: https://jp1.platform.mulesoft.com/api-experience-hub
+  description: JP
+security:
+- bearerAuth: []
+tags:
+- name: User Management
+  description: "Manage portal users, prospects, registration and identity providers"
+- name: Asset Curation
+  description: "Add, remove and configure API assets in your portal"
+- name: User Groups
+  description: "Manage user groups, profiles and group mappings"
+- name: Connections
+  description: "Manage Salesforce connections for API Experience Hub"
+- name: Portals
+  description: "Manage API portals"
+paths:
+  /api/v1/connections/{connectionId}/apiPortals:
+    get:
+      tags:
+      - Portals
+      summary: List portals for connection
+      description: Returns all portals associated with a specific connection.
+      operationId: getAllApiPortalByConnectionId
+      parameters:
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PortalDTO"
+              example:
+              - id: "550e8400-e29b-41d4-a716-446655440000"
+                connectionId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                name: "Developer Portal"
+                targetPortalId: "77777777-7777-7777-7777-777777777777"
+                internalPortalId: "770e8400-e29b-41d4-a716-446655440002"
+                builderUrl: "https://example.my.site.com/builder"
+                siteUrl: "https://example.my.site.com"
+                createdDate: "2024-01-10T08:00:00Z"
+                updatedDate: "2024-06-15T14:30:00Z"
+                finishedAtLeastOnce: true
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/users/{targetUserId}/userGroups:
+    put:
+      tags:
+      - User Management
+      summary: Assign user groups to user
+      description: Applies the specified user group memberships to a portal user.
+      operationId: addGroupMappingToUser
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetUserId
+        in: path
+        description: Unique identifier of the target portal user
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: List of user group IDs to assign to the user (maximum 20)
+        content:
+          application/json:
+            schema:
+              maxItems: 20
+              minItems: 0
+              type: array
+              items:
+                type: string
+                format: uuid
+            example:
+            - "550e8400-e29b-41d4-a716-446655440000"
+            - "660e8400-e29b-41d4-a716-446655440001"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections:
+    get:
+      tags:
+      - Connections
+      summary: List connections
+      description: Returns all connections for the current organization.
+      operationId: getConnections
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConnectionDTO"
+              example:
+              - id: "conn-001"
+                organizationId: "88888888-8888-8888-8888-888888888888"
+                targetOrganizationId: "66666666-6666-6666-6666-666666666666"
+                targetOrganizationDomain: "example.my.salesforce.com"
+                type: "SALESFORCE"
+                environment: "PRODUCTION"
+                username: "admin@example.com"
+                createdDate: "2024-01-10T08:00:00Z"
+                updatedDate: "2024-06-15T14:30:00Z"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/userGroups:
+    get:
+      tags:
+      - User Groups
+      summary: List profiles and user groups
+      description: Returns all profiles and user groups for a portal.
+      operationId: getAllProfilesByPortal
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProfileDTO"
+              example:
+              - id: "550e8400-e29b-41d4-a716-446655440000"
+                name: "Everyone"
+                description: "Default user group for all portal users"
+                isAdmin: false
+                isAutoGenerated: true
+                isDefault: true
+                isPublic: true
+                createdDate: "2024-01-10T08:00:00Z"
+                children:
+                - id: "660e8400-e29b-41d4-a716-446655440001"
+                  name: "API Developers"
+                  description: "Users who can create applications"
+                  isAdmin: false
+                  isAutoGenerated: false
+                  isDefault: false
+                  isPublic: false
+                  createdDate: "2024-02-15T12:00:00Z"
+                  children: []
+    post:
+      tags:
+      - User Groups
+      summary: Create a user group
+      description: Creates a new user group within the portal.
+      operationId: createUserGroup
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: User group creation request with name and optional description
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserGroupRequestDTO"
+            example:
+              name: "API Developers"
+              description: "Users who can create applications"
+              parentUserGroupId: "550e8400-e29b-41d4-a716-446655440000"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "415":
+          description: Unsupported Media Type
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/userGroups/{userGroupId}/groupMappings:
+    get:
+      tags:
+      - User Groups
+      summary: List group mappings
+      description: Returns all team group mappings for a specific user group.
+      operationId: getGroupMappings
+      parameters:
+      - name: userGroupId
+        in: path
+        description: Unique identifier of the user group
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TeamGroupMapping"
+              example:
+              - external_group_name: "API Developers"
+                membership_type: "member"
+                provider_id: "idp-001"
+    post:
+      tags:
+      - User Groups
+      summary: Add group mapping
+      description: Adds an identity provider group mapping to a user group.
+      operationId: addAdditionalGroupMapping
+      parameters:
+      - name: userGroupId
+        in: path
+        description: Unique identifier of the user group
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "Group mapping to add, with identity provider ID and group name"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserGroupAddGroupMappingDTO"
+            example:
+              groupMappingName: "API Developers"
+              idpId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets:
+    post:
+      tags:
+      - Asset Curation
+      summary: Publish assets to portal
+      description: Adds one or more Exchange assets to the portal for consumer discovery.
+      operationId: addAssetsToCommunity
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "List of assets to publish, identified by group ID and asset ID"
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/CommunityAssetGaCreateDTO"
+            example:
+            - assetId: "payment-api"
+              groupId: "com.example"
+            - assetId: "order-api"
+              groupId: "com.example"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CommunityAssetGaCreateDTO"
+              example:
+              - assetId: "payment-api"
+                groupId: "com.example"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets/search:
+    post:
+      tags:
+      - Asset Curation
+      summary: Search published assets
+      description: Searches assets currently published in the portal.
+      operationId: searchCommunityAssets
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: x-limit
+        in: header
+        description: Maximum number of search results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: x-from
+        in: header
+        description: Offset for paginated search results
+        required: false
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        description: Search criteria for published portal assets
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityAssetsSearchRequest"
+            example:
+              searchTerm: "payment"
+              userGroupId: "dddddddd-dddd-dddd-dddd-dddddddddddd"
+              categories:
+              - "Department:Finance"
+              tags:
+              - payments
+              sort:
+                direction: DESC
+                criteria: LAST_UPDATED
+              showInherited: true
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CommunityAssetsSearchResult"
+              example:
+                assets:
+                - assetId: "payment-api"
+                  groupId: "com.example"
+                  name: "Payment API"
+                  description: "API for processing payments"
+                  type: "rest-api"
+                  businessGroupId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                  businessGroupName: "Finance"
+                  createdById: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                  lastUpdated: "2024-06-15T14:30:00Z"
+                  addedOn: "2024-01-10T08:00:00Z"
+                  categories:
+                  - "Department:Finance"
+                  tags:
+                  - payments
+                facets:
+                  categories:
+                  - "Department:Finance"
+                  tags:
+                  - payments
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets/search/exchange:
+    post:
+      tags:
+      - Asset Curation
+      summary: Search Exchange assets
+      description: Searches Anypoint Exchange for assets available to publish.
+      operationId: searchExchangeAssets
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: x-limit
+        in: header
+        description: Maximum number of search results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: x-from
+        in: header
+        description: Offset for paginated search results
+        required: false
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        description: Search criteria for Anypoint Exchange assets
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExchangeSearchRequest"
+            example:
+              searchTerm: "order"
+              categories:
+              - "Department:Commerce"
+              tags:
+              - orders
+              sort:
+                direction: DESC
+                criteria: LAST_UPDATED
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ExchangeAssetsSearchResult"
+              example:
+                assets:
+                - assetId: "order-api"
+                  groupId: "com.example"
+                  name: "Order API"
+                  description: "API for managing orders"
+                  type: "rest-api"
+                  businessGroupId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                  businessGroupName: "Commerce"
+                  createdById: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                  createdByName: "John Doe"
+                  createdAt: "2024-01-10T08:00:00Z"
+                  lastUpdated: "2024-06-15T14:30:00Z"
+                  latestVersion: "1.2.3"
+                  categories:
+                  - "Department:Commerce"
+                  tags:
+                  - orders
+                facets:
+                  categories:
+                  - "Department:Commerce"
+                  tags:
+                  - orders
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets/remove:
+    post:
+      tags:
+      - Asset Curation
+      summary: Remove assets from portal
+      description: Removes one or more assets from the portal.
+      operationId: removeAssetFromCommunity
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: "List of assets to remove, identified by group ID and asset ID"
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/CommunityAssetGaRemoveDTO"
+            example:
+            - assetId: "payment-api"
+              groupId: "com.example"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets/exchange/search:
+    post:
+      tags:
+      - Asset Curation
+      summary: Search Exchange assets (legacy)
+      description: Legacy endpoint for searching Anypoint Exchange assets.
+      operationId: legacySearchExchangeAssets
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: x-limit
+        in: header
+        description: Maximum number of search results to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: x-from
+        in: header
+        description: Offset for paginated search results
+        required: false
+        schema:
+          type: integer
+          format: int32
+      requestBody:
+        description: Search criteria for Anypoint Exchange assets
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExchangeSearchRequest"
+            example:
+              searchTerm: "order"
+              categories:
+              - "Department:Commerce"
+              tags:
+              - orders
+              sort:
+                direction: DESC
+                criteria: LAST_UPDATED
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ExchangeAsset"
+              example:
+              - assetId: "order-api"
+                groupId: "com.example"
+                name: "Order API"
+                description: "API for managing orders"
+                type: "rest-api"
+                businessGroupId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                businessGroupName: "Commerce"
+                createdById: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                createdByName: "John Doe"
+                createdAt: "2024-01-10T08:00:00Z"
+                lastUpdated: "2024-06-15T14:30:00Z"
+                latestVersion: "1.2.3"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/users/{targetUserId}/enable:
+    patch:
+      tags:
+      - User Management
+      summary: Enable a user
+      description: Enables a previously disabled portal user account.
+      operationId: enableCommunityUser
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetUserId
+        in: path
+        description: Unique identifier of the target portal user
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/users/{targetUserId}/disable:
+    patch:
+      tags:
+      - User Management
+      summary: Disable a user
+      description: Disables a portal user account.
+      operationId: disableCommunityUser
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: targetUserId
+        in: path
+        description: Unique identifier of the target portal user
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/userGroups/{userGroupId}:
+    delete:
+      tags:
+      - User Groups
+      summary: Delete a user group
+      description: Permanently deletes a user group from the portal.
+      operationId: deleteUserGroup
+      parameters:
+      - name: userGroupId
+        in: path
+        description: Unique identifier of the user group
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+    patch:
+      tags:
+      - User Groups
+      summary: Update a user group
+      description: Updates the name and description of a user group.
+      operationId: updateUserGroup
+      parameters:
+      - name: userGroupId
+        in: path
+        description: Unique identifier of the user group
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: User group update request with new name or description
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserGroupRequestDTO"
+            example:
+              name: "API Developers (Updated)"
+              description: "Updated description for API developers group"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ProfileDTO"
+              example:
+                id: "660e8400-e29b-41d4-a716-446655440001"
+                name: "API Developers (Updated)"
+                description: "Updated description for API developers group"
+                isAdmin: false
+                isAutoGenerated: false
+                isDefault: false
+                isPublic: false
+                createdDate: "2024-02-15T12:00:00Z"
+                children: []
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/prospects/{prospectId}:
+    delete:
+      tags:
+      - User Management
+      summary: Reject a prospect
+      description: Deletes a pending prospect registration request.
+      operationId: rejectProspect
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: prospectId
+        in: path
+        description: Unique identifier of the prospect
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProspectDTO"
+              example: []
+    patch:
+      tags:
+      - User Management
+      summary: Approve a prospect
+      description: Approves a pending prospect and creates their user account.
+      operationId: approveProspect
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: prospectId
+        in: path
+        description: Unique identifier of the prospect
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        description: Prospect approval configuration with user group assignments
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProspectApproveDTO"
+            example:
+              userGroupIds:
+              - "550e8400-e29b-41d4-a716-446655440000"
+              - "660e8400-e29b-41d4-a716-446655440001"
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/assets/{groupId}/{assetId}:
+    get:
+      tags:
+      - Asset Curation
+      summary: Get asset version visibility
+      description: Returns visibility settings for all minor versions of an asset.
+      operationId: getAllVersionsVisibilityByGA
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ProducerAssetDetail"
+              example:
+                assetId: "payment-api"
+                groupId: "com.example"
+                name: "Payment API"
+                instanceVisibility: "All"
+                type: "rest-api"
+                minorVersionProfilesVisibility:
+                - minorVersion: "v1"
+                  profileVisibility:
+                  - "550e8400-e29b-41d4-a716-446655440000"
+    patch:
+      tags:
+      - Asset Curation
+      summary: Update asset visibility
+      description: Updates the visibility settings for an asset's minor versions and instances.
+      operationId: updateCommunityAsset
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: groupId
+        in: path
+        description: Exchange group ID of the asset
+        required: true
+        schema:
+          type: string
+      - name: assetId
+        in: path
+        description: Exchange asset ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Visibility settings to apply to the asset's minor versions and instances
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommunityAssetVersionUpdateDTO"
+            example:
+              instancesVisibility: "Custom"
+              minorVersions:
+              - minorVersion: "v1"
+                profileVisibility:
+                - "550e8400-e29b-41d4-a716-446655440000"
+                - "660e8400-e29b-41d4-a716-446655440001"
+              - minorVersion: "v2"
+                profileVisibility:
+                - "550e8400-e29b-41d4-a716-446655440000"
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/users:
+    get:
+      tags:
+      - User Management
+      summary: List users
+      description: Returns portal users with optional filtering by status and search term.
+      operationId: getCommunityUsers
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: searchTerm
+        in: query
+        description: Text to search for in user names and emails
+        required: false
+        schema:
+          maxLength: 128
+          minLength: 0
+          type: string
+      - name: isActive
+        in: query
+        description: Filter users by active status
+        required: false
+        schema:
+          type: boolean
+      - name: x-limit
+        in: header
+        description: Maximum number of users to return
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: x-offset
+        in: header
+        description: Number of results to skip for pagination
+        required: false
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CommunityUserDTO"
+              example:
+              - id: "user-001"
+                name: "Jane Developer"
+                email: "jane@example.com"
+                username: "jane.developer"
+                isActive: true
+                isExternal: false
+                anypointUsername: "jane.developer"
+                anypointIdpId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+                userGroupIds:
+                - "550e8400-e29b-41d4-a716-446655440000"
+                anypointGroups:
+                - "API Developers"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/users/{userId}:
+    get:
+      tags:
+      - User Management
+      summary: Get user details
+      description: Returns detailed information about a specific portal user.
+      operationId: getCommunityUser
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: userId
+        in: path
+        description: Unique identifier of the portal user
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CommunityUserDTO"
+              example:
+                id: "user-001"
+                name: "Jane Developer"
+                email: "jane@example.com"
+                username: "jane.developer"
+                isActive: true
+                isExternal: false
+                anypointUsername: "jane.developer"
+                anypointIdpId: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+                userGroupIds:
+                - "550e8400-e29b-41d4-a716-446655440000"
+                anypointGroups:
+                - "API Developers"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/prospects:
+    get:
+      tags:
+      - User Management
+      summary: List prospects
+      description: Returns all prospects with optional search filtering.
+      operationId: getProspects
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: searchTerm
+        in: query
+        description: Text to search for in prospect names and emails
+        required: false
+        schema:
+          maxLength: 128
+          minLength: 0
+          type: string
+          default: ""
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProspectDTO"
+              example:
+              - id: "880e8400-e29b-41d4-a716-446655440003"
+                firstName: "Bob"
+                lastName: "Builder"
+                email: "bob@example.com"
+                username: "bob.builder"
+                status: "PENDING"
+                portalId: "55555555-5555-5555-5555-555555555555"
+                createdDate: "2024-06-15T14:30:00Z"
+                updatedDate: "2024-06-15T14:30:00Z"
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/prospects/count:
+    get:
+      tags:
+      - User Management
+      summary: Get prospect count
+      description: Returns the count of pending prospects for the portal.
+      operationId: getProspectCount
+      parameters:
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ProspectCountDTO"
+              example:
+                count: 5
+  /api/v1/connections/{connectionId}/apiPortals/{portalId}/userGroups/{userGroupId}/groupMappings/{idpId}/{groupMappingName}:
+    delete:
+      tags:
+      - User Groups
+      summary: Delete group mapping
+      description: Removes an identity provider group mapping from a user group.
+      operationId: deleteGroupMappings
+      parameters:
+      - name: userGroupId
+        in: path
+        description: Unique identifier of the user group
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: portalId
+        in: path
+        description: Unique identifier of the portal
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: connectionId
+        in: path
+        description: Unique identifier of the Salesforce connection
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: idpId
+        in: path
+        description: Identity provider ID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: groupMappingName
+        in: path
+        description: Name of the group mapping to remove
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "401":
+          description: Unauthorized
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponseDTO"
+        "200":
+          description: OK
+components:
+  schemas:
+    ErrorDetail:
+      type: object
+      required:
+      - message
+      properties:
+        message:
+          type: string
+          description: Detailed error message
+        code:
+          type: string
+          description: Machine-readable error code
+        arguments:
+          type: array
+          description: Additional context for the error
+          items:
+            type: object
+    ErrorResponseDTO:
+      type: object
+      required:
+      - name
+      - status
+      - message
+      properties:
+        name:
+          type: string
+          description: Error name
+        status:
+          type: integer
+          description: HTTP status code
+          format: int32
+        message:
+          type: string
+          description: Human-readable error message
+        details:
+          type: array
+          description: List of error details
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+    ConnectionDTO:
+      type: object
+      required:
+      - id
+      - organizationId
+      - type
+      properties:
+        createdDate:
+          type: string
+          description: Date the connection was created
+          format: date-time
+        defaultIdPId:
+          type: string
+          description: Default identity provider ID for this connection
+        environment:
+          type: string
+          description: Target Salesforce environment type
+          enum:
+          - PRODUCTION
+          - SANDBOX
+        id:
+          type: string
+          description: Unique connection identifier
+        organizationId:
+          type: string
+          description: Anypoint Platform organization ID
+          format: uuid
+        sandboxName:
+          type: string
+          description: "Salesforce sandbox name, if applicable"
+        targetOrganizationDomain:
+          type: string
+          description: Salesforce organization domain URL
+        targetOrganizationId:
+          type: string
+          description: Target Salesforce organization ID
+          format: uuid
+        type:
+          type: string
+          description: Connection type
+          example: SALESFORCE
+        updatedDate:
+          type: string
+          description: Date the connection was last updated
+          format: date-time
+        username:
+          type: string
+          description: Username used for the Salesforce connection
+      description: Salesforce connection details
+    UserGroupRequestDTO:
+      type: object
+      required:
+      - name
+      properties:
+        description:
+          type: string
+          description: Human-readable description of the user group
+        name:
+          maxLength: 95
+          type: string
+          description: User group name
+        parentUserGroupId:
+          type: string
+          description: ID of the parent user group for nesting
+          format: uuid
+    UserGroupAddGroupMappingDTO:
+      required:
+      - groupMappingName
+      type: object
+      properties:
+        groupMappingName:
+          type: string
+          description: External group name to map to this user group
+        idpId:
+          type: string
+          description: Identity provider ID for the group mapping
+          format: uuid
+    CommunityAssetGaCreateDTO:
+      required:
+      - assetId
+      - groupId
+      type: object
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier to add to the portal
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+    CommunityAssetsSearchRequest:
+      type: object
+      properties:
+        searchTerm:
+          type: string
+          description: Text to search for in asset names and descriptions
+        userGroupId:
+          type: string
+          description: Filter assets visible to this user group
+          format: uuid
+        categories:
+          type: array
+          description: Filter by categories in key:value format
+          items:
+            type: string
+            description: Filter by categories in key:value format
+        tags:
+          type: array
+          description: Filter by tags
+          items:
+            type: string
+            description: Filter by tags
+        sort:
+          $ref: "#/components/schemas/SearchSort"
+        showInherited:
+          type: boolean
+          description: Whether to include assets inherited from parent groups
+    SearchSort:
+      type: object
+      required:
+      - criteria
+      - direction
+      properties:
+        direction:
+          type: string
+          description: Sort direction
+          enum:
+          - ASC
+          - DESC
+        criteria:
+          type: string
+          description: Sort criteria field
+          enum:
+          - LAST_UPDATED
+          - NAME
+          - CREATED_AT
+      description: Sort configuration for search results
+    CommunityAsset:
+      type: object
+      required:
+      - assetId
+      - groupId
+      - name
+      - type
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier within the organization
+        businessGroupId:
+          type: string
+          description: Business group ID that owns the asset
+          format: uuid
+        businessGroupName:
+          type: string
+          description: Business group name
+        createdById:
+          type: string
+          description: ID of the user who created the asset
+          format: uuid
+        description:
+          type: string
+          description: Human-readable description of the asset
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        lastUpdated:
+          type: string
+          description: Timestamp of the last update to the asset
+          format: date-time
+        addedOn:
+          type: string
+          description: Timestamp when the asset was added to the portal
+          format: date-time
+        name:
+          type: string
+          description: Display name of the asset
+        type:
+          type: string
+          description: Asset type classifier
+          example: rest-api
+        categories:
+          uniqueItems: true
+          type: array
+          description: Categories assigned to the asset
+          items:
+            type: string
+            description: Categories assigned to the asset
+        tags:
+          uniqueItems: true
+          type: array
+          description: Tags associated with the asset
+          items:
+            type: string
+            description: Tags associated with the asset
+      description: List of community assets matching the search criteria
+    CommunityAssetsSearchResult:
+      type: object
+      required:
+      - assets
+      properties:
+        assets:
+          type: array
+          description: List of community assets matching the search criteria
+          items:
+            $ref: "#/components/schemas/CommunityAsset"
+        facets:
+          $ref: "#/components/schemas/Facets"
+    Facets:
+      type: object
+      required:
+      - categories
+      - tags
+      properties:
+        categories:
+          type: array
+          description: Category facet values
+          items:
+            type: string
+            description: Category facet values
+        tags:
+          type: array
+          description: Tag facet values
+          items:
+            type: string
+            description: Tag facet values
+      description: Available facets for filtering search results
+    ExchangeSearchRequest:
+      type: object
+      properties:
+        searchTerm:
+          type: string
+          description: Text to search for in asset names and descriptions
+        categories:
+          type: array
+          description: Filter by categories in key:value format
+          items:
+            type: string
+            description: Filter by categories in key:value format
+        tags:
+          type: array
+          description: Filter by tags
+          items:
+            type: string
+            description: Filter by tags
+        sort:
+          $ref: "#/components/schemas/SearchSort"
+    ExchangeAsset:
+      type: object
+      required:
+      - assetId
+      - groupId
+      - name
+      - type
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier within the organization
+        businessGroupId:
+          type: string
+          description: Business group ID that owns the asset
+          format: uuid
+        businessGroupName:
+          type: string
+          description: Business group name
+        createdAt:
+          type: string
+          description: Timestamp when the asset was created
+          format: date-time
+        createdById:
+          type: string
+          description: ID of the user who created the asset
+          format: uuid
+        createdByName:
+          type: string
+          description: Name of the user who created the asset
+        description:
+          type: string
+          description: Human-readable description of the asset
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        lastUpdated:
+          type: string
+          description: Timestamp of the last update to the asset
+          format: date-time
+        latestVersion:
+          type: string
+          description: Latest minor version string
+          example: "1.0"
+        name:
+          type: string
+          description: Display name of the asset
+        type:
+          type: string
+          description: Asset type classifier
+          example: rest-api
+        categories:
+          uniqueItems: true
+          type: array
+          description: Categories assigned to the asset
+          items:
+            type: string
+            description: Categories assigned to the asset
+        tags:
+          uniqueItems: true
+          type: array
+          description: Tags associated with the asset
+          items:
+            type: string
+            description: Tags associated with the asset
+    ExchangeAssetsSearchResult:
+      type: object
+      required:
+      - assets
+      properties:
+        assets:
+          type: array
+          description: List of Anypoint Exchange assets matching the search criteria
+          items:
+            $ref: "#/components/schemas/ExchangeAsset"
+        facets:
+          $ref: "#/components/schemas/Facets"
+    CommunityAssetGaRemoveDTO:
+      required:
+      - assetId
+      - groupId
+      type: object
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier to remove from the portal
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+    ProfileDTO:
+      required:
+      - id
+      - name
+      type: object
+      properties:
+        children:
+          type: array
+          description: Child user groups nested under this group
+          items:
+            $ref: "#/components/schemas/ProfileDTO"
+        createdDate:
+          type: string
+          description: Date the user group was created
+          format: date-time
+        description:
+          type: string
+          description: Human-readable description of the user group
+        id:
+          type: string
+          description: Unique user group identifier
+          format: uuid
+        isAdmin:
+          type: boolean
+          description: Whether this is the admin user group
+        isAutoGenerated:
+          type: boolean
+          description: Whether this user group was auto-generated by the system
+        isDefault:
+          type: boolean
+          description: Whether this is the default portal user group
+        isPublic:
+          type: boolean
+          description: Whether this user group is publicly visible
+        name:
+          type: string
+          description: User group name
+    ProspectApproveDTO:
+      required:
+      - userGroupIds
+      type: object
+      properties:
+        userGroupIds:
+          type: array
+          description: User group IDs to assign to the approved prospect
+          items:
+            type: string
+            description: User group IDs to assign to the approved prospect
+            format: uuid
+    CommunityAssetVersionUpdateDTO:
+      type: object
+      required:
+      - minorVersions
+      properties:
+        instancesVisibility:
+          type: string
+          description: Visibility level for API instances
+          enum:
+          - All
+          - Public
+          - Custom
+        minorVersions:
+          type: array
+          description: Per-version visibility settings
+          items:
+            $ref: "#/components/schemas/CommunityAssetVersionVisibilityForAPICuratorDTO"
+    CommunityAssetVersionVisibilityForAPICuratorDTO:
+      type: object
+      required:
+      - minorVersion
+      properties:
+        minorVersion:
+          type: string
+          description: Minor version string
+          example: "v1"
+          pattern: ^v?\d+$
+        profileVisibility:
+          type: array
+          description: User group IDs that can view this version
+          items:
+            type: string
+            description: User group IDs that can view this version
+            format: uuid
+      description: Per-version visibility settings
+    PortalDTO:
+      required:
+      - id
+      - name
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique portal identifier
+          format: uuid
+        connectionId:
+          type: string
+          description: Associated Salesforce connection ID
+          format: uuid
+        name:
+          type: string
+          description: Portal name
+        targetPortalId:
+          type: string
+          description: Salesforce Experience Cloud site ID
+          format: uuid
+        internalPortalId:
+          type: string
+          description: Internal portal identifier
+          format: uuid
+        builderUrl:
+          type: string
+          description: URL of the Experience Builder for this portal
+          format: uri
+        siteUrl:
+          type: string
+          description: Public URL of the portal site
+          format: uri
+        createdDate:
+          type: string
+          description: Date the portal was created
+          format: date-time
+        updatedDate:
+          type: string
+          description: Date the portal was last updated
+          format: date-time
+        finishedAtLeastOnce:
+          type: boolean
+          description: Whether the portal setup has completed at least once
+      description: API Experience Hub portal information
+    CommunityUserDTO:
+      required:
+      - email
+      - id
+      type: object
+      properties:
+        anypointGroups:
+          type: array
+          description: Anypoint Platform groups the user belongs to
+          items:
+            type: string
+            description: Anypoint Platform groups the user belongs to
+        anypointIdpId:
+          type: string
+          description: Anypoint identity provider ID for the user
+          format: uuid
+        anypointUsername:
+          type: string
+          description: Anypoint Platform username
+        email:
+          type: string
+          description: User email address
+          format: email
+        id:
+          type: string
+          description: Unique Salesforce user identifier
+        isActive:
+          type: boolean
+          description: Whether the user account is active
+        name:
+          type: string
+          description: Full name of the user
+        username:
+          type: string
+          description: Salesforce username
+        userGroupIds:
+          type: array
+          description: User group IDs the user is a member of
+          items:
+            type: string
+            description: User group IDs the user is a member of
+        isExternal:
+          type: boolean
+          description: Whether the user is an external community user
+    TeamGroupMapping:
+      type: object
+      required:
+      - provider_id
+      - external_group_name
+      properties:
+        external_group_name:
+          type: string
+          description: Name of the external identity provider group
+        membership_type:
+          type: string
+          description: Membership type within the team
+          example: member
+        provider_id:
+          type: string
+          description: Identity provider ID for this group mapping
+    ProspectDTO:
+      required:
+      - email
+      - id
+      type: object
+      properties:
+        createdDate:
+          type: string
+          description: Date the access request was created
+          format: date-time
+        email:
+          type: string
+          description: Email address of the prospect
+          format: email
+        firstName:
+          type: string
+          description: First name of the prospect
+        id:
+          type: string
+          description: Unique prospect identifier
+          format: uuid
+        lastName:
+          type: string
+          description: Last name of the prospect
+        portalId:
+          type: string
+          description: Portal ID the access request is associated with
+          format: uuid
+        status:
+          type: string
+          description: Current status of the access request
+          enum:
+          - APPROVED
+          - PENDING
+        updatedDate:
+          type: string
+          description: Date the access request was last updated
+          format: date-time
+        username:
+          type: string
+          description: Username of the prospect
+    ProspectCountDTO:
+      required:
+      - count
+      type: object
+      properties:
+        count:
+          type: integer
+          description: Number of pending access requests
+          format: int64
+    ProducerAssetDetail:
+      type: object
+      required:
+      - assetId
+      - groupId
+      - name
+      - type
+      properties:
+        assetId:
+          type: string
+          description: Asset identifier within the organization
+        groupId:
+          type: string
+          description: Organization group ID that owns the asset
+        name:
+          type: string
+          description: Display name of the asset
+        instanceVisibility:
+          type: string
+          description: Visibility level for API instances
+          enum:
+          - All
+          - Public
+          - Custom
+        minorVersionProfilesVisibility:
+          type: array
+          description: Per-version user group visibility settings
+          items:
+            $ref: "#/components/schemas/CommunityAssetVersionVisibilityForAPICuratorDTO"
+        type:
+          type: string
+          description: Asset type classifier
+          example: rest-api
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: Anypoint Platform bearer token obtained from Access Management
+      scheme: bearer

--- a/apis/api-experience-hub-management/api.yaml
+++ b/apis/api-experience-hub-management/api.yaml
@@ -1,7 +1,29 @@
 openapi: 3.0.1
 info:
   title: API Experience Hub Management API
-  description: API Experience Hub API
+  description: |
+    Administer API Experience Hub portals, members and the assets they expose.
+
+    Use this API as a portal owner to provision and operate Salesforce-hosted developer
+    portals that surface APIs from Anypoint Exchange. The management surface covers four
+    jobs:
+
+    - **Connections and portals** — list Salesforce connections, enumerate the portals
+      attached to each connection, and resolve the external organization id used by the
+      Consumer API.
+    - **Asset curation** — publish, search, update and remove the Exchange assets that
+      appear in a portal's catalog, including version visibility.
+    - **Members and prospects** — list portal users, enable or disable accounts, review
+      pending sign-ups, and approve or reject prospects.
+    - **User groups and access** — create user groups, manage their group mappings to
+      external IdP groups, and assign or revoke user-group memberships.
+
+    All paths are scoped by `connectionId` (the Salesforce connection registered in the
+    hub) and `portalId` (the portal hosted under that connection). Both are obtained from
+    `GET /connections` and `GET /connections/{connectionId}/apiPortals`. Authentication is
+    via bearer token. Errors follow the standard Anypoint JSON error envelope; list
+    endpoints support `searchTerm` filtering and header-based pagination
+    (`x-limit` / `x-offset`).
   version: 1.0.0
 servers:
 - url: https://anypoint.mulesoft.com/api-experience-hub
@@ -41,6 +63,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       responses:
         "400":
           description: Bad Request
@@ -88,6 +116,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -95,6 +129,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: targetUserId
         in: path
         description: Unique identifier of the target portal user
@@ -102,6 +142,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getCommunityUsers
+          values: $[*].id
+          labels: $[*].name
+          description: Portal user enrolled in the selected portal
       requestBody:
         description: List of user group IDs to assign to the user (maximum 20)
         content:
@@ -185,6 +231,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -192,6 +244,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       responses:
         "400":
           description: Bad Request
@@ -246,6 +304,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -253,6 +317,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       requestBody:
         description: User group creation request with name and optional description
         content:
@@ -300,6 +370,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllProfilesByPortal
+          values: $[*].id
+          labels: $[*].name
+          description: User group or profile defined in the portal
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -307,6 +383,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -314,6 +396,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       responses:
         "400":
           description: Bad Request
@@ -353,6 +441,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllProfilesByPortal
+          values: $[*].id
+          labels: $[*].name
+          description: User group or profile defined in the portal
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -360,6 +454,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -367,6 +467,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       requestBody:
         description: "Group mapping to add, with identity provider ID and group name"
         content:
@@ -407,6 +513,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -414,6 +526,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       requestBody:
         description: "List of assets to publish, identified by group ID and asset ID"
         content:
@@ -467,6 +585,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -474,6 +598,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: x-limit
         in: header
         description: Maximum number of search results to return
@@ -561,6 +691,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -568,6 +704,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: x-limit
         in: header
         description: Maximum number of search results to return
@@ -655,6 +797,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -662,6 +810,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       requestBody:
         description: "List of assets to remove, identified by group ID and asset ID"
         content:
@@ -704,6 +858,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -711,6 +871,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: x-limit
         in: header
         description: Maximum number of search results to return
@@ -790,6 +956,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -797,6 +969,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: targetUserId
         in: path
         description: Unique identifier of the target portal user
@@ -804,6 +982,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getCommunityUsers
+          values: $[*].id
+          labels: $[*].name
+          description: Portal user enrolled in the selected portal
       responses:
         "400":
           description: Bad Request
@@ -834,6 +1018,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -841,6 +1031,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: targetUserId
         in: path
         description: Unique identifier of the target portal user
@@ -848,6 +1044,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getCommunityUsers
+          values: $[*].id
+          labels: $[*].name
+          description: Portal user enrolled in the selected portal
       responses:
         "400":
           description: Bad Request
@@ -878,6 +1080,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllProfilesByPortal
+          values: $[*].id
+          labels: $[*].name
+          description: User group or profile defined in the portal
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -885,6 +1093,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -892,6 +1106,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       responses:
         "400":
           description: Bad Request
@@ -921,6 +1141,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllProfilesByPortal
+          values: $[*].id
+          labels: $[*].name
+          description: User group or profile defined in the portal
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -928,6 +1154,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -935,6 +1167,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       requestBody:
         description: User group update request with new name or description
         content:
@@ -989,6 +1227,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -996,6 +1240,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: prospectId
         in: path
         description: Unique identifier of the prospect
@@ -1003,6 +1253,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getProspects
+          values: $[*].id
+          labels: $[*].email
+          description: Prospect awaiting approval into the portal
       responses:
         "400":
           description: Bad Request
@@ -1039,6 +1295,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1046,6 +1308,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: prospectId
         in: path
         description: Unique identifier of the prospect
@@ -1053,6 +1321,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getProspects
+          values: $[*].id
+          labels: $[*].email
+          description: Prospect awaiting approval into the portal
       requestBody:
         description: Prospect approval configuration with user group assignments
         content:
@@ -1093,6 +1367,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1100,18 +1380,35 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: searchCommunityAssets
+          values: $.assets[*].groupId
+          description: Exchange group identifier for an asset published in the portal
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: searchCommunityAssets
+          values: $.assets[*].assetId
+          labels: $.assets[*].name
+          description: Asset published in the portal
       responses:
         "400":
           description: Bad Request
@@ -1155,6 +1452,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1162,18 +1465,35 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: groupId
         in: path
         description: Exchange group ID of the asset
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: searchCommunityAssets
+          values: $.assets[*].groupId
+          description: Exchange group identifier for an asset published in the portal
       - name: assetId
         in: path
         description: Exchange asset ID
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: searchCommunityAssets
+          values: $.assets[*].assetId
+          labels: $.assets[*].name
+          description: Asset published in the portal
       requestBody:
         description: Visibility settings to apply to the asset's minor versions and instances
         content:
@@ -1221,6 +1541,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1228,6 +1554,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: searchTerm
         in: query
         description: Text to search for in user names and emails
@@ -1305,6 +1637,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1312,6 +1650,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: userId
         in: path
         description: Unique identifier of the portal user
@@ -1319,6 +1663,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getCommunityUsers
+          values: $[*].id
+          labels: $[*].name
+          description: Portal user enrolled in the selected portal
       responses:
         "400":
           description: Bad Request
@@ -1366,6 +1716,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1373,6 +1729,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: searchTerm
         in: query
         description: Text to search for in prospect names and emails
@@ -1428,6 +1790,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1435,6 +1803,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       responses:
         "400":
           description: Bad Request
@@ -1471,6 +1845,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllProfilesByPortal
+          values: $[*].id
+          labels: $[*].name
+          description: User group or profile defined in the portal
       - name: portalId
         in: path
         description: Unique identifier of the portal
@@ -1478,6 +1858,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getAllApiPortalByConnectionId
+          values: $[*].targetPortalId
+          labels: $[*].name
+          description: Portal hosted under the selected connection
       - name: connectionId
         in: path
         description: Unique identifier of the Salesforce connection
@@ -1485,6 +1871,12 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getConnections
+          values: $[*].id
+          labels: $[*].targetOrganizationDomain
+          description: Salesforce connection registered in API Experience Hub
       - name: idpId
         in: path
         description: Identity provider ID
@@ -1492,12 +1884,23 @@ paths:
         schema:
           type: string
           format: uuid
+        x-origin:
+        - api: urn:api:access-management
+          operation: getIdentityProviders
+          values: $.data[*].id
+          labels: $.data[*].name
+          description: Identity provider configured for the organization
       - name: groupMappingName
         in: path
         description: Name of the group mapping to remove
         required: true
         schema:
           type: string
+        x-origin:
+        - api: urn:api:api-experience-hub-management
+          operation: getGroupMappings
+          values: $[*].name
+          description: Existing group-mapping name on the user group
       responses:
         "400":
           description: Bad Request

--- a/apis/api-experience-hub-management/exchange.json
+++ b/apis/api-experience-hub-management/exchange.json
@@ -1,0 +1,12 @@
+{
+  "main": "api.yaml",
+  "name": "API Experience Hub Management API",
+  "classifier": "oas",
+  "tags": [],
+  "groupId": "f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform",
+  "assetId": "api-experience-hub-management",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "originalFormatVersion": "3.0",
+  "organizationId": "8bfc8bbf-5508-419e-aadc-77dfe18a8172"
+}

--- a/scripts/portal_generator/parsers/oas_parser.py
+++ b/scripts/portal_generator/parsers/oas_parser.py
@@ -117,21 +117,25 @@ def _convert_to_plain(obj):
     return obj
 
 
-def resolve_schema(schema: Dict, base_dir: Path, depth: int = 0) -> Dict:
-    """Resolve a schema, following $ref if it points to an external file.
+def resolve_schema(schema: Dict, base_dir: Path, depth: int = 0, components: Dict = None) -> Dict:
+    """Resolve a schema, following $ref to either an external file or an
+    internal #/components/schemas/* entry when components are provided.
     Returns the schema with top-level properties expanded.
     Limits depth to avoid infinite recursion."""
     if not isinstance(schema, dict) or depth > 2:
         return schema or {}
 
-    # Handle $ref to external file
     if '$ref' in schema:
         ref = schema['$ref']
         if ref.startswith('#'):
-            return schema  # Internal ref, can't resolve without full spec
+            if components:
+                resolved = resolve_ref(ref, components)
+                if resolved and isinstance(resolved, dict):
+                    return resolve_schema(resolved, base_dir, depth + 1, components)
+            return schema  # No components or ref not found: passthrough
         resolved = resolve_external_ref(ref, base_dir)
         if resolved and isinstance(resolved, dict):
-            return resolve_schema(resolved, base_dir, depth + 1)
+            return resolve_schema(resolved, base_dir, depth + 1, components)
         return schema
 
     # Handle allOf: merge properties from all schemas
@@ -140,7 +144,7 @@ def resolve_schema(schema: Dict, base_dir: Path, depth: int = 0) -> Dict:
         merged_props = {}
         merged_required = []
         for sub in schema['allOf']:
-            resolved_sub = resolve_schema(sub, base_dir, depth + 1)
+            resolved_sub = resolve_schema(sub, base_dir, depth + 1, components)
             if isinstance(resolved_sub, dict):
                 merged_props.update(resolved_sub.get('properties', {}))
                 merged_required.extend(resolved_sub.get('required', []))
@@ -159,10 +163,10 @@ def resolve_schema(schema: Dict, base_dir: Path, depth: int = 0) -> Dict:
     return schema
 
 
-def extract_schema_properties(schema: Dict, base_dir: Path) -> List[Dict]:
+def extract_schema_properties(schema: Dict, base_dir: Path, components: Dict = None) -> List[Dict]:
     """Extract a flat list of property definitions from a schema for rendering.
     Returns list of {name, type, required, description, constraints, children}."""
-    resolved = resolve_schema(schema, base_dir)
+    resolved = resolve_schema(schema, base_dir, components=components)
     if not isinstance(resolved, dict):
         return []
 
@@ -176,9 +180,15 @@ def extract_schema_properties(schema: Dict, base_dir: Path) -> List[Dict]:
 
         # Resolve nested $ref for the property itself
         if '$ref' in prop:
-            ext = resolve_external_ref(prop['$ref'], base_dir)
-            if ext and isinstance(ext, dict):
-                prop = ext
+            ref = prop['$ref']
+            if ref.startswith('#') and components:
+                internal = resolve_ref(ref, components)
+                if internal and isinstance(internal, dict):
+                    prop = internal
+            else:
+                ext = resolve_external_ref(ref, base_dir)
+                if ext and isinstance(ext, dict):
+                    prop = ext
 
         prop_type = prop.get('type', '')
         if prop.get('format'):
@@ -211,7 +221,7 @@ def extract_schema_properties(schema: Dict, base_dir: Path) -> List[Dict]:
         # Extract nested properties for object types
         children = []
         if prop.get('type') == 'object' and 'properties' in prop:
-            children = extract_schema_properties(prop, base_dir)
+            children = extract_schema_properties(prop, base_dir, components)
 
         result.append({
             'name': str(name),
@@ -311,14 +321,14 @@ def extract_operations(paths: Dict, components: Dict = None, base_dir: Path = No
                 if 'requestBody' in op:
                     rb = op['requestBody']
                     if isinstance(rb, dict):
-                        request_body = _extract_request_body(rb, base_dir)
+                        request_body = _extract_request_body(rb, base_dir, components)
 
                 # Extract responses with resolved schemas and examples
                 responses = {}
                 if 'responses' in op:
                     for status, response in op.get('responses', {}).items():
                         if isinstance(response, dict):
-                            responses[str(status)] = _extract_response(response, base_dir)
+                            responses[str(status)] = _extract_response(response, base_dir, components)
 
                 operations.append({
                     'method': method.upper(),
@@ -353,7 +363,7 @@ def _extract_param(param: Dict) -> Dict:
     }
 
 
-def _extract_request_body(rb: Dict, base_dir: Path = None) -> Dict:
+def _extract_request_body(rb: Dict, base_dir: Path = None, components: Dict = None) -> Dict:
     """Extract request body with resolved schema properties and examples."""
     result = {
         'required': rb.get('required', False),
@@ -373,10 +383,10 @@ def _extract_request_body(rb: Dict, base_dir: Path = None) -> Dict:
 
         # Resolve schema (raw + flattened)
         if 'schema' in media_type and base_dir:
-            resolved = resolve_schema(media_type['schema'], base_dir)
+            resolved = resolve_schema(media_type['schema'], base_dir, components=components)
             if resolved:
                 result['raw_schemas'][ct] = _convert_to_plain(resolved)
-            props = extract_schema_properties(media_type['schema'], base_dir)
+            props = extract_schema_properties(media_type['schema'], base_dir, components)
             if props:
                 result['schemas'][ct] = props
 
@@ -398,7 +408,7 @@ def _extract_request_body(rb: Dict, base_dir: Path = None) -> Dict:
     return result
 
 
-def _extract_response(response: Dict, base_dir: Path = None) -> Dict:
+def _extract_response(response: Dict, base_dir: Path = None, components: Dict = None) -> Dict:
     """Extract a response with resolved schema properties and examples."""
     result = {
         'description': response.get('description', ''),
@@ -416,7 +426,7 @@ def _extract_response(response: Dict, base_dir: Path = None) -> Dict:
 
         # Resolve schema
         if 'schema' in media_type and base_dir:
-            props = extract_schema_properties(media_type['schema'], base_dir)
+            props = extract_schema_properties(media_type['schema'], base_dir, components)
             if props:
                 result['schemas'][ct] = props
 

--- a/scripts/portal_generator/parsers/oas_parser.py
+++ b/scripts/portal_generator/parsers/oas_parser.py
@@ -85,6 +85,9 @@ def load_example_content(ref_or_value, base_dir: Path) -> Optional[str]:
                 return json.dumps(_convert_to_plain(ref_or_value['value']), indent=2)
             # Inline example object
             return json.dumps(_convert_to_plain(ref_or_value), indent=2)
+        elif isinstance(ref_or_value, list):
+            # Inline list example (e.g. array request body example)
+            return json.dumps(_convert_to_plain(ref_or_value), indent=2)
         elif isinstance(ref_or_value, str):
             if len(ref_or_value) > 500:
                 return None  # Not a file path
@@ -163,12 +166,51 @@ def resolve_schema(schema: Dict, base_dir: Path, depth: int = 0, components: Dic
     return schema
 
 
+def _resolve_inline_ref(node: Dict, base_dir: Path, components: Dict = None) -> Dict:
+    """Resolve a single $ref node (internal or external) to its target dict.
+    Returns the original node unchanged if no $ref or it can't be resolved."""
+    if not isinstance(node, dict) or '$ref' not in node:
+        return node
+    ref = node['$ref']
+    if ref.startswith('#') and components:
+        internal = resolve_ref(ref, components)
+        if internal and isinstance(internal, dict):
+            return internal
+    elif not ref.startswith('#'):
+        ext = resolve_external_ref(ref, base_dir)
+        if ext and isinstance(ext, dict):
+            return ext
+    return node
+
+
 def extract_schema_properties(schema: Dict, base_dir: Path, components: Dict = None) -> List[Dict]:
     """Extract a flat list of property definitions from a schema for rendering.
-    Returns list of {name, type, required, description, constraints, children}."""
+    Returns list of {name, type, required, description, constraints, children}.
+
+    For top-level array schemas, returns a single synthetic 'items' row whose
+    children are the properties of the resolved items schema -- so callers and
+    templates can render array-of-DTO bodies/responses without special casing."""
     resolved = resolve_schema(schema, base_dir, components=components)
     if not isinstance(resolved, dict):
         return []
+
+    # Top-level array schema: synthesize an 'items' row with the item properties
+    # as children. This handles array request bodies and array responses where
+    # the items use $ref to a component schema.
+    if resolved.get('type') == 'array' and 'items' in resolved:
+        items_schema = _resolve_inline_ref(resolved['items'], base_dir, components)
+        items_resolved = resolve_schema(items_schema, base_dir, components=components)
+        items_type = items_resolved.get('type', 'object') if isinstance(items_resolved, dict) else 'object'
+        children = extract_schema_properties(items_schema, base_dir, components)
+        return [{
+            'name': 'items',
+            'type': f'array[{items_type}]',
+            'required': False,
+            'description': resolved.get('description', '') or 'Array items',
+            'constraints': [],
+            'children': children,
+            'schema': resolved,
+        }]
 
     properties = resolved.get('properties', {})
     required_fields = set(resolved.get('required', []))
@@ -196,10 +238,11 @@ def extract_schema_properties(schema: Dict, base_dir: Path, components: Dict = N
         if prop.get('nullable'):
             prop_type += ', nullable'
 
-        # Items type for arrays
+        # Items type for arrays (resolve $ref to surface the real item type)
         items = prop.get('items', {})
         if isinstance(items, dict) and prop_type.startswith('array'):
-            items_type = items.get('type', 'object')
+            resolved_items = _resolve_inline_ref(items, base_dir, components)
+            items_type = resolved_items.get('type', 'object') if isinstance(resolved_items, dict) else 'object'
             prop_type = f"array[{items_type}]"
 
         constraints = []

--- a/scripts/portal_generator/templates/operations/operation_detail.html
+++ b/scripts/portal_generator/templates/operations/operation_detail.html
@@ -145,7 +145,7 @@
                     {% endif %}
                 </div>
                 {% for ct, props in rb.schemas|default({})|items %}
-                {{ render_schema_table(props, '') }}
+                {{ render_schema_table(props, '', operation.operationId ~ '-rb') }}
                 {% endfor %}
                 {% if rb.examples %}
                 <details class="response-examples-section">
@@ -198,7 +198,7 @@
                     <div class="param-description">{{ response.description|md }}</div>
                     {% endif %}
                     {% for ct, props in response.schemas|default({})|items %}
-                    {{ render_schema_table(props) }}
+                    {{ render_schema_table(props, '', operation.operationId ~ '-resp-' ~ status) }}
                     {% endfor %}
                     {% if response.examples %}
                     <details class="response-examples-section">

--- a/scripts/portal_generator/templates/operations/schema_table.html
+++ b/scripts/portal_generator/templates/operations/schema_table.html
@@ -1,8 +1,9 @@
 {% from "operations/macros.html" import param_type, param_type_simple %}
 
-{% macro render_schema_table(properties, title='') %}
+{% macro render_schema_table(properties, title='', id_prefix='') %}
 {% if properties %}
 {% if title %}<h5 class="schema-title">{{ title }}</h5>{% endif %}
+{% set scope = (id_prefix ~ '-') if id_prefix else '' %}
 <div class="params-list">
     {% for prop in properties %}
     {% set prop_desc = prop.description|md if prop.description else '' %}
@@ -10,6 +11,7 @@
     {% set has_default = schema.default is defined and schema.default is not none %}
     {% set has_constraints = schema.minimum is defined or schema.maximum is defined or schema.minLength is defined or schema.maxLength is defined or schema.pattern is defined or has_default %}
     {% set should_collapse = prop_desc|should_collapse_description or has_constraints %}
+    {% set nested_id = scope ~ (prop.name|replace(' ', '-')|replace('.', '-')|lower) ~ '-' ~ loop.index %}
     <div class="param-item{% if should_collapse %} has-collapsible{% endif %}">
         <div class="param-header">
             {% if should_collapse %}
@@ -18,7 +20,7 @@
             </button>
             {% endif %}
             {% if prop.children and prop.children|length > 0 %}
-            <button class="nested-prop-toggle" onclick="toggleNestedProps('{{ prop.name|replace(' ', '-')|replace('.', '-')|lower }}-{{ loop.index }}')" aria-label="Toggle nested properties">
+            <button class="nested-prop-toggle" onclick="toggleNestedProps('{{ nested_id }}')" aria-label="Toggle nested properties">
                 <svg viewBox="0 0 16 16" fill="none"><path d="M6 4L10 8L6 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
             {% endif %}
@@ -49,7 +51,7 @@
         </div>
         {% endif %}
         {% if prop.children and prop.children|length > 0 %}
-        <div class="nested-properties" id="{{ prop.name|replace(' ', '-')|replace('.', '-')|lower }}-{{ loop.index }}" style="display:none">
+        <div class="nested-properties" id="{{ nested_id }}" style="display:none">
             <div class="params-list nested-params-list">
                 {% for child in prop.children %}
                 {% set child_desc = child.description|md if child.description else '' %}

--- a/scripts/tests/test_oas_parser.py
+++ b/scripts/tests/test_oas_parser.py
@@ -151,6 +151,43 @@ class TestResolveSchema:
         result = resolve_schema(schema, tmp_path)
         assert result == schema
 
+    def test_internal_ref_resolves_with_components(self, tmp_path):
+        components = {
+            'schemas': {
+                'Pet': {
+                    'type': 'object',
+                    'required': ['name'],
+                    'properties': {'name': {'type': 'string'}},
+                }
+            }
+        }
+        schema = {'$ref': '#/components/schemas/Pet'}
+        result = resolve_schema(schema, tmp_path, components=components)
+        assert result['type'] == 'object'
+        assert 'name' in result['properties']
+        assert result['required'] == ['name']
+
+    def test_internal_ref_chain_resolves_with_components(self, tmp_path):
+        components = {
+            'schemas': {
+                'Outer': {'$ref': '#/components/schemas/Inner'},
+                'Inner': {
+                    'type': 'object',
+                    'properties': {'id': {'type': 'string'}},
+                },
+            }
+        }
+        result = resolve_schema(
+            {'$ref': '#/components/schemas/Outer'}, tmp_path, components=components
+        )
+        assert result['type'] == 'object'
+        assert 'id' in result['properties']
+
+    def test_internal_ref_unknown_component_passthrough(self, tmp_path):
+        schema = {'$ref': '#/components/schemas/Missing'}
+        result = resolve_schema(schema, tmp_path, components={'schemas': {}})
+        assert result == schema
+
     def test_depth_limit(self, tmp_path):
         schema = {'type': 'string'}
         result = resolve_schema(schema, tmp_path, depth=3)
@@ -262,6 +299,44 @@ class TestExtractSchemaProperties:
             },
         }
         props = extract_schema_properties(schema, tmp_path)
+        assert len(props) == 1
+        assert props[0]['type'] == 'string'
+        assert any('enum' in c for c in props[0]['constraints'])
+
+    def test_internal_ref_top_level_schema(self, tmp_path):
+        components = {
+            'schemas': {
+                'UserGroupRequestDTO': {
+                    'type': 'object',
+                    'required': ['name'],
+                    'properties': {
+                        'name': {'type': 'string', 'description': 'Group name'},
+                        'description': {'type': 'string'},
+                        'parentUserGroupId': {'type': 'string', 'format': 'uuid'},
+                    },
+                }
+            }
+        }
+        schema = {'$ref': '#/components/schemas/UserGroupRequestDTO'}
+        props = extract_schema_properties(schema, tmp_path, components=components)
+        names = [p['name'] for p in props]
+        assert names == ['name', 'description', 'parentUserGroupId']
+        assert next(p for p in props if p['name'] == 'name')['required'] is True
+        assert next(p for p in props if p['name'] == 'description')['required'] is False
+
+    def test_internal_ref_in_property(self, tmp_path):
+        components = {
+            'schemas': {
+                'Status': {'type': 'string', 'enum': ['active', 'inactive']},
+            }
+        }
+        schema = {
+            'type': 'object',
+            'properties': {
+                'status': {'$ref': '#/components/schemas/Status'},
+            },
+        }
+        props = extract_schema_properties(schema, tmp_path, components=components)
         assert len(props) == 1
         assert props[0]['type'] == 'string'
         assert any('enum' in c for c in props[0]['constraints'])
@@ -402,6 +477,81 @@ class TestExtractOperations:
         }
         ops = extract_operations(paths)
         assert ops[0]['operationId'] == 'get__items'
+
+    def test_request_body_with_internal_ref_resolves_properties(self, tmp_path):
+        """Regression: bodies that use $ref to #/components/schemas/* must
+        render their property tables, not appear empty in the portal."""
+        paths = {
+            '/userGroups': {
+                'post': {
+                    'operationId': 'createUserGroup',
+                    'requestBody': {
+                        'required': True,
+                        'content': {
+                            'application/json': {
+                                'schema': {'$ref': '#/components/schemas/UserGroupRequestDTO'},
+                            }
+                        },
+                    },
+                    'responses': {},
+                },
+            }
+        }
+        components = {
+            'schemas': {
+                'UserGroupRequestDTO': {
+                    'type': 'object',
+                    'required': ['name'],
+                    'properties': {
+                        'name': {'type': 'string', 'description': 'Group name'},
+                        'description': {'type': 'string'},
+                        'parentUserGroupId': {'type': 'string', 'format': 'uuid'},
+                    },
+                }
+            }
+        }
+        ops = extract_operations(paths, components, tmp_path)
+        rb = ops[0]['requestBody']
+        assert rb['schemas'].get('application/json'), \
+            'request body schema must expose properties when using internal $ref'
+        names = [p['name'] for p in rb['schemas']['application/json']]
+        assert names == ['name', 'description', 'parentUserGroupId']
+
+    def test_response_with_internal_ref_resolves_properties(self, tmp_path):
+        """Same fix should apply to response schemas using internal $ref."""
+        paths = {
+            '/userGroups': {
+                'get': {
+                    'operationId': 'listUserGroups',
+                    'responses': {
+                        '200': {
+                            'description': 'OK',
+                            'content': {
+                                'application/json': {
+                                    'schema': {'$ref': '#/components/schemas/UserGroupDTO'},
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+        }
+        components = {
+            'schemas': {
+                'UserGroupDTO': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {'type': 'string', 'format': 'uuid'},
+                        'name': {'type': 'string'},
+                    },
+                }
+            }
+        }
+        ops = extract_operations(paths, components, tmp_path)
+        resp = ops[0]['responses']['200']
+        assert resp['schemas'].get('application/json')
+        names = [p['name'] for p in resp['schemas']['application/json']]
+        assert names == ['id', 'name']
 
     def test_empty_paths(self):
         assert extract_operations({}) == []

--- a/scripts/tests/test_oas_parser.py
+++ b/scripts/tests/test_oas_parser.py
@@ -341,6 +341,63 @@ class TestExtractSchemaProperties:
         assert props[0]['type'] == 'string'
         assert any('enum' in c for c in props[0]['constraints'])
 
+    def test_top_level_array_body_with_internal_ref_items(self, tmp_path):
+        """Regression: array request bodies whose items use $ref must surface
+        the item's properties as children of a synthetic 'items' row."""
+        components = {
+            'schemas': {
+                'CommunityAssetGaCreateDTO': {
+                    'type': 'object',
+                    'required': ['assetId', 'groupId'],
+                    'properties': {
+                        'assetId': {'type': 'string', 'description': 'Exchange asset id'},
+                        'groupId': {'type': 'string', 'description': 'Exchange group id'},
+                    },
+                }
+            }
+        }
+        schema = {
+            'type': 'array',
+            'items': {'$ref': '#/components/schemas/CommunityAssetGaCreateDTO'},
+        }
+        props = extract_schema_properties(schema, tmp_path, components=components)
+        assert len(props) == 1
+        assert props[0]['name'] == 'items'
+        assert props[0]['type'] == 'array[object]'
+        child_names = [c['name'] for c in props[0]['children']]
+        assert child_names == ['assetId', 'groupId']
+
+    def test_top_level_array_body_with_inline_items(self, tmp_path):
+        schema = {
+            'type': 'array',
+            'items': {'type': 'string'},
+        }
+        props = extract_schema_properties(schema, tmp_path)
+        assert len(props) == 1
+        assert props[0]['name'] == 'items'
+        assert props[0]['type'] == 'array[string]'
+        assert props[0]['children'] == []
+
+    def test_array_property_items_ref_resolves_type(self, tmp_path):
+        """A property of type array whose items use $ref should report the
+        resolved item type (e.g. 'object'), not the literal 'object' fallback."""
+        components = {
+            'schemas': {
+                'Tag': {'type': 'string', 'enum': ['a', 'b']},
+            }
+        }
+        schema = {
+            'type': 'object',
+            'properties': {
+                'tags': {
+                    'type': 'array',
+                    'items': {'$ref': '#/components/schemas/Tag'},
+                },
+            },
+        }
+        props = extract_schema_properties(schema, tmp_path, components=components)
+        assert props[0]['type'] == 'array[string]'
+
     def test_empty_properties(self, tmp_path):
         schema = {'type': 'object'}
         assert extract_schema_properties(schema, tmp_path) == []
@@ -517,6 +574,57 @@ class TestExtractOperations:
         names = [p['name'] for p in rb['schemas']['application/json']]
         assert names == ['name', 'description', 'parentUserGroupId']
 
+    def test_array_request_body_resolves_items_and_keeps_inline_example(self, tmp_path):
+        """Regression: array bodies (type: array, items: $ref) must render
+        their item properties AND their inline list example -- both were
+        previously dropped, leaving the body and Examples section empty."""
+        paths = {
+            '/assets': {
+                'post': {
+                    'operationId': 'addAssetsToCommunity',
+                    'requestBody': {
+                        'required': True,
+                        'content': {
+                            'application/json': {
+                                'schema': {
+                                    'type': 'array',
+                                    'items': {'$ref': '#/components/schemas/CommunityAssetGaCreateDTO'},
+                                },
+                                'example': [
+                                    {'assetId': 'payment-api', 'groupId': 'com.example'},
+                                ],
+                            }
+                        },
+                    },
+                    'responses': {},
+                },
+            }
+        }
+        components = {
+            'schemas': {
+                'CommunityAssetGaCreateDTO': {
+                    'type': 'object',
+                    'required': ['assetId', 'groupId'],
+                    'properties': {
+                        'assetId': {'type': 'string'},
+                        'groupId': {'type': 'string'},
+                    },
+                }
+            }
+        }
+        ops = extract_operations(paths, components, tmp_path)
+        rb = ops[0]['requestBody']
+        # Body fields render via the synthetic 'items' row
+        props = rb['schemas']['application/json']
+        assert len(props) == 1
+        assert props[0]['name'] == 'items'
+        child_names = [c['name'] for c in props[0]['children']]
+        assert child_names == ['assetId', 'groupId']
+        # Inline list example survives
+        assert rb['examples']['application/json']['Default']
+        parsed = json.loads(rb['examples']['application/json']['Default'])
+        assert parsed[0]['assetId'] == 'payment-api'
+
     def test_response_with_internal_ref_resolves_properties(self, tmp_path):
         """Same fix should apply to response schemas using internal $ref."""
         paths = {
@@ -677,6 +785,16 @@ class TestLoadExampleContent:
 
     def test_missing_ref(self, tmp_path):
         assert load_example_content({'$ref': 'missing.json'}, tmp_path) is None
+
+    def test_inline_list(self, tmp_path):
+        """Regression: array request bodies often supply an inline YAML list
+        as the example value. load_example_content must serialize lists, not
+        treat them as None (which would drop the Examples section)."""
+        example = [{'assetId': 'payment-api', 'groupId': 'com.example'}]
+        result = load_example_content(example, tmp_path)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed == example
 
 
 # ============================================================================

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -1276,3 +1276,63 @@ class TestBuildMcpLookup:
         gen = self._make_generator(mcps)
         lookup = gen._build_mcp_lookup()
         assert lookup['test']['tools']['search']['inputSchema'] == schema
+
+
+# ============================================================================
+# render_schema_table macro -- regression tests for nested-prop id uniqueness
+# ============================================================================
+
+class TestRenderSchemaTableIds:
+    """The render_schema_table macro must scope nested-property ids by an
+    optional id_prefix so that multiple operations on the same page (or a
+    single operation rendering both a request body and responses) don't
+    produce colliding `id="..."` attributes that break the toggle button."""
+
+    @pytest.fixture
+    def render(self):
+        from portal_generator.template_env import create_env
+        env = create_env()
+        wrapper = env.from_string(
+            "{% from 'operations/schema_table.html' import render_schema_table %}"
+            "{{ render_schema_table(props, '', prefix) }}"
+        )
+
+        def _render(props, prefix=''):
+            return wrapper.render(props=props, prefix=prefix)
+
+        return _render
+
+    def _items_row(self):
+        return [{
+            'name': 'items',
+            'type': 'array[object]',
+            'required': False,
+            'description': 'Array items',
+            'constraints': [],
+            'children': [{
+                'name': 'assetId',
+                'type': 'string',
+                'required': True,
+                'description': 'Asset id',
+                'constraints': [],
+                'children': [],
+                'schema': {'type': 'string'},
+            }],
+            'schema': {'type': 'array'},
+        }]
+
+    def test_id_prefix_makes_ids_unique(self, render):
+        html_a = render(self._items_row(), prefix='addAssetsToCommunity-rb')
+        html_b = render(self._items_row(), prefix='removeAssetFromCommunity-rb')
+        assert 'id="addAssetsToCommunity-rb-items-1"' in html_a
+        assert 'id="removeAssetFromCommunity-rb-items-1"' in html_b
+        # Toggle onclick targets the same id as the panel
+        assert "toggleNestedProps('addAssetsToCommunity-rb-items-1')" in html_a
+        assert "toggleNestedProps('removeAssetFromCommunity-rb-items-1')" in html_b
+
+    def test_empty_prefix_preserves_legacy_id_shape(self, render):
+        """When id_prefix is empty (default), ids remain in the original
+        form so existing callers / tests don't shift unexpectedly."""
+        html = render(self._items_row(), prefix='')
+        assert 'id="items-1"' in html
+        assert "toggleNestedProps('items-1')" in html

--- a/skills/curate-portal-assets/SKILL.md
+++ b/skills/curate-portal-assets/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: curate-portal-assets
+description: |
+  Curate API assets in an API Experience Hub portal. Use when an admin needs to
+  publish Exchange assets to a portal, adjust which minor versions are visible
+  to consumers, or remove assets from a portal. Covers discovery of unpublished
+  assets, publishing, visibility configuration and removal.
+---
+
+# Curate Portal Assets
+
+## Overview
+
+Curates the API catalog of an API Experience Hub (AEH) portal: discovers Exchange assets that are not yet published, adds selected assets to the portal, inspects the visibility of each minor version, adjusts visibility per version, and removes assets that should no longer be published. The workflow lets portal administrators control exactly which APIs — and which minor versions — are exposed to portal consumers.
+
+**What you'll build:** A curated portal catalog with the right assets and minor-version visibility for your consumers.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid Bearer token for Anypoint Platform
+   - **AEH Administrator** or **AEH Portal Administrator** permissions
+
+2. **Environment already bootstrapped** (not covered by this workflow — use the AEH UI for these)
+   - The Salesforce Connection has been created in AEH
+   - At least one Portal has been created on that connection
+
+## Step 1: List AEH Connections
+
+Retrieve the AEH connections the user has access to. The selected connection's ID is used as `connectionId` in every downstream management call.
+
+**What you'll need:**
+- Bearer token
+
+**Action:** List connections and pick the one hosting the target portal.
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getConnections
+inputs: {}
+outputs:
+  - name: connectionId
+    path: $[*].id
+    labels: $[*].name
+    description: AEH connection ID (Salesforce org link) backing the portal
+```
+
+**What happens next:** The chosen `connectionId` scopes every subsequent call to a single Salesforce org connection.
+
+## Step 2: List Portals on the Connection
+
+List the portals that live on the selected connection and pick the target `portalId`.
+
+**What you'll need:**
+- `connectionId` from Step 1
+
+**Action:** Retrieve the available portals.
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getAllApiPortalByConnectionId
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID from Step 1
+outputs:
+  - name: portalId
+    path: $[*].id
+    labels: $[*].name
+    description: ID of the portal to curate
+```
+
+**What happens next:** You now have the `(connectionId, portalId)` pair required by every curation operation.
+
+## Step 3: Discover Unpublished Exchange Assets
+
+Search Exchange for assets that the connected Salesforce org has access to but that are **not yet published** in this portal. This is the candidate list for publication.
+
+**What you'll need:**
+- `connectionId` and `portalId` from previous steps
+- Optional search query / filters (name, tags, categories)
+
+**Action:** Search unpublished Exchange assets.
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: searchExchangeAssets
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID from Step 1
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID from Step 2
+  searchRequest:
+    userProvided: true
+    description: Search criteria (free-text query, categories, tags, pagination)
+    example:
+      searchTerm: orders
+      limit: 25
+      offset: 0
+outputs:
+  - name: candidateAssets
+    path: $.assets[*]
+    labels: $.assets[*].name
+    description: Exchange assets available for publication in this portal
+  - name: candidateGroupId
+    path: $.assets[*].groupId
+    description: groupId of each candidate asset
+  - name: candidateAssetId
+    path: $.assets[*].assetId
+    description: assetId of each candidate asset
+```
+
+**What happens next:** Present candidates to the user and let them pick one or more assets to publish. Collect their `groupId`/`assetId` pairs for Step 4.
+
+## Step 4: Add Assets to the Portal
+
+Publish one or more selected Exchange assets to the portal.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+- Asset coordinates chosen in Step 3
+
+**Action:** Add assets to the portal catalog.
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: addAssetsToCommunity
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID from Step 1
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID from Step 2
+  assetsRequest:
+    userProvided: true
+    description: Array of Exchange asset references to publish (groupId + assetId, optional minorVersion filter)
+    example:
+      assets:
+        - groupId: f1e97bc6-315a-4490-82a7-23abe036327a
+          assetId: orders-api
+outputs:
+  - name: publishedAssetIds
+    path: $[*].assetId
+    description: The newly published asset IDs
+```
+
+**What happens next:** The assets are now visible in the portal catalog. By default all public minor versions become visible — Step 6 adjusts that.
+
+## Step 5: Inspect Visibility of a Published Asset
+
+Retrieve the current visibility state for each minor version of a published asset so the admin can decide which versions to hide or expose.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+- `groupId`, `assetId` of the asset to inspect
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getAllVersionsVisibilityByGA
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  groupId:
+    userProvided: true
+    description: Exchange groupId of the asset to inspect
+  assetId:
+    userProvided: true
+    description: Exchange assetId of the asset to inspect
+outputs:
+  - name: versionVisibilities
+    path: $.versions[*]
+    labels: $.versions[*].minorVersion
+    description: Per-minor-version visibility state (published, hidden, profile-restricted)
+```
+
+**What happens next:** Present the version list and let the admin toggle visibility per minor version in Step 6.
+
+## Step 6: Update Asset Visibility
+
+Update the visibility of specific minor versions (e.g., hide deprecated versions, restrict new versions to a specific user group).
+
+**What you'll need:**
+- `connectionId`, `portalId`, `groupId`, `assetId`
+- Visibility changes the admin chose in Step 5
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: updateCommunityAsset
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  groupId:
+    from:
+      variable: groupId
+    description: groupId from Step 5
+  assetId:
+    from:
+      variable: assetId
+    description: assetId from Step 5
+  visibilityUpdate:
+    userProvided: true
+    description: Per-minor-version visibility payload
+    example:
+      versions:
+        - minorVersion: "1.0"
+          visibility: PUBLISHED
+        - minorVersion: "2.0"
+          visibility: HIDDEN
+outputs:
+  - name: updatedAssetId
+    path: $.assetId
+    description: Confirmed assetId with new visibility applied
+```
+
+**What happens next:** Portal consumers now see only the minor versions you marked `PUBLISHED`.
+
+## Step 7: Remove Assets (Optional)
+
+Remove assets that should no longer be exposed — e.g., fully deprecated APIs.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+- List of `(groupId, assetId)` pairs to remove
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: removeAssetFromCommunity
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  removeRequest:
+    userProvided: true
+    description: Array of asset coordinates to unpublish
+    example:
+      assets:
+        - groupId: f1e97bc6-315a-4490-82a7-23abe036327a
+          assetId: legacy-orders-api
+outputs:
+  - name: removedAssetIds
+    path: $[*].assetId
+    description: Assets that were successfully removed from the portal
+```
+
+**What happens next:** Consumers no longer see the removed assets. Existing contracts against those assets remain intact but cannot be created anew.
+
+## Completion Checklist
+
+- [ ] Connection and portal selected
+- [ ] Candidate Exchange assets identified
+- [ ] Selected assets published to the portal
+- [ ] Minor-version visibility reviewed and adjusted
+- [ ] Deprecated/unwanted assets removed (if applicable)
+
+## What You've Built
+
+✅ **Curated Portal Catalog** — Only the assets and minor versions you intend are visible to portal consumers, matching your publishing strategy.
+
+## Next Steps
+
+1. **Search the published catalog** — Use `searchCommunityAssets` (management) to confirm the final list your portal consumers will see.
+2. **Manage portal members** — See the `manage-portal-members-and-prospects` skill to approve consumers who will browse the new assets.
+3. **Monitor consumer contracts** — Track contract creation through the consumer API to understand adoption of each newly published asset.
+
+## Related Jobs
+
+- **manage-portal-members-and-prospects** — Approve and manage who can see the curated catalog
+- **manage-portal-user-groups** — Define user groups used in version-level visibility restrictions

--- a/skills/discover-portal-apis/SKILL.md
+++ b/skills/discover-portal-apis/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: discover-portal-apis
+description: |
+  Discover APIs published in an API Experience Hub portal as a portal
+  consumer. Use when an end user needs to browse the catalog, search
+  assets by keyword or filter, open an API's detail page, read its terms
+  and conditions, or fetch rendered documentation pages and resources.
+---
+
+# Discover Portal APIs
+
+## Overview
+
+As a portal consumer (end user), you need to find the right API and understand what it does before requesting access. This workflow covers the discovery surface of an API Experience Hub (AEH) portal: listing and searching published assets, inspecting a specific asset's metadata, reading its terms of use, and fetching its documentation pages and downloadable resources.
+
+**What you'll build:** A short list of candidate APIs and the supporting docs you need to decide which one to request access to.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid portal-consumer Bearer token
+   - Membership in the portal (see `manage-portal-members-and-prospects` for the admin flow that grants this)
+
+2. **Portal context known**
+   - `targetOrganizationId` — the Anypoint organization hosting the portal
+   - `portalId` / `targetPortalId` — the specific portal you are browsing
+
+## Step 1: List Published Assets in the Portal
+
+Start with a broad browse of everything the portal publishes.
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: listAssetsCommunityAsset
+inputs:
+  targetOrganizationId:
+    userProvided: true
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    userProvided: true
+    description: Portal ID the user is browsing
+outputs:
+  - name: assets
+    path: $.assets[*]
+    labels: $.assets[*].name
+    description: Assets published in the portal
+  - name: groupId
+    path: $.assets[*].groupId
+    description: Exchange groupId of an asset, used by detail-level operations
+  - name: assetId
+    path: $.assets[*].assetId
+    description: Exchange assetId of an asset
+  - name: minorVersion
+    path: $.assets[*].minorVersion
+    description: Minor version visible to the consumer
+```
+
+## Step 2: Search for Specific Assets
+
+Narrow the list with a keyword, tag, category or asset-type filter.
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`
+- Search criteria
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: searchCommunityAssets
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    from:
+      variable: targetPortalId
+    description: Portal ID the user is browsing
+  searchRequest:
+    userProvided: true
+    description: Search criteria (free-text query, categories, tags, paging)
+    example:
+      searchTerm: orders
+      tags:
+        - v2
+      limit: 25
+      offset: 0
+outputs:
+  - name: matchingAssets
+    path: $.assets[*]
+    labels: $.assets[*].name
+    description: Assets matching the search query
+```
+
+## Step 3: Open an Asset's Detail Page
+
+Retrieve the full metadata of one asset — summary, description, contact info, classifier, all visible minor versions.
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`
+- `groupId`, `assetId`, `minorVersion` chosen from Step 1 or Step 2
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getAssetDetails
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    from:
+      variable: targetPortalId
+    description: Portal ID the user is browsing
+  groupId:
+    from:
+      variable: groupId
+    description: Exchange groupId of the asset
+  assetId:
+    from:
+      variable: assetId
+    description: Exchange assetId of the asset
+  minorVersion:
+    from:
+      variable: minorVersion
+    description: Minor version to open
+outputs:
+  - name: assetDetails
+    path: $
+    description: Full asset metadata, including instances and tiers available to request
+```
+
+## Step 4: Read Terms and Conditions
+
+Before requesting access, consumers should read the terms published for the asset.
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`, `groupId`, `assetId`, `minorVersion`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getTermsAndConditions
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    from:
+      variable: targetPortalId
+    description: Portal ID the user is browsing
+  groupId:
+    from:
+      variable: groupId
+    description: Exchange groupId of the asset
+  assetId:
+    from:
+      variable: assetId
+    description: Exchange assetId of the asset
+  minorVersion:
+    from:
+      variable: minorVersion
+    description: Minor version whose terms to fetch
+outputs:
+  - name: termsContent
+    path: $.content
+    description: Markdown/HTML content of the terms and conditions
+```
+
+## Step 5: Fetch Documentation Pages
+
+Each asset can publish multiple documentation pages (home, guides, changelog, etc.).
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`, `groupId`, `assetId`, `minorVersion`
+- Optional page path (the API uses a wildcard — pass the specific page path to fetch a single page)
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getAssetPages
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    from:
+      variable: targetPortalId
+    description: Portal ID the user is browsing
+  groupId:
+    from:
+      variable: groupId
+    description: Exchange groupId of the asset
+  assetId:
+    from:
+      variable: assetId
+    description: Exchange assetId of the asset
+  minorVersion:
+    from:
+      variable: minorVersion
+    description: Minor version to fetch pages for
+  pagePath:
+    userProvided: true
+    description: Optional documentation page path (leave empty to list all pages)
+outputs:
+  - name: pageContent
+    path: $
+    description: The requested documentation page (or list of pages)
+```
+
+## Step 6: Fetch Asset Resources (Optional)
+
+Download companion resources (diagrams, sample files, SDK bundles) attached to an asset.
+
+**What you'll need:**
+- `targetOrganizationId`, `targetPortalId`, `groupId`, `assetId`, `minorVersion`
+- `resourceId` obtained from the asset-details response in Step 3
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getAssetResource
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  targetPortalId:
+    from:
+      variable: targetPortalId
+    description: Portal ID the user is browsing
+  groupId:
+    from:
+      variable: groupId
+    description: Exchange groupId of the asset
+  assetId:
+    from:
+      variable: assetId
+    description: Exchange assetId of the asset
+  minorVersion:
+    from:
+      variable: minorVersion
+    description: Minor version to fetch the resource from
+  resourceId:
+    userProvided: true
+    description: Resource ID obtained from the asset detail response
+outputs:
+  - name: resourceContent
+    path: $
+    description: The binary/text resource content
+```
+
+## Completion Checklist
+
+- [ ] Portal catalog browsed or searched
+- [ ] Candidate asset identified
+- [ ] Full asset details reviewed
+- [ ] Terms and conditions read
+- [ ] Documentation pages consulted
+- [ ] Companion resources downloaded (if applicable)
+
+## What You've Built
+
+✅ **Informed API Choice** — You have the metadata, terms and docs you need to decide which API to request access to.
+
+## Next Steps
+
+1. **Request access** — See `request-api-access` to create a contract against the chosen instance and tier.
+2. **Manage your applications** — See `manage-portal-applications` to create the application identity that will consume the API.
+
+## Related Jobs
+
+- **request-api-access** — Create a contract between your app and the discovered API
+- **manage-portal-applications** — Manage the applications that hold API credentials

--- a/skills/manage-portal-applications/SKILL.md
+++ b/skills/manage-portal-applications/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: manage-portal-applications
+description: |
+  Manage the applications that hold API credentials inside an API Experience
+  Hub portal. Use when a portal consumer needs to list their applications,
+  check if a name is available, create a new application, update metadata,
+  rotate the client secret, or delete an application they no longer use.
+---
+
+# Manage Portal Applications
+
+## Overview
+
+Applications are the credential-bearing objects portal consumers use to call APIs. Each application has a `clientId` / `clientSecret` pair and can hold multiple contracts against published APIs. This workflow covers the application lifecycle from a portal-consumer perspective: inventory, name-availability check, create, update, secret rotation, and deletion.
+
+**What you'll build:** A clean application portfolio with the credentials you need to consume portal APIs.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid portal-consumer Bearer token
+   - Membership in the portal
+
+2. **Portal context known**
+   - `targetOrganizationId` — Anypoint organization hosting the portal
+   - `portalId` — the portal you are a member of
+
+## Step 1: List Your Applications
+
+Start by viewing the applications already registered under your portal membership.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getApplications
+inputs:
+  targetOrganizationId:
+    userProvided: true
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    userProvided: true
+    description: Portal ID the user belongs to
+outputs:
+  - name: applications
+    path: $.applications[*]
+    labels: $.applications[*].name
+    description: Your existing applications in this portal
+  - name: applicationId
+    path: $.applications[*].id
+    description: ID used by the per-application operations
+```
+
+## Step 2: Check Application-Name Availability
+
+Before creating a new application, confirm the desired name is not already taken in the portal.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`
+- Proposed application name
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: checkExistenceApplicationName
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  nameCheckRequest:
+    userProvided: true
+    description: The candidate application name to check for uniqueness
+    example:
+      name: orders-prod-client
+outputs:
+  - name: nameAvailable
+    path: $.available
+    description: Whether the proposed name is free to use
+```
+
+**What happens next:** If taken, pick a different name and re-check; if free, proceed to Step 3.
+
+## Step 3: Create a New Application
+
+Register a new application to obtain `clientId` / `clientSecret` credentials.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`
+- Application details (name, description, redirect URIs if OIDC/OAuth2)
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: createApplication
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  groupId:
+    userProvided: true
+    description: groupId of the asset to bind the application to (if required by portal policy)
+  assetId:
+    userProvided: true
+    description: assetId of the asset to bind the application to
+  minorVersion:
+    userProvided: true
+    description: minor version of the asset
+  applicationRequest:
+    userProvided: true
+    description: Application metadata and OAuth/OIDC settings
+    example:
+      name: orders-prod-client
+      description: Production client for the Orders API
+      redirectUris:
+        - https://app.example.com/callback
+outputs:
+  - name: createdApplicationId
+    path: $.id
+    description: The new application ID
+  - name: clientId
+    path: $.clientId
+    description: OAuth client ID issued to the application
+  - name: clientSecret
+    path: $.clientSecret
+    description: OAuth client secret (shown only at creation — store it securely)
+```
+
+**What happens next:** Capture the `clientSecret` now — it is not retrievable later; you must rotate via Step 5 if lost.
+
+## Step 4: Update Application Metadata
+
+Change an application's name, description, or OAuth redirect URIs after creation.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: updateApplication
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: ID of the application to update
+  applicationUpdate:
+    userProvided: true
+    description: Updated application metadata
+    example:
+      name: orders-prod-client
+      description: Production client for the Orders API (v2)
+      redirectUris:
+        - https://app.example.com/v2/callback
+outputs:
+  - name: updatedApplicationId
+    path: $.id
+    description: Confirmed ID of the updated application
+```
+
+## Step 5: Reset Client Secret
+
+Rotate the `clientSecret` — e.g., after a suspected leak or as part of key-rotation policy.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: resetClientSecretForApplication
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: ID of the application to rotate
+outputs:
+  - name: newClientSecret
+    path: $.clientSecret
+    description: Newly generated client secret (store it securely — only shown once)
+```
+
+**What happens next:** Update every consumer of this application to use the new secret. The previous secret is invalidated.
+
+## Step 6: View Application Details
+
+Inspect a single application's current state — metadata plus any derived info.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getApplicationDetailById
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: ID of the application to inspect
+outputs:
+  - name: applicationDetails
+    path: $
+    description: Current application metadata (clientId present; secret never returned)
+```
+
+## Step 7: Delete an Application (Optional)
+
+Remove an application that is no longer in use. All contracts bound to it are revoked.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: deleteApplication
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: ID of the application to delete
+outputs:
+  - name: deletedApplicationId
+    path: $.id
+    description: Confirmation of the deleted application
+```
+
+## Completion Checklist
+
+- [ ] Existing applications reviewed
+- [ ] Unique application name confirmed
+- [ ] New application created and secret captured
+- [ ] Metadata kept up to date (name, description, redirect URIs)
+- [ ] Secrets rotated on schedule or after incidents
+- [ ] Stale applications deleted
+
+## What You've Built
+
+✅ **Healthy Application Portfolio** — Active applications with fresh credentials, no stale clients lingering.
+
+## Next Steps
+
+1. **Request API access** — See `request-api-access` to create a contract from an application against a published API.
+2. **Monitor contracts** — See the contract-listing steps in `request-api-access` to audit which APIs each application consumes.
+
+## Related Jobs
+
+- **request-api-access** — Bind an application to an API via a contract
+- **discover-portal-apis** — Find APIs your application should request access to

--- a/skills/manage-portal-members-and-prospects/SKILL.md
+++ b/skills/manage-portal-members-and-prospects/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: manage-portal-members-and-prospects
+description: |
+  Manage the lifecycle of API Experience Hub portal members and prospects.
+  Use when an admin needs to approve or reject prospects (candidate users),
+  list active members, inspect and update a member's user-group assignments,
+  or disable a member. Covers the full join → approve → assign → disable flow.
+---
+
+# Manage Portal Members and Prospects
+
+## Overview
+
+Handles the membership lifecycle of an API Experience Hub (AEH) portal. Prospects are users who have requested access but are not yet portal members; members are active users with assigned user groups. This workflow lets portal administrators approve or reject prospects, audit the member list, adjust user-group assignments per member, and disable members who should no longer have access.
+
+**What you'll build:** A governed portal membership list with the right people assigned to the right user groups.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid Bearer token for Anypoint Platform
+   - **AEH Administrator** or **AEH Portal Administrator** permissions
+
+2. **Environment already bootstrapped**
+   - Connection and portal exist (use the AEH UI if not)
+   - At least one user group exists in the portal (see `manage-portal-user-groups`)
+
+## Step 1: List AEH Connections
+
+Retrieve the AEH connections the user has access to.
+
+**What you'll need:**
+- Bearer token
+
+**Action:** List connections and pick the one hosting the target portal.
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getConnections
+inputs: {}
+outputs:
+  - name: connectionId
+    path: $[*].id
+    labels: $[*].name
+    description: AEH connection ID (Salesforce org link) backing the portal
+```
+
+**What happens next:** The chosen `connectionId` scopes every subsequent call.
+
+## Step 2: List Portals on the Connection
+
+Pick the target portal whose membership you want to manage.
+
+**What you'll need:**
+- `connectionId` from Step 1
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getAllApiPortalByConnectionId
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID from Step 1
+outputs:
+  - name: portalId
+    path: $[*].id
+    labels: $[*].name
+    description: ID of the portal to manage
+```
+
+## Step 3: List Pending Prospects
+
+Retrieve the list of users who have requested access to the portal but are not yet members.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getProspects
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+outputs:
+  - name: prospects
+    path: $.prospects[*]
+    labels: $.prospects[*].email
+    description: Pending prospects awaiting admin decision
+  - name: prospectId
+    path: $.prospects[*].id
+    description: Prospect ID used by the approve/reject operations
+```
+
+**What happens next:** Present the prospect list and let the admin choose who to approve or reject.
+
+## Step 4: Approve a Prospect
+
+Promote a prospect to an active portal member and assign them to one or more user groups. Repeat per prospect the admin wants to approve.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `prospectId`
+- User-group IDs to assign (discover via `manage-portal-user-groups` Step "List User Groups")
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: approveProspect
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  prospectId:
+    from:
+      variable: prospectId
+    description: The prospect being approved
+  approvalRequest:
+    userProvided: true
+    description: User groups to assign to the new member on approval
+    example:
+      userGroups:
+        - id: 00G1a000000abcD
+outputs:
+  - name: approvedUserId
+    path: $.userId
+    description: The user ID of the newly approved member
+```
+
+**What happens next:** The prospect is now a portal member with the chosen group assignments.
+
+## Step 5: Reject a Prospect (Optional)
+
+Reject prospects who should not be granted access.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `prospectId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: rejectProspect
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  prospectId:
+    from:
+      variable: prospectId
+    description: The prospect being rejected
+outputs:
+  - name: rejectedProspectId
+    path: $.id
+    description: The rejected prospect's ID (for audit)
+```
+
+**What happens next:** The prospect is removed from the queue. They can re-request access later.
+
+## Step 6: List Portal Members
+
+Retrieve active portal members to audit who currently has access.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getCommunityUsers
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+outputs:
+  - name: members
+    path: $.users[*]
+    labels: $.users[*].email
+    description: Active portal members
+  - name: userId
+    path: $.users[*].id
+    description: Portal-member user ID used by per-member operations
+```
+
+## Step 7: Inspect a Member's User-Group Assignments
+
+Fetch the specific group assignments of one member.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `userId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getCommunityUser
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  userId:
+    from:
+      variable: userId
+    description: Portal-member user ID
+outputs:
+  - name: memberUserGroups
+    path: $.userGroups[*]
+    labels: $.userGroups[*].name
+    description: Current user groups assigned to the member
+```
+
+**What happens next:** Present the current assignments; let the admin decide new memberships for Step 8.
+
+## Step 8: Update a Member's User-Group Assignments
+
+Replace or extend the user groups assigned to a specific member.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `userId`
+- Target user-group IDs
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: addGroupMappingToUser
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  targetUserId:
+    from:
+      variable: userId
+    description: Portal-member user ID
+  userGroupsRequest:
+    userProvided: true
+    description: Full replacement set of user groups for this member
+    example:
+      userGroups:
+        - id: 00G1a000000abcD
+        - id: 00G1a000000efgH
+outputs:
+  - name: updatedUserId
+    path: $.userId
+    description: Confirmed member ID with new assignments applied
+```
+
+**What happens next:** The member now has exactly the user groups you specified.
+
+## Step 9: Disable a Portal Member (Optional)
+
+Revoke a member's access without deleting their record — useful for offboarding.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `targetUserId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: disableCommunityUser
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  targetUserId:
+    from:
+      variable: userId
+    description: The member to disable
+outputs:
+  - name: disabledUserId
+    path: $.userId
+    description: Confirmed disabled member ID
+```
+
+**What happens next:** The disabled member can no longer sign in to the portal. Their API contracts remain intact for audit.
+
+## Completion Checklist
+
+- [ ] Connection and portal selected
+- [ ] Pending prospects reviewed
+- [ ] Approved prospects assigned to correct user groups
+- [ ] Unwanted prospects rejected
+- [ ] Existing members' group assignments audited
+- [ ] Offboarded members disabled (if applicable)
+
+## What You've Built
+
+✅ **Governed Portal Membership** — Prospects are triaged and approved members have the right user-group entitlements.
+
+## Next Steps
+
+1. **Manage user groups themselves** — See `manage-portal-user-groups` to define the groups referenced here.
+2. **Curate the visible catalog** — See `curate-portal-assets` to control which APIs members see.
+3. **Monitor contracts** — Track which approved members create consumer contracts against published APIs.
+
+## Related Jobs
+
+- **curate-portal-assets** — Control which APIs and minor versions portal members see
+- **manage-portal-user-groups** — Define and maintain the user groups assigned here

--- a/skills/manage-portal-user-groups/SKILL.md
+++ b/skills/manage-portal-user-groups/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: manage-portal-user-groups
+description: |
+  Manage the user groups that gate access to APIs and content inside an API
+  Experience Hub portal. Use when an admin needs to list, create, update, or
+  delete user groups, or to manage group mappings (links between external
+  identity-provider groups and AEH user groups). These groups are the unit
+  used for per-version asset visibility and member assignments.
+---
+
+# Manage Portal User Groups
+
+## Overview
+
+User groups are the authorization primitive inside an API Experience Hub (AEH) portal. They control which members can see which APIs/minor versions, and they can be mapped to groups coming from a federated identity provider (IdP) so membership is synchronized automatically at login. This workflow covers the full user-group lifecycle and their IdP mappings.
+
+**What you'll build:** A clean, well-scoped set of user groups (and IdP mappings) that AEH can use for asset visibility and member permissioning.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid Bearer token for Anypoint Platform
+   - **AEH Administrator** or **AEH Portal Administrator** permissions
+
+2. **Environment already bootstrapped**
+   - Connection and portal already created
+   - Optional: an IdP configured on the portal (needed only for group mappings)
+
+## Step 1: List AEH Connections
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getConnections
+inputs: {}
+outputs:
+  - name: connectionId
+    path: $[*].id
+    labels: $[*].name
+    description: AEH connection ID backing the portal
+```
+
+## Step 2: List Portals on the Connection
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getAllApiPortalByConnectionId
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID from Step 1
+outputs:
+  - name: portalId
+    path: $[*].id
+    labels: $[*].name
+    description: ID of the portal whose user groups you'll manage
+```
+
+## Step 3: List User Groups (Profiles)
+
+Retrieve the existing user groups on the portal so the admin can decide whether to create, update, or delete them.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getAllProfilesByPortal
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+outputs:
+  - name: userGroups
+    path: $.profiles[*]
+    labels: $.profiles[*].name
+    description: Existing user groups (profiles) on the portal
+  - name: userGroupId
+    path: $.profiles[*].id
+    description: ID of a specific user group, used by update/delete
+```
+
+**What happens next:** Present the list and let the admin pick the next action (create/update/delete or manage mappings).
+
+## Step 4: Create a New User Group
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: createUserGroup
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  userGroupRequest:
+    userProvided: true
+    description: Definition of the new user group
+    example:
+      name: Gold Tier Consumers
+      description: Members granted access to premium APIs
+outputs:
+  - name: createdUserGroupId
+    path: $.id
+    description: The newly created user group ID
+```
+
+**What happens next:** The new group is available for asset visibility rules and member assignments.
+
+## Step 5: Update an Existing User Group
+
+Rename or change the description of a group. The group membership itself is updated via `manage-portal-members-and-prospects`.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `userGroupId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: updateUserGroup
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  userGroupId:
+    from:
+      variable: userGroupId
+    description: ID of the user group to update
+  userGroupRequest:
+    userProvided: true
+    description: Updated name/description for the user group
+    example:
+      name: Gold Tier Consumers (EU)
+      description: Members granted access to premium EU-region APIs
+outputs:
+  - name: updatedUserGroupId
+    path: $.id
+    description: Confirmed ID of the updated user group
+```
+
+## Step 6: Delete a User Group (Optional)
+
+Remove a user group that is no longer needed. Verify no members or visibility rules depend on it first.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `userGroupId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: deleteUserGroup
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  userGroupId:
+    from:
+      variable: userGroupId
+    description: ID of the user group to delete
+outputs:
+  - name: deletedUserGroupId
+    path: $.id
+    description: Confirmation of the deleted user group
+```
+
+**What happens next:** The group is gone; any visibility rules or member assignments that referenced it need to be revisited.
+
+## Step 7: List Group Mappings
+
+Group mappings link a federated IdP group (SAML / OIDC) to an AEH user group so membership syncs at login.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: getGroupMappings
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+outputs:
+  - name: groupMappings
+    path: $.mappings[*]
+    labels: $.mappings[*].idpGroupName
+    description: Existing IdP-to-AEH group mappings
+  - name: groupMappingId
+    path: $.mappings[*].id
+    description: ID used to delete a mapping
+```
+
+## Step 8: Create a Group Mapping
+
+Link an IdP group to an AEH user group.
+
+**What you'll need:**
+- `connectionId`, `portalId`
+- The AEH `userGroupId` (from Step 3) and the IdP group identifier
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: addAdditionalGroupMapping
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  mappingRequest:
+    userProvided: true
+    description: Mapping between an external IdP group and an AEH user group
+    example:
+      idpGroupName: "gold-tier-consumers"
+      userGroupId: 00G1a000000abcD
+outputs:
+  - name: createdGroupMappingId
+    path: $.id
+    description: The newly created mapping ID
+```
+
+**What happens next:** Users who log in via the IdP and belong to the mapped IdP group are automatically placed into the AEH user group.
+
+## Step 9: Delete a Group Mapping (Optional)
+
+Remove a stale mapping — e.g., when the IdP group has been renamed or retired.
+
+**What you'll need:**
+- `connectionId`, `portalId`, `groupMappingId`
+
+```yaml
+api: urn:api:api-experience-hub-management
+operationId: deleteGroupMappings
+inputs:
+  connectionId:
+    from:
+      variable: connectionId
+    description: Connection ID
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  groupMappingId:
+    from:
+      variable: groupMappingId
+    description: ID of the mapping to remove
+outputs:
+  - name: deletedGroupMappingId
+    path: $.id
+    description: Confirmation of the removed mapping
+```
+
+## Completion Checklist
+
+- [ ] Connection and portal selected
+- [ ] Existing user groups inventoried
+- [ ] New user groups created as required
+- [ ] Outdated user groups renamed or deleted
+- [ ] IdP group mappings reviewed and updated
+
+## What You've Built
+
+✅ **Governed User-Group Model** — A set of well-named user groups and IdP mappings that cleanly drive asset visibility and member permissioning.
+
+## Next Steps
+
+1. **Restrict asset visibility** — See `curate-portal-assets` Step 6 to hide or expose specific minor versions per user group.
+2. **Assign members** — See `manage-portal-members-and-prospects` to place portal members into the correct groups.
+
+## Related Jobs
+
+- **curate-portal-assets** — Apply these user groups to asset-visibility decisions
+- **manage-portal-members-and-prospects** — Assign portal members into these user groups

--- a/skills/request-api-access/SKILL.md
+++ b/skills/request-api-access/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: request-api-access
+description: |
+  Request access to a published API in an API Experience Hub portal by
+  creating a contract between one of your applications and a specific API
+  instance/tier. Use when a portal consumer needs to discover available
+  tiers and grant types, create a contract, review existing contracts,
+  or change an SLA tier on an active contract.
+---
+
+# Request API Access
+
+## Overview
+
+In AEH, "access" to an API is granted via a **contract**: a binding between one of your applications and a specific API instance (e.g., sandbox/production) under a chosen SLA tier. This workflow covers the full consumer-side request flow: discovering the tiers and grant types offered, creating a contract, listing your contracts, and adjusting the SLA tier later.
+
+**What you'll build:** Active contracts between your applications and the APIs you need, on the right SLA tiers.
+
+## Prerequisites
+
+Before starting, ensure:
+
+1. **Authentication ready**
+   - Valid portal-consumer Bearer token
+   - Membership in the portal
+
+2. **Portal and application context**
+   - `targetOrganizationId`, `portalId`
+   - An existing `applicationId` (see `manage-portal-applications` to create one)
+   - Target asset coordinates: `groupId`, `assetId`, `minorVersion`, `instanceId` (see `discover-portal-apis` Step 3)
+
+## Step 1: List Available SLA Tiers for an Instance
+
+Tiers define throughput/quota limits and governance rules for an API instance. Some instances require a tier selection; others default to an implicit tier.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`
+- `groupId`, `assetId`, `minorVersion`, `instanceId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getTiers
+inputs:
+  targetOrganizationId:
+    userProvided: true
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    userProvided: true
+    description: Portal ID the user belongs to
+  groupId:
+    userProvided: true
+    description: Exchange groupId of the target asset
+  assetId:
+    userProvided: true
+    description: Exchange assetId of the target asset
+  minorVersion:
+    userProvided: true
+    description: Minor version the consumer wants access to
+  instanceId:
+    userProvided: true
+    description: API instance ID (environment) to contract against
+outputs:
+  - name: tiers
+    path: $.tiers[*]
+    labels: $.tiers[*].name
+    description: SLA tiers offered on this instance
+  - name: tierId
+    path: $.tiers[*].id
+    description: Tier ID passed to the create-contract call
+```
+
+## Step 2: List Grant Types Offered by the API Instance
+
+Grant types (`client_credentials`, `authorization_code`, etc.) describe how your application will obtain tokens. Some APIs require that at least one grant type matches between API and application.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `instanceId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getGrantTypesByInstanceId
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  instanceId:
+    from:
+      variable: instanceId
+    description: API instance ID
+outputs:
+  - name: instanceGrantTypes
+    path: $.grantTypes[*]
+    description: Grant types the instance supports
+```
+
+## Step 3: List Grant Types Supported by Your Application
+
+Cross-check your application's supported grant types against the instance's.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getGrantTypesByApplicationId
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    userProvided: true
+    description: ID of the application that will hold the contract
+outputs:
+  - name: applicationGrantTypes
+    path: $.grantTypes[*]
+    description: Grant types the application can use
+```
+
+**What happens next:** Confirm at least one grant type overlaps between Step 2 and Step 3 before creating the contract.
+
+## Step 4: Create a Contract
+
+Bind the application to the API instance under the chosen tier.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`
+- `groupId`, `assetId`, `minorVersion`
+- `applicationId`, optional `tierId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: createContract
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  groupId:
+    from:
+      variable: groupId
+    description: Exchange groupId of the target asset
+  assetId:
+    from:
+      variable: assetId
+    description: Exchange assetId of the target asset
+  minorVersion:
+    from:
+      variable: minorVersion
+    description: Minor version for the contract
+  contractRequest:
+    userProvided: true
+    description: Contract payload (application, tier, optional custom fields)
+    example:
+      applicationId: a1b2c3d4-0000-0000-0000-000000000000
+      tierId: 12345
+      acceptedTerms: true
+outputs:
+  - name: contractId
+    path: $.id
+    description: The newly created contract ID (may be PENDING until approved)
+  - name: contractStatus
+    path: $.status
+    description: Current status — typically APPROVED or PENDING
+```
+
+**What happens next:** If the API requires admin approval, the contract is `PENDING`. Otherwise it is immediately `APPROVED` and the application can call the API.
+
+## Step 5: List Contracts for an Application
+
+Audit which APIs a specific application currently has (or has requested) access to.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getContractsByApplicationId
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: Application to audit
+outputs:
+  - name: applicationContracts
+    path: $.contracts[*]
+    labels: $.contracts[*].assetName
+    description: Contracts held by this application
+  - name: contractIds
+    path: $.contracts[*].id
+    description: Contract IDs for deeper inspection
+```
+
+## Step 6: Get Contract Details
+
+Retrieve the full state of one contract — useful to verify status, tier, and SLA usage.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`, `contractId`
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: getContract
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: Application holding the contract
+  contractId:
+    from:
+      variable: contractIds
+    description: Specific contract ID
+outputs:
+  - name: contractDetails
+    path: $
+    description: Full contract details (status, tier, associated asset/instance)
+```
+
+## Step 7: Change the SLA Tier on an Active Contract
+
+Upgrade or downgrade the SLA tier — e.g., from Bronze to Gold as consumption grows.
+
+**What you'll need:**
+- `targetOrganizationId`, `portalId`, `applicationId`, `contractId`
+- New `tierId` chosen from Step 1
+
+```yaml
+api: urn:api:api-experience-hub-consumer
+operationId: assignSlaTierToContract
+inputs:
+  targetOrganizationId:
+    from:
+      variable: targetOrganizationId
+    description: Anypoint organization ID hosting the portal
+  portalId:
+    from:
+      variable: portalId
+    description: Portal ID
+  applicationId:
+    from:
+      variable: applicationId
+    description: Application holding the contract
+  contractId:
+    from:
+      variable: contractIds
+    description: Contract whose tier is changing
+  tierId:
+    from:
+      variable: tierId
+    description: New SLA tier ID
+outputs:
+  - name: updatedContractId
+    path: $.id
+    description: Contract ID confirmed with the new tier applied
+```
+
+**What happens next:** Depending on portal policy, the new tier may apply immediately or wait for admin approval.
+
+## Completion Checklist
+
+- [ ] Available tiers reviewed
+- [ ] Grant types cross-checked between application and instance
+- [ ] Contract created
+- [ ] Contract status verified (APPROVED vs PENDING)
+- [ ] Existing contracts for the application audited
+- [ ] SLA tier adjusted when consumption changes
+
+## What You've Built
+
+✅ **Active Contract(s)** — Your applications are bound to the APIs you need on the correct SLA tiers, with grant types that match.
+
+## Next Steps
+
+1. **Call the API** — Use the application's `clientId` / `clientSecret` (from `manage-portal-applications`) to obtain tokens per the chosen grant type.
+2. **Monitor usage** — Track quota/throughput against the chosen tier; upgrade via Step 7 when you hit limits.
+
+## Related Jobs
+
+- **discover-portal-apis** — Find the asset, instance and tiers to request
+- **manage-portal-applications** — Manage the applications that hold contracts


### PR DESCRIPTION
## Summary

  Adds the **API Experience Hub Consumer** and **Management** APIs with their JTBD skills, and along the way fixes two portal-generator rendering bugs that left request/response bodies empty for any spec that uses idiomatic OAS internal `$ref`s.

  ### New specs
  - `apis/api-experience-hub-consumer/api.yaml` (21 operations) — asset discovery, application management, request access
  - `apis/api-experience-hub-management/api.yaml` (25 operations) — connections/portals, asset curation, members & prospects, user groups
  - Both specs pass governance with zero violations: `info.description` rewritten in imperative voice, full `x-origin` annotations on every path parameter (cross-API where needed).

  ### New skills
  Six JTBDs that reference the new APIs via `urn:api:`:
  - `discover-portal-apis`
  - `request-api-access`
  - `manage-portal-applications`
  - `curate-portal-assets`
  - `manage-portal-members-and-prospects`
  - `manage-portal-user-groups`

  ### Portal generator fixes

  While building these specs we hit two latent bugs that affected every API in the repo using internal `$ref`s:

  1. **Internal `$ref` resolution** (`oas_parser.py`) — `resolve_schema` previously returned schemas of the form `{$ref: "#/components/schemas/X"}` unchanged because the parser didn't thread the `components` dict through. Now it does, and request/response field tables render
  for any spec using OAS-idiomatic refs.
  2. **Array-bodies render with expandable items** (`oas_parser.py` + `schema_table.html`) — top-level `array` schemas (e.g. `addAssetsToCommunity`, `removeAssetFromCommunity`) now render a synthetic `items` row whose children are the resolved item-schema's properties; inline
  list examples are now serialized; nested-property toggle ids are scoped by `operationId` to fix a latent collision class that broke the expand button when more than one operation on a page used the same property name.

  ## Test plan

  - [x] Pass 1 (basic OAS) and Pass 2 (governance ruleset) both clean for both specs
  - [x] `validate_xorigin.py` cross-checks every `x-origin` operation reference across all 36 APIs — no violations
  - [x] `validate_jtbd.py` validates the six new skill files
  - [x] `make test-portal` — **315 passed** (+14 new tests covering internal-ref resolution, array-body rendering, inline-list examples, and nested-id scoping)
  - [x] Regenerated portal locally and verified:
    - `createUserGroup` body shows `name`/`description`/`parentUserGroupId`
    - `addAssetsToCommunity` / `removeAssetFromCommunity` show expandable `items` row with `assetId` / `groupId` and inline list example
    - Items toggle works on every operation (no duplicate `id="items-1"` on the page)
  - [ ] Reviewer to spot-check a couple of x-origin source operations on the portal — particularly `targetOrganizationId` (resolves via `getConnections` → external SF org id, not Anypoint org) and `idpId` (resolves via `access-management.getIdentityProviders`)