### PR TITLE
@W-22456748 add manage-flex-gateway-policy-project skill

### DIFF
--- a/skills/mule-development/CHANGELOG.md
+++ b/skills/mule-development/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@salesforce/mulesoft-vibes-skills` are documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-05-18
+
+### Added
+
+- **`manage-flex-gateway-policy-project`** — new skill that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisite checks, `anypoint-cli-v4 pdk policy-project create`, `make setup` / `build-asset-files` / `build` / `publish` / `release`, plus an upgrade-PDK runbook and troubleshooting for the most common toolchain failure modes. Lets agents take a developer from "I want a custom policy" through to a released Exchange asset without leaving the IDE.
+
 ## [1.0.3] - 2026-05-14
 
 ### Changed

--- a/skills/mule-development/CHANGELOG.md
+++ b/skills/mule-development/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **`manage-flex-gateway-policy-project`** — new skill that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisite checks, `anypoint-cli-v4 pdk policy-project create`, `make setup` / `build-asset-files` / `build`, local execution via the scaffolded `playground/` (`make run` against a Dockerized Flex Gateway in local-disconnected mode), then `make publish` and `make release` to Anypoint Exchange. Includes an upgrade-PDK runbook and troubleshooting for the most common toolchain failure modes. Lets agents take a developer from "I want a custom policy" through to a released Exchange asset without leaving the IDE.
+- **`develop-pdk-policy`** — new skill that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisite checks, `anypoint-cli-v4 pdk policy-project create`, `make setup` / `build-asset-files` / `build`, local execution via the scaffolded `playground/` (`make run` against a Dockerized Flex Gateway in local-disconnected mode), then `make publish` and `make release` to Anypoint Exchange. Includes an upgrade-PDK runbook and troubleshooting for the most common toolchain failure modes. Lets agents take a developer from "I want a custom policy" through to a released Exchange asset without leaving the IDE.
 
 ## [1.0.3] - 2026-05-14
 

--- a/skills/mule-development/CHANGELOG.md
+++ b/skills/mule-development/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **`manage-flex-gateway-policy-project`** — new skill that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisite checks, `anypoint-cli-v4 pdk policy-project create`, `make setup` / `build-asset-files` / `build` / `publish` / `release`, plus an upgrade-PDK runbook and troubleshooting for the most common toolchain failure modes. Lets agents take a developer from "I want a custom policy" through to a released Exchange asset without leaving the IDE.
+- **`manage-flex-gateway-policy-project`** — new skill that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisite checks, `anypoint-cli-v4 pdk policy-project create`, `make setup` / `build-asset-files` / `build`, local execution via the scaffolded `playground/` (`make run` against a Dockerized Flex Gateway in local-disconnected mode), then `make publish` and `make release` to Anypoint Exchange. Includes an upgrade-PDK runbook and troubleshooting for the most common toolchain failure modes. Lets agents take a developer from "I want a custom policy" through to a released Exchange asset without leaving the IDE.
 
 ## [1.0.3] - 2026-05-14
 

--- a/skills/mule-development/develop-pdk-policy/SKILL.md
+++ b/skills/mule-development/develop-pdk-policy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: manage-flex-gateway-policy-project
+name: develop-pdk-policy
 description: Drive the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK) — verify prerequisites, scaffold the project, edit the gcl.yaml schema, build the WebAssembly artifact, exercise it locally with the Docker playground, then publish a dev version and cut a release to Anypoint Exchange. Use this skill whenever the user mentions PDK, Flex Gateway custom policies, `anypoint-cli-v4 pdk`, `cargo anypoint`, `make build` / `make publish` / `make release`, the `wasm32-wasip1` target, or asks to "create a custom policy", "scaffold a PDK project", "build a Flex Gateway policy", "publish a policy to Exchange", "test my policy locally", "upgrade PDK", or troubleshoots a PDK build / publish / release failure — even if they don't use the word "PDK" explicitly.
 license: Apache-2.0
 compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, `make`, and Docker (for the local playground in Step 7). Assumes `wasm32-wasip1` target is installed.

--- a/skills/mule-development/develop-pdk-policy/SKILL.md
+++ b/skills/mule-development/develop-pdk-policy/SKILL.md
@@ -123,9 +123,7 @@ make build-asset-files
 
 This regenerates `src/generated/config.rs` so the policy's Rust code can reference the configuration as typed structs. **Do not hand-edit `src/generated/`** — it gets overwritten on every `build-asset-files` run.
 
-The developer's actual policy logic lives in `src/lib.rs` (the entry point) and any helper modules they add — that's design work outside this skill's scope. If the developer asks for examples of common patterns (header manipulation, JWT validation, HTTP calls, rate limiting, etc.), point them at the public examples repo: https://github.com/mulesoft/pdk-examples.
-
-> **Note:** A dedicated PDK examples skill is being tracked in [W-22456751](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Zt4fKYAR/view) and will surface these patterns directly through Claude. Until that lands, the public repo is the canonical source.
+The developer's actual policy logic lives in `src/lib.rs` (the entry point) and any helper modules they add — that's design work outside this skill's scope.
 
 ## Step 6: Build the Policy
 
@@ -299,7 +297,7 @@ If traffic still hits the old behavior after both steps, confirm in Runtime Mana
 - **PDK prerequisites:** https://docs.mulesoft.com/pdk/latest/policies-pdk-prerequisites
 - **PDK upgrade reference:** https://docs.mulesoft.com/pdk/latest/policies-pdk-upgrade-pdk
 - **PDK overview:** https://docs.mulesoft.com/pdk/latest/
-- **Public examples:** https://github.com/mulesoft/pdk-examples
+- **Custom policy examples (docs):** https://docs.mulesoft.com/pdk/latest/policies-pdk-policy-templates
 
 ---
 

--- a/skills/mule-development/develop-pdk-policy/SKILL.md
+++ b/skills/mule-development/develop-pdk-policy/SKILL.md
@@ -2,7 +2,7 @@
 name: develop-pdk-policy
 description: Drive the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK) — verify prerequisites, scaffold the project, edit the gcl.yaml schema, build the WebAssembly artifact, exercise it locally with the Docker playground, then publish a dev version and cut a release to Anypoint Exchange. Use this skill whenever the user mentions PDK, Flex Gateway custom policies, `anypoint-cli-v4 pdk`, `cargo anypoint`, `make build` / `make publish` / `make release`, the `wasm32-wasip1` target, or asks to "create a custom policy", "scaffold a PDK project", "build a Flex Gateway policy", "publish a policy to Exchange", "test my policy locally", "upgrade PDK", or troubleshoots a PDK build / publish / release failure — even if they don't use the word "PDK" explicitly.
 license: Apache-2.0
-compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, `make`, and Docker (for the local playground in Step 7). Assumes `wasm32-wasip1` target is installed.
+compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.8.0+) installed, Rust toolchain (rustc + cargo), `make`, and Docker (for the local playground in Step 7). Assumes `wasm32-wasip1` target is installed. `cargo-anypoint` is installed automatically by `make setup` in Step 4 — it is not a manual prerequisite.
 metadata:
   author: mule-dx-tooling
   version: "1.0.0"
@@ -27,22 +27,21 @@ anypoint-cli-v4 --version
 anypoint-cli-v4 plugins
 ```
 
