### PR TITLE
Fix typo in @salesforce/mulesoft-vibes-skills package name 

### DIFF
--- a/skills/mule-development/package.json
+++ b/skills/mule-development/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saleseforce/mulesoft-vibes-skills",
+  "name": "@salesforce/mulesoft-vibes-skills",
   "version": "1.0.2",
   "description": "MuleSoft DX skills to enhance Mule developement",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
- Fixes typo in skills/mule-development/package.json: @saleseforce → @salesforce introduced in https://github.com/mulesoft/mulesoft-dx/pull/61