### PR TITLE
Add repository field to mulesoft-vibes-skills package.json

### DIFF
--- a/skills/mule-development/package.json
+++ b/skills/mule-development/package.json
@@ -13,7 +13,12 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "homepage": "https://github.com/mulesoft/mulesoft-dx/tree/master/skills/mule-developement",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mulesoft/mulesoft-dx.git",
+    "directory": "skills/mule-development"
+  },
+  "homepage": "https://github.com/mulesoft/mulesoft-dx/tree/master/skills/mule-development",
   "keywords": [
     "mulesoft",
     "mule",


### PR DESCRIPTION
## Summary
- Add a `repository` field to `skills/mule-development/package.json` so the URL matches the source repo recorded in the npm provenance attestation.

## Why
The previous run (after PR #64 fixed the `id-token` permission) successfully minted a sigstore provenance bundle pointing at `github.com/mulesoft/mulesoft-dx`, but `npm publish` then rejected the upload:

```
E422 Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "", expected
to match "https://github.com/mulesoft/mulesoft-dx" from provenance
```

npm requires `package.json.repository.url` to match the provenance source. Adding the field with the canonical URL satisfies the check. The `directory` subkey points at the monorepo subpath so `npm view` can show the right "View Source" link.

## Test plan
- [ ] After merge, the `release-skills` workflow fires on the `push` event (path filter `skills/mule-development/**` matches).
- [ ] `npm publish --provenance=true` succeeds and `@salesforce/mulesoft-vibes-skills@1.0.1` appears on the npm registry with provenance.
- [ ] `npm view @salesforce/mulesoft-vibes-skills repository` returns the `mulesoft/mulesoft-dx` URL.