-The plugin list must include `anypoint-pdk-plugin`. If you see the older `anypoint-cli-pdk-plugin` (PDK < 1.7.0), tell the user to upgrade:
+The plugin list must include `anypoint-pdk-plugin`. If you see the older `anypoint-cli-pdk-plugin` (PDK < 1.8.0), tell the user to upgrade:
 
 ```bash
 anypoint-cli-v4 plugins:uninstall anypoint-cli-pdk-plugin
 anypoint-cli-v4 plugins:install anypoint-pdk-plugin
 ```
 
-**Check Rust and `cargo-anypoint`:**
+**Check Rust:**
 
 ```bash
 rustc --version
 cargo --version
-cargo anypoint --version
 ```
 
-If `cargo anypoint` is not installed, the developer must install it. The exact version is set by the `Makefile` of each policy project (see Step 4) — for a brand-new install before any project exists, point the user to the prerequisites doc rather than guessing a version.
+`cargo-anypoint` is **not** checked here — `make setup` in Step 4 installs the version pinned by the project's `Makefile` automatically.
 
 **Check the WASM target:**
 
@@ -105,7 +104,7 @@ Install the project's pinned `cargo-anypoint` version and any other tooling the 
 make setup
 ```
 
-This is what aligns the developer's toolchain to the version of `cargo-anypoint` that the project's `Makefile` declares. Do **not** skip it even if `cargo anypoint --version` already worked in Step 1 — the project may pin a different version than what's globally installed.
+**Heads-up — this changes the global `cargo-anypoint` install.** Under the hood, `make setup` runs `cargo install cargo-anypoint@<pinned-version>` (plus `cargo-llvm-cov`), which installs to `~/.cargo/bin/`. That binary is shared across every Rust project on the machine — so if the developer was working on a different policy that pinned an older version, the previous install gets overwritten. This is expected and how `cargo install` works; it just means the developer's "global" `cargo-anypoint` always reflects the most recently set-up policy.
 
 **Common issues:**
 
@@ -125,6 +124,8 @@ make build-asset-files
 This regenerates `src/generated/config.rs` so the policy's Rust code can reference the configuration as typed structs. **Do not hand-edit `src/generated/`** — it gets overwritten on every `build-asset-files` run.
 
 The developer's actual policy logic lives in `src/lib.rs` (the entry point) and any helper modules they add — that's design work outside this skill's scope. If the developer asks for examples of common patterns (header manipulation, JWT validation, HTTP calls, rate limiting, etc.), point them at the public examples repo: https://github.com/mulesoft/pdk-examples.
+
+> **Note:** A dedicated PDK examples skill is being tracked in [W-22456751](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Zt4fKYAR/view) and will surface these patterns directly through Claude. Until that lands, the public repo is the canonical source.
 
 ## Step 6: Build the Policy
 
@@ -284,9 +285,14 @@ After completing the lifecycle, verify:
 
 ### Policy applied successfully but does not run on traffic
 
-**Cause:** The dev/release version was published but the API instance in API Manager is still pinned to an older version, or the policy is disabled.
+**Cause:** A custom policy in API Manager has two moving parts — the **definition version** (the schema / config shape) and the **implementation version** (the WASM artifact published by `make publish` / `make release`). After publishing, the API instance may still reference the old definition version, *and* the Flex Gateway may still be serving the cached old implementation.
 
-**Fix:** In API Manager, open the API instance, find the policy in the applied policies list, and confirm the version matches what was just published. Toggle disable/enable to force a refresh if needed.
+**Fix:** Both parts may need a nudge:
+
+1. **Bump the definition version on the API instance.** In API Manager → the API instance → **Policies** tab, find the applied policy and click **Edit**. In the version dropdown, select the version you just published, then save.
+2. **Force the implementation refresh.** Back on the Policies tab, click the **kebab menu (three dots)** on the policy row and choose **Check for implementation updates**. This makes Flex re-fetch the WASM instead of serving its cached copy.
+
+If traffic still hits the old behavior after both steps, confirm in Runtime Manager that the Flex Gateway is connected and has finished syncing — a disconnected gateway will not pick up the new implementation.
 
 ## Additional Resources
 

--- a/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
+++ b/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-flex-gateway-policy-project
-description: Create, build, and publish a custom Flex Gateway policy with the Policy Development Kit (PDK). Use when the user asks to "create a new Flex Gateway policy", "scaffold a PDK policy project", "build a custom policy", "publish a PDK policy", "release a Flex Gateway policy", or mentions PDK, `anypoint-cli-v4 pdk`, `cargo anypoint`, or the Flex Gateway custom policy lifecycle. Covers prerequisites, project creation, configuration, build, dev publish, and release.
+description: Drive the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK) — verify prerequisites, scaffold the project, edit the gcl.yaml schema, build the WebAssembly artifact, exercise it locally with the Docker playground, then publish a dev version and cut a release to Anypoint Exchange. Use this skill whenever the user mentions PDK, Flex Gateway custom policies, `anypoint-cli-v4 pdk`, `cargo anypoint`, `make build` / `make publish` / `make release`, the `wasm32-wasip1` target, or asks to "create a custom policy", "scaffold a PDK project", "build a Flex Gateway policy", "publish a policy to Exchange", "test my policy locally", "upgrade PDK", or troubleshoots a PDK build / publish / release failure — even if they don't use the word "PDK" explicitly.
 license: Apache-2.0
 compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, `make`, and Docker (for the local playground in Step 7). Assumes `wasm32-wasip1` target is installed.
 metadata:
@@ -15,8 +15,6 @@ You are a Flex Gateway policy specialist helping a developer scaffold, build, an
 ## Your Task
 
 Drive the full lifecycle of a custom Flex Gateway policy project: verify prerequisites, create the project, configure it, build it, publish a development version for in-cluster testing, and finally cut a release version. Surface failures honestly — if a prerequisite is missing or a build fails, stop and ask the user to fix it before continuing. Do not invent workarounds.
-
-## Step-by-Step Process
 
 ## Step 1: Verify Prerequisites
 
@@ -133,7 +131,7 @@ make build-asset-files
 
 This regenerates `src/generated/config.rs` so the policy's Rust code can reference the configuration as typed structs. **Do not hand-edit `src/generated/`** — it gets overwritten on every `build-asset-files` run.
 
-The user's policy logic lives in `src/lib.rs` (entry point) and any helper modules they add. Point them there; do not write the policy logic in this skill — that's the developer's design work. If they ask for examples of common patterns (header manipulation, JWT validation, HTTP calls, rate limiting), refer them to the `pdk-examples` repo: https://github.com/mulesoft/pdk-examples.
+The developer's actual policy logic lives in `src/lib.rs` (the entry point) and any helper modules they add — that's design work outside this skill's scope. If the developer asks for examples of common patterns (header manipulation, JWT validation, HTTP calls, rate limiting, etc.), point them at the public examples repo: https://github.com/mulesoft/pdk-examples.
 
 ## Step 6: Build the Policy
 
@@ -147,9 +145,8 @@ This runs `cargo build --target wasm32-wasip1 --release` under the hood and emit
 
 If the build fails, read the error carefully before reacting:
 
-- **Compilation errors in `src/`** — the developer's policy code has bugs. Show them the error, do not attempt to fix it without their input.
-- **`error: target wasm32-wasip1 not installed`** — back to Step 1, run `rustup target add wasm32-wasip1`.
-- **`error: failed to select a version for ...`** — the `Cargo.toml` has incompatible `pdk` / `pdk-test` versions. See the "Upgrade PDK" section below; do not bump versions without the user's say-so.
+- **Compilation errors in `src/`** — these belong to the developer's policy code. Show the error, do not silently attempt fixes.
+- **`error: failed to select a version for ...`** — the `Cargo.toml` has incompatible `pdk` / `pdk-test` versions. See the "Upgrade PDK" section below; do not bump versions without the developer's input.
 
 ## Step 7: Run the Policy Locally
 
@@ -207,7 +204,7 @@ After publishing, the asset is visible in Exchange under the configured org. The
 
 ## Step 9: Release a Production Version
 
-Once the developer is happy with the policy and has tested the dev version against a real gateway:
+Once the developer is satisfied with the policy after exercising it via the local playground (Step 7) or a deployed dev version (Step 8):
 
 ```bash
 make release
