### PR TITLE
Trigger release-skills on push to master, not pull_request closed

### DIFF
--- a/.github/workflows/release-skills.yml
+++ b/.github/workflows/release-skills.yml
@@ -1,15 +1,13 @@
 name: release-skills
 
 on:
-  pull_request:
+  push:
     branches: [master]
-    types: [closed]
-    paths: ['skills/mule-development/*']
+    paths: ['skills/mule-development/**']
   workflow_dispatch:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Switch the `release-skills` workflow from `pull_request: types: [closed]` to `push: branches: [master]` so it can mint an OIDC token for npm provenance.

## Why the previous fix wasn't enough
GitHub forces `GITHUB_TOKEN` to read-only on `pull_request` events that originate from forks, as a security policy — and it strips elevated permissions like `id-token: write` regardless of what the workflow declares. Both prior failing runs (PR #49 and PR #63) came from a fork, so the workflow setup log shows:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
```

No `id-token` line at all, which is why `npm publish --provenance=true` failed with `EUSAGE: Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`.

The `push` event fires after the merge commit lands on `mulesoft/mulesoft-dx:master`, runs in the parent repo's trusted context, and gets the full permissions the workflow asks for.

## Other small cleanups
- Widen path glob from `skills/mule-development/*` to `skills/mule-development/**` so nested files (most of the package) actually trigger the workflow.
- Drop the now-redundant `if: github.event.pull_request.merged == true || ...` guard — `push` fires once on the merged commit, and the path filter handles "only when relevant files change".

## Test plan
- [ ] After merge, confirm the `release-skills` workflow runs from the `push` event.
- [ ] Confirm the workflow setup log now shows `Id-token: write` under `GITHUB_TOKEN Permissions`.
- [ ] Confirm `npm publish --provenance=true` succeeds and `@salesforce/mulesoft-vibes-skills@<next>` appears on the npm registry with provenance.
- [ ] Confirm `workflow_dispatch` still works for manual reruns.