### PR TITLE
Fix release-skills workflow and package name typo

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -7,14 +7,13 @@ on:
     paths: ['skills/mule-development/*']
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write # Required for OIDC authentication (npm trusted publishing)
-
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC authentication (npm trusted publishing)
     defaults:
       run:
         working-directory: skills/mule-development

--- a/skills/mule-development/package-lock.json
+++ b/skills/mule-development/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@saleseforce/mulesoft-vibes-skills",
-  "version": "1.0.0",
+  "name": "@salesforce/mulesoft-vibes-skills",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@saleseforce/mulesoft-vibes-skills",
-      "version": "1.0.0",
+      "name": "@salesforce/mulesoft-vibes-skills",
+      "version": "1.0.1",
       "license": "SEE LICENSE IN LICENSE.txt"
     }
   }

--- a/skills/mule-development/package.json
+++ b/skills/mule-development/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saleseforce/mulesoft-vibes-skills",
+  "name": "@salesforce/mulesoft-vibes-skills",
   "version": "1.0.1",
   "description": "MuleSoft DX skills to enhance Mule developement",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
## Summary
- Move `id-token: write` permission to the job level in `.github/workflows/release-skills.yml` so npm provenance can mint an OIDC token at publish time. The previous run failed with `EUSAGE: Provenance generation in GitHub Actions requires "write" access to the "id-token" permission` even though the permission was set at the workflow level — declaring it on the job is the reliable form.
  - based from https://github.com/forcedotcom/sf-pack/pull/72/changes 
- Correct the package name from `@saleseforce/mulesoft-vibes-skills` to `@salesforce/mulesoft-vibes-skills` in `skills/mule-development/package.json` and `package-lock.json`.

## Test plan
- [ ] Re-run the `release-skills` workflow (via `workflow_dispatch` or by merging a change under `skills/mule-development/`) and confirm `npm publish --provenance=true` succeeds.
- [ ] Confirm the published artifact appears under `@salesforce/mulesoft-vibes-skills` on npm.