@@ -273,23 +270,6 @@ After completing the lifecycle, verify:
 - [ ] `README.md` documents the policy's purpose, configuration, and example usage.
 
 ## Troubleshooting
-
-### `anypoint-cli-v4: command not found`
-
-**Cause:** Anypoint CLI v4 not installed, or not on `PATH`.
-
-**Fix:** Install via npm: `npm install -g anypoint-cli-v4`. Confirm with `anypoint-cli-v4 --version`.
-
-### `Plugin 'anypoint-pdk-plugin' not found` after `make setup`
-
-**Cause:** The PDK plugin was not installed before scaffolding the project, or it was installed under the old pre-1.7.0 name.
-
-**Fix:**
-
-```bash
-anypoint-cli-v4 plugins:uninstall anypoint-cli-pdk-plugin
-anypoint-cli-v4 plugins:install anypoint-pdk-plugin
-```
 
 ### `cargo-anypoint` version mismatch on `make setup`
 

--- a/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
+++ b/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
@@ -2,7 +2,7 @@
 name: manage-flex-gateway-policy-project
 description: Create, build, and publish a custom Flex Gateway policy with the Policy Development Kit (PDK). Use when the user asks to "create a new Flex Gateway policy", "scaffold a PDK policy project", "build a custom policy", "publish a PDK policy", "release a Flex Gateway policy", or mentions PDK, `anypoint-cli-v4 pdk`, `cargo anypoint`, or the Flex Gateway custom policy lifecycle. Covers prerequisites, project creation, configuration, build, dev publish, and release.
 license: Apache-2.0
-compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, and `make`. Assumes `wasm32-wasip1` target is installed.
+compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, `make`, and Docker (for the local playground in Step 7). Assumes `wasm32-wasip1` target is installed.
 metadata:
   author: mule-dx-tooling
   version: "1.0.0"
@@ -94,7 +94,15 @@ From the chosen target directory, run:
 anypoint-cli-v4 pdk policy-project create --name <policy-name>
 ```
 
-This produces a directory named `<policy-name>/` with the project skeleton (`Cargo.toml`, `Makefile`, `definition/gcl.yaml`, `src/lib.rs`, `tests/`, etc.). `cd` into it before running any further command — every subsequent step assumes the project root is the working directory.
+This produces a directory named `<policy-name>/` with the project skeleton:
+
+- `Cargo.toml`, `Makefile`, `README.md` — project root
+- `definition/gcl.yaml` — policy schema (Step 5)
+- `src/lib.rs` + `src/generated/` — Rust source and generated config bindings
+- `tests/` — integration test scaffolding
+- `playground/` — Docker-based local Flex Gateway harness used by `make run` (Step 7)
+
+`cd` into the new directory before running any further command — every subsequent step assumes the project root is the working directory.
 
 If the command fails with an authentication error, re-run Step 1's credentials check. If it fails with `command not found: pdk`, the PDK plugin is not installed correctly — back to Step 1.
 
@@ -143,19 +151,61 @@ If the build fails, read the error carefully before reacting:
 - **`error: target wasm32-wasip1 not installed`** — back to Step 1, run `rustup target add wasm32-wasip1`.
 - **`error: failed to select a version for ...`** — the `Cargo.toml` has incompatible `pdk` / `pdk-test` versions. See the "Upgrade PDK" section below; do not bump versions without the user's say-so.
 
-## Step 7: Publish a Development Version
+## Step 7: Run the Policy Locally
 
-For testing the policy against a real Flex Gateway before cutting a release:
+Before publishing anything to Exchange, exercise the policy against a real Flex Gateway running locally. The scaffold ships a `playground/` directory with a `docker-compose.yaml` that spins up Flex Gateway plus an `httpbin` backend, and a `make run` target that copies the freshly built `.wasm` into the gateway and starts everything.
+
+**Prerequisite — registration.yaml.** `make run` requires a `registration.yaml` in `playground/config/`. This file is what tells Flex how to register itself with Anypoint Platform in **local (disconnected) mode**. If you already have a Flex instance registered in local mode, copy its `registration.yaml` into `playground/config/`. Otherwise, generate one:
+
+1. Open Anypoint Platform → Runtime Manager → Flex Gateway tab.
+2. Click **Add Gateway**.
+3. Select **Docker** as the OS.
+4. Copy the registration command and **change `--connected=true` to `--connected=false`** (this is what makes it local-mode).
+5. Run that command from inside `playground/config/`. It writes `registration.yaml` there.
+
+**Configure the test API.** Open `playground/config/api.yaml`. The scaffold pre-wires it to apply the policy to traffic at `http://0.0.0.0:8081` and proxy to the `httpbin` backend. Fill in `policies[0].config:` with values that match the schema you declared in `definition/gcl.yaml`. Example:
+
+```yaml
+config:
+  someProperty: desiredValue
+  anotherProperty: 42
+```
+
+If the policy takes no configuration, leave `config: {}`.
+
+**Run it.**
+
+```bash
+make run
+```
+
+Flex listens on `http://localhost:8081`. Send test requests with `curl` and confirm the policy behaves as designed:
+
+```bash
+curl -i http://localhost:8081/anything/echo/
+```
+
+Tail logs with `docker compose -f playground/docker-compose.yaml logs -f local-flex` (in a second terminal). When done, `Ctrl-C` to stop, or `docker compose -f playground/docker-compose.yaml down` to clean up.
+
+**Common issues:**
+
+- **`registration.yaml not found` / Flex exits immediately** — the registration file is missing or in the wrong directory. Confirm it lives at `playground/config/registration.yaml` and that step 4 above was done with `--connected=false`.
+- **Policy code changes not picked up** — `make run` rebuilds before running. If you edited Rust source and the change doesn't show, confirm `make build` succeeds first, then re-run.
+- **Port 8081 already in use** — another local service is bound. Stop it, or edit `playground/docker-compose.yaml` to map a different host port.
+
+## Step 8: Publish a Development Version
+
+Once the local playground confirms the policy behaves as expected, publish a development version so it can be applied to a real API instance in your Anypoint org:
 
 ```bash
 make publish
 ```
 
