### PR TITLE
@W-22342183 darkmode not enabled yet

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -8255,6 +8255,10 @@ function clearAllVariables(slug) {
 // ============================================================================
 
 (function initDarkMode() {
+    // Only show toggle when ?darkmode=true is present (feature in development)
+    var params = new URLSearchParams(window.location.search);
+    if (params.get('darkmode') !== 'true') return;
+
     // Restore saved theme immediately to prevent flash
     var savedTheme = localStorage.getItem('theme');
     if (savedTheme === 'dark') {


### PR DESCRIPTION
Restore the query param guard in portal.js that was lost during the last merge. The base.html head script already had it; this brings portal.js back in sync so the toggle is hidden unless ?darkmode=true is in the URL.