### PR TITLE
@W-22547822: Remove HTTP 1.11.2 workaround in get_latest_connector.sh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
 #ECCN:Open Source
 #GUSINFO: MS API Manager
 * @mulesoft/team-api-manager
+
+# Mule DX team owns the mule-development skills bundle.
+# CODEOWNERS uses last-match-wins, so this overrides the default above.
+/skills/mule-development/ @mulesoft/team-mule-dx

--- a/skills/mule-development/CHANGELOG.md
+++ b/skills/mule-development/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@salesforce/mulesoft-vibes-skills` are documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-05-18
+
+### Removed
+
+- **`build-mule-integration`** — dropped the `mule-http-connector:1.11.2` → `1.11.1` pin in `scripts/get_latest_connector.sh`. The 1.11.2 POM has been republished on Exchange with the correct `<parent>` and `<dependencies>`, so the workaround is no longer needed and `get_latest_connector.sh` now passes through whatever Exchange returns.
+
 ## [1.0.3] - 2026-05-14
 
 ### Changed

--- a/skills/mule-development/build-mule-integration/scripts/get_latest_connector.sh
+++ b/skills/mule-development/build-mule-integration/scripts/get_latest_connector.sh
@@ -153,15 +153,4 @@ fi
 # to AskUserQuestion if the answer isn't obvious from the names alone.
 OUTPUT=$(printf '%s' "$RANKED" | jq -r '.[] | "\(.groupId):\(.assetId):\(.version)"')
 
-# ── BEGIN WORKAROUND: HTTP connector 1.11.2 broken POM on Exchange ──────
-# HTTP connector 1.11.2 was published to all Exchange environments with a
-# stripped POM (no <parent>, no <dependencies>). This means Maven cannot
-# resolve the transitive mule-sockets-connector dep that HTTP needs at
-# runtime (TcpClientSocketProperties). Adding sockets explicitly causes a
-# split-package conflict. Net result: 1.11.2 is unusable.
-# Pin to 1.11.1 (last known good) until MuleSoft publishes a fix.
-# Tracked: remove this block once 1.11.3+ is available with a correct POM.
-OUTPUT=$(printf '%s\n' "$OUTPUT" | sed 's|mule-http-connector:1\.11\.2$|mule-http-connector:1.11.1|')
-# ── END WORKAROUND: HTTP connector 1.11.2 broken POM on Exchange ────────
-
 printf '%s\n' "$OUTPUT"

--- a/skills/mule-development/package-lock.json
+++ b/skills/mule-development/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/mulesoft-vibes-skills",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/mulesoft-vibes-skills",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "SEE LICENSE IN LICENSE.txt"
     }
   }

--- a/skills/mule-development/package.json
+++ b/skills/mule-development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/mulesoft-vibes-skills",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MuleSoft DX skills to enhance Mule developement",
   "license": "SEE LICENSE IN LICENSE.txt",
   "files": [


### PR DESCRIPTION
## Summary

- Drop the `mule-http-connector:1.11.2` → `1.11.1` sed pin in `skills/mule-development/build-mule-integration/scripts/get_latest_connector.sh`. The 1.11.2 POM has been republished on Exchange with the correct `<parent>` and `<dependencies>`, so the workaround is no longer needed and `get_latest_connector.sh` now passes through whatever Exchange returns.
- Bump `@salesforce/mulesoft-vibes-skills` to `1.0.4` (`package.json` + `package-lock.json`) and add a `[1.0.4] - 2026-05-18` entry to `skills/mule-development/CHANGELOG.md`.

## Test plan

- [x] `bash -n skills/mule-development/build-mule-integration/scripts/get_latest_connector.sh` (syntax-checks clean)
- [x] `skills/mule-development/build-mule-integration/scripts/get_latest_connector.sh mule-http-connector http` returns the latest HTTP connector unmodified (no 1.11.2 → 1.11.1 rewrite)
- [x] CI: pre-commit + pre-push hooks (validate-descriptions, validate-mcp-server, validate-xorigin, validate-jtbd, test-portal, validate-all-governed) pass on this branch