-This uploads a `-DEV` versioned asset to the user's Anypoint Exchange organization. Dev versions are mutable — every `make publish` overwrites the same dev asset, which is exactly what you want during the inner loop. They are **not** suitable for production traffic.
+This uploads the asset to the user's Anypoint Exchange organization with **`-dev` appended to the assetId** and a **timestamp appended to the version** (for example, `1.0.0-20260518135700`). Each `make publish` produces a new timestamped version — earlier dev versions remain in Exchange and are still applicable. Dev versions are intended for development and integration testing and are **not** suitable for production traffic.
 
-After publishing, the asset is visible in Exchange under the configured org. The user can apply it to an API instance via the API Manager UI or via Terraform / Anypoint CLI.
+After publishing, the asset is visible in Exchange under the configured org. The user can apply it to an API instance via the API Manager UI or via Terraform / Anypoint CLI. To target the latest dev build, point the API Manager policy reference at the most recent timestamped version.
 
-## Step 8: Release a Production Version
+## Step 9: Release a Production Version
 
 Once the developer is happy with the policy and has tested the dev version against a real gateway:
 
@@ -167,8 +217,8 @@ This publishes an immutable, semver-versioned asset to Exchange. The version com
 
 **Gate before releasing:**
 
-- The dev version was tested against a real Flex Gateway, not just `cargo test`.
-- `Cargo.toml` `version` was bumped if a prior release exists.
+- The policy was exercised end-to-end against a real Flex Gateway — either via Step 7's local playground or via a `make publish` dev version applied to an API instance.
+- `Cargo.toml` `version` was bumped if a prior release exists with the same value.
 - The policy's `gcl.yaml` description and `README.md` are accurate — these are what consumers see in Exchange.
 
 ## Upgrade PDK
@@ -216,7 +266,7 @@ Full upgrade reference: https://docs.mulesoft.com/pdk/latest/policies-pdk-upgrad
 After completing the lifecycle, verify:
 
 - [ ] `make build` succeeds on a clean clone (`make clean && make build`).
-- [ ] The dev version was applied to a real Flex Gateway and exercised against expected request/response shapes.
+- [ ] `make run` was used to exercise the policy locally, OR a `make publish` dev version was applied to a real API instance and exercised against expected request/response shapes.
 - [ ] `Cargo.toml` `version` is set correctly for the release (immutable in Exchange).
 - [ ] `definition/gcl.yaml` describes every configurable property with `title` + `description`.
 - [ ] Sensitive properties carry `@context.@characteristics: [security:sensitive]`.

