### PR TITLE
@W-22342183 Add MuleSoft favicon to portal pages

### DIFF
--- a/scripts/portal_generator/templates/base.html
+++ b/scripts/portal_generator/templates/base.html
@@ -22,6 +22,7 @@
     <link rel="help" href="{{ base_url|default('') }}/AGENTS.md" title="Agent Guide">
     <link rel="help" type="text/plain" href="{{ base_url|default('') }}/llms.txt" title="LLM Discovery (llmstxt.org)">
     <meta name="robots" content="index, follow">
+    <link rel="icon" type="image/x-icon" href="https://www.mulesoft.com/c/public/exp/app/favicon.ico">
     <title>{% block title %}Anypoint Platform APIs{% endblock %}</title>
     {% if chrome and chrome.dependencies %}
     {{ chrome.dependencies|safe }}


### PR DESCRIPTION
Use the absolute URL to www.mulesoft.com favicon so it works when the portal is hosted on a different domain.