--- a/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
+++ b/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: manage-flex-gateway-policy-project
+description: Create, build, and publish a custom Flex Gateway policy with the Policy Development Kit (PDK). Use when the user asks to "create a new Flex Gateway policy", "scaffold a PDK policy project", "build a custom policy", "publish a PDK policy", "release a Flex Gateway policy", or mentions PDK, `anypoint-cli-v4 pdk`, `cargo anypoint`, or the Flex Gateway custom policy lifecycle. Covers prerequisites, project creation, configuration, build, dev publish, and release.
+license: Apache-2.0
+compatibility: Requires Anypoint CLI v4 with the `anypoint-pdk-plugin` (PDK 1.7.0+) installed, Rust toolchain (rustc + cargo), `cargo-anypoint` plugin, and `make`. Assumes `wasm32-wasip1` target is installed.
+metadata:
+  author: mule-dx-tooling
+  version: "1.0.0"
+  cli: anypoint-cli-v4
+allowed-tools: Bash Read Write Edit AskUserQuestion
+---
+
+You are a Flex Gateway policy specialist helping a developer scaffold, build, and publish a custom policy with MuleSoft's Policy Development Kit (PDK).
+
+## Your Task
+
+Drive the full lifecycle of a custom Flex Gateway policy project: verify prerequisites, create the project, configure it, build it, publish a development version for in-cluster testing, and finally cut a release version. Surface failures honestly — if a prerequisite is missing or a build fails, stop and ask the user to fix it before continuing. Do not invent workarounds.
+
+## Step-by-Step Process
+
+## Step 1: Verify Prerequisites
+
+Before running any `pdk` command, confirm the developer has the required toolchain. Run these checks and report each result. If any check fails, stop and link the user to https://docs.mulesoft.com/pdk/latest/policies-pdk-prerequisites — do not propose workarounds or auto-install.
+
+**Check Anypoint CLI v4 and the PDK plugin:**
+
+```bash
+anypoint-cli-v4 --version
+anypoint-cli-v4 plugins
+```
+
+The plugin list must include `anypoint-pdk-plugin`. If you see the older `anypoint-cli-pdk-plugin` (PDK < 1.7.0), tell the user to upgrade:
+
+```bash
+anypoint-cli-v4 plugins:uninstall anypoint-cli-pdk-plugin
+anypoint-cli-v4 plugins:install anypoint-pdk-plugin
+```
+
+**Check Rust and `cargo-anypoint`:**
+
+```bash
+rustc --version
+cargo --version
+cargo anypoint --version
+```
+
+If `cargo anypoint` is not installed, the developer must install it. The exact version is set by the `Makefile` of each policy project (see Step 4) — for a brand-new install before any project exists, point the user to the prerequisites doc rather than guessing a version.
+
+**Check the WASM target:**
+
+```bash
+rustup target list --installed | grep wasm32-wasip1
+```
+
+If `wasm32-wasip1` is missing:
+
+```bash
+rustup target add wasm32-wasip1
+```
+
+**Check Anypoint Platform credentials:**
+
+The developer must be logged in to the org/environment that will host the policy. Confirm with:
+
+```bash
+anypoint-cli-v4 conf
+```
+
+If not logged in:
+
+```bash
+anypoint-cli-v4 conf user <username>
+anypoint-cli-v4 conf password <password>
+anypoint-cli-v4 conf organization <orgId>
+anypoint-cli-v4 conf environment <envId>
+```
+
+**Gate:** all four checks pass. Do not proceed otherwise.
+
+## Step 2: Confirm Policy Name and Target Directory
+
+Ask the user **one question at a time**:
+
+1. "What is the name of the policy? (lowercase kebab-case, e.g. `header-injector`, `request-token-validator`)"
+2. "Where should I scaffold the project? (default: current working directory)"
+
+Validate the name: lowercase letters, digits, and hyphens only. Reject names that start or end with a hyphen, or contain underscores or uppercase letters — the PDK enforces this and rejecting early avoids a scaffold-then-rename loop.
+
+## Step 3: Create the Policy Project
+
+From the chosen target directory, run:
+
+```bash
+anypoint-cli-v4 pdk policy-project create --name <policy-name>
+```
+
+This produces a directory named `<policy-name>/` with the project skeleton (`Cargo.toml`, `Makefile`, `definition/gcl.yaml`, `src/lib.rs`, `tests/`, etc.). `cd` into it before running any further command — every subsequent step assumes the project root is the working directory.
+
+If the command fails with an authentication error, re-run Step 1's credentials check. If it fails with `command not found: pdk`, the PDK plugin is not installed correctly — back to Step 1.
+
+## Step 4: Set Up the Project
+
+Install the project's pinned `cargo-anypoint` version and any other tooling the Makefile manages:
+
+```bash
+make setup
+```
+
+This is what aligns the developer's toolchain to the version of `cargo-anypoint` that the project's `Makefile` declares. Do **not** skip it even if `cargo anypoint --version` already worked in Step 1 — the project may pin a different version than what's globally installed.
+
+**Common issues:**
+
+- **`cargo: command not found`** — Rust is not on `PATH`. Source the cargo env (`. "$HOME/.cargo/env"`) or restart the shell after installing Rust.
+- **Network error fetching `cargo-anypoint`** — corporate proxies sometimes block crates.io. Ask the user about proxy configuration before retrying.
+
+## Step 5: Configure the Policy
+
+Open `definition/gcl.yaml` and walk the user through declaring the policy's configuration schema (the parameters their policy will accept at runtime). The schema lives under `properties:`. Each property needs `title`, `description`, and a type. Sensitive properties (tokens, secrets) must carry the `@context.@characteristics: [security:sensitive]` annotation so they're masked in the UI.
+
+After editing `gcl.yaml`, regenerate the Rust config bindings:
+
+```bash
+make build-asset-files
+```
+
+This regenerates `src/generated/config.rs` so the policy's Rust code can reference the configuration as typed structs. **Do not hand-edit `src/generated/`** — it gets overwritten on every `build-asset-files` run.
+
+The user's policy logic lives in `src/lib.rs` (entry point) and any helper modules they add. Point them there; do not write the policy logic in this skill — that's the developer's design work. If they ask for examples of common patterns (header manipulation, JWT validation, HTTP calls, rate limiting), refer them to the `pdk-examples` repo: https://github.com/mulesoft/pdk-examples.
+
+## Step 6: Build the Policy
+
+Compile the policy to a WebAssembly module:
+
+```bash
+make build
+```
+
+This runs `cargo build --target wasm32-wasip1 --release` under the hood and emits a `.wasm` artifact under `target/wasm32-wasip1/release/`.
+
+If the build fails, read the error carefully before reacting:
+
+- **Compilation errors in `src/`** — the developer's policy code has bugs. Show them the error, do not attempt to fix it without their input.
+- **`error: target wasm32-wasip1 not installed`** — back to Step 1, run `rustup target add wasm32-wasip1`.
+- **`error: failed to select a version for ...`** — the `Cargo.toml` has incompatible `pdk` / `pdk-test` versions. See the "Upgrade PDK" section below; do not bump versions without the user's say-so.
+
+## Step 7: Publish a Development Version
+
+For testing the policy against a real Flex Gateway before cutting a release:
+
+```bash
+make publish
+```
+
+This uploads a `-DEV` versioned asset to the user's Anypoint Exchange organization. Dev versions are mutable — every `make publish` overwrites the same dev asset, which is exactly what you want during the inner loop. They are **not** suitable for production traffic.
+
+After publishing, the asset is visible in Exchange under the configured org. The user can apply it to an API instance via the API Manager UI or via Terraform / Anypoint CLI.
+
+## Step 8: Release a Production Version
+
+Once the developer is happy with the policy and has tested the dev version against a real gateway:
+
+```bash
+make release
+```
+
+This publishes an immutable, semver-versioned asset to Exchange. The version comes from the policy's `Cargo.toml` (`version = "..."`) — bump it before running `make release` if you've already published this version once. Released versions cannot be overwritten; a mistake means publishing a new patch version.
+
+**Gate before releasing:**
+
+- The dev version was tested against a real Flex Gateway, not just `cargo test`.
+- `Cargo.toml` `version` was bumped if a prior release exists.
+- The policy's `gcl.yaml` description and `README.md` are accurate — these are what consumers see in Exchange.
+
+## Upgrade PDK
+
+PDK has five separately versioned components. Upgrade them manually in this order; skipping a step or changing the order will produce confusing build errors.
+
+1. **Anypoint CLI PDK Plugin**
+
+   ```bash
+   anypoint-cli-v4 plugins:install anypoint-pdk-plugin
+   anypoint-cli-v4 plugins
+   ```
+
+   If upgrading from a version older than 1.7.0, first uninstall the old plugin name:
+
+   ```bash
+   anypoint-cli-v4 plugins:uninstall anypoint-cli-pdk-plugin
+   ```
+
+2. **PDK Rust libraries** — update `Cargo.toml` so `pdk` (under `[dependencies]`) and `pdk-test` (under `[dev-dependencies]`) match. Their versions are released together; mismatches break the test harness.
+
+3. **Anypoint Cargo plugin** — update the version in the `Makefile` line that reads:
+
+   ```makefile
+   install-cargo-anypoint:
+       cargo install cargo-anypoint@<VERSION>
+   ```
+
+   Then re-run `make setup`. Verify with `cargo anypoint --version`.
+
+4. **Rust version** — update `rust-version = "X.XX.0"` in `Cargo.toml` to match the PDK release notes.
+
+5. **WASI crate** — replace `wasm32-wasi` with `wasm32-wasip1` in the `Makefile` (the `TARGET` variable) and in `tests/common/mod.rs`.
+
+Full upgrade reference: https://docs.mulesoft.com/pdk/latest/policies-pdk-upgrade-pdk
+
+## Special Cases
+
+- **PDK 1.8.0 Tokio error** — add `resolver = "2"` to the `[package]` section of `Cargo.toml`.
+- **Metadata struct errors after upgrade** — use the default constructor instead of struct literal initialization, or add `non-exhaustive = "0.1.1"` as a dev-dependency.
+- **Pre-1.6.0 policies being upgraded** — remove `registry = "anypoint"` from `Cargo.toml` dependencies and update Makefile references accordingly.
+
+## Completion Checklist
+
+After completing the lifecycle, verify:
+
+- [ ] `make build` succeeds on a clean clone (`make clean && make build`).
+- [ ] The dev version was applied to a real Flex Gateway and exercised against expected request/response shapes.
+- [ ] `Cargo.toml` `version` is set correctly for the release (immutable in Exchange).
+- [ ] `definition/gcl.yaml` describes every configurable property with `title` + `description`.
+- [ ] Sensitive properties carry `@context.@characteristics: [security:sensitive]`.
+- [ ] `README.md` documents the policy's purpose, configuration, and example usage.
+
+## Troubleshooting
+
+### `anypoint-cli-v4: command not found`
+
+**Cause:** Anypoint CLI v4 not installed, or not on `PATH`.
+
+**Fix:** Install via npm: `npm install -g anypoint-cli-v4`. Confirm with `anypoint-cli-v4 --version`.
+
+### `Plugin 'anypoint-pdk-plugin' not found` after `make setup`
+
+**Cause:** The PDK plugin was not installed before scaffolding the project, or it was installed under the old pre-1.7.0 name.
+
+**Fix:**
+
+```bash
+anypoint-cli-v4 plugins:uninstall anypoint-cli-pdk-plugin
+anypoint-cli-v4 plugins:install anypoint-pdk-plugin
+```
+
+### `cargo-anypoint` version mismatch on `make setup`
+
+**Cause:** A globally installed `cargo-anypoint` is shadowing the version pinned by the project's `Makefile`.
+
+**Fix:** `make setup` reinstalls the pinned version. If the Makefile pin is itself wrong, see the "Upgrade PDK" section.
+
+### `make publish` returns 401 / 403
+
+**Cause:** The CLI is not logged in to the target org/environment, or the user lacks the "Exchange Contributor" role for that org.
+
+**Fix:** Re-run the credentials block from Step 1. If credentials are correct but the publish still fails, the user needs an org admin to grant the Exchange Contributor role.
+
+### `make release` fails with "asset version already exists"
+
+**Cause:** Released versions in Exchange are immutable. The version in `Cargo.toml` was already published.
+
+**Fix:** Bump `Cargo.toml`'s `version` field (typically the patch component for fixes) and re-run `make release`. Do not attempt to delete the existing version.
+
+### Policy applied successfully but does not run on traffic
+
+**Cause:** The dev/release version was published but the API instance in API Manager is still pinned to an older version, or the policy is disabled.
+
+**Fix:** In API Manager, open the API instance, find the policy in the applied policies list, and confirm the version matches what was just published. Toggle disable/enable to force a refresh if needed.
+
+## Additional Resources
+
+- **PDK prerequisites:** https://docs.mulesoft.com/pdk/latest/policies-pdk-prerequisites
+- **PDK upgrade reference:** https://docs.mulesoft.com/pdk/latest/policies-pdk-upgrade-pdk
+- **PDK overview:** https://docs.mulesoft.com/pdk/latest/
+- **Public examples:** https://github.com/mulesoft/pdk-examples
+
+---
+
+**Need help?** Failing at a specific step usually means a tooling version mismatch. Re-run Step 1 — it's cheap and rules out the most common class of issues before deeper debugging.

--- a/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
+++ b/skills/mule-development/manage-flex-gateway-policy-project/SKILL.md
@@ -64,14 +64,7 @@ The developer must be logged in to the org/environment that will host the policy
 anypoint-cli-v4 conf
 ```
 
-If not logged in:
-
-```bash
-anypoint-cli-v4 conf user <username>
-anypoint-cli-v4 conf password <password>
-anypoint-cli-v4 conf organization <orgId>
-anypoint-cli-v4 conf environment <envId>
-```
+If credentials are not set, or `make publish` / `make release` later fails with 401/403, follow the prerequisites doc: https://docs.mulesoft.com/pdk/latest/policies-pdk-prerequisites — auth requires a Connected App with the **Exchange Contributor** scope on the target org. Do not propose workaround login flows.
 
 **Gate:** all four checks pass. Do not proceed otherwise.
 

--- a/skills/mule-development/package-lock.json
+++ b/skills/mule-development/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/mulesoft-vibes-skills",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/mulesoft-vibes-skills",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.txt"
     }
   }

--- a/skills/mule-development/package.json
+++ b/skills/mule-development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/mulesoft-vibes-skills",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "MuleSoft DX skills to enhance Mule developement",
   "license": "SEE LICENSE IN LICENSE.txt",
   "files": [


### PR DESCRIPTION
## Summary

  - Adds `skills/mule-development/manage-flex-gateway-policy-project/SKILL.md`, an agent-facing workflow that drives the full lifecycle of a custom Flex Gateway policy with the Policy Development Kit (PDK): prerequisites → `anypoint-cli-v4 pdk
  policy-project create` → `make setup` / `build-asset-files` / `build` → local execution via the scaffolded `playground/` (`make run`) → `make publish` (dev) → `make release` (production).
  - Self-sufficient on the public `anypoint-cli-v4` path — no MCP dependency — so it works for any customer with the CLI + Rust + cargo-anypoint + Docker installed.
  - Includes an upgrade-PDK runbook (five components, in order) and troubleshooting for the common toolchain failure modes (plugin name change at PDK 1.7.0, cargo-anypoint version mismatch, Exchange immutability, applied-but-not-running
  policies, registration.yaml gotchas, etc.).
  - Bumps `@salesforce/mulesoft-vibes-skills` to `1.1.0` (minor: new skill).

  GUS: [W-22456748](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ZsOSBYA3/view)

  ## Decisions worth flagging

  **MCP duplication, intentionally parked.** The `mule-flex-pdk-service` MCP server's `manage_flex_gateway_policy_project` tool currently returns a fixed instruction string that overlaps with this skill's lifecycle steps. The parent Epic ([264]
  Provide the agent with policy resources to enable policy generation) explicitly calls out a single unified channel for AI-assisted policy development, so collapsing that MCP tool down to a pointer at this skill is the right end state. Doing it
   now would require a coordinated change in `mulesoft-mcp-server` and a release; I will file a follow-up GUS work item for that once this skill is published to npm and customers are using it.

  **Air-Gapped Flex playground simplification: blocked on Product.** The ticket asked us to check whether the local playground could be simplified using the Air-Gapped Flex feature (Flex without registration for ~10–15 min). Per the [referenced
  Slack thread](https://salesforce-internal.slack.com/archives/C024PRY3P6K/p1778614812866799), the feature exists internally but is **not exposed to customers** — Ariel Neisen flagged that it needs a Product decision before we can bake it into a
   customer-facing skill, and the team agreed to take it to Product. That conversation has not closed yet. Decision for this PR: ship the skill assuming the standard registration flow with `--connected=false` (which is what customers have
  today). When Product greenlights Air-Gapped for external use, the natural seam to add it is Step 7's "registration.yaml" prerequisite block — that whole section becomes optional / replaced by an Air-Gapped startup command.

  ## Verification

  - `python3 scripts/build/validate_jtbd.py skills/mule-development/manage-flex-gateway-policy-project/SKILL.md .` passes.
  - `make pre-commit-hook` passes (validate-descriptions, validate-mcp-server, validate-xorigin, validate-jtbd).
  - Smoke-tested Steps 1–6 end-to-end against a fresh scaffold: prereqs detected correctly, `pdk policy-project create` produces a working tree, `make setup` / `make build-asset-files` / `make build` all succeed, and the resulting `.wasm`
  artifact is written under `target/wasm32-wasip1/release/`. The smoke test surfaced two corrections that landed in the second commit (playground step, accurate publish versioning).
