### PR TITLE
@W-22565547 Improve AI-readiness: add llms.txt directive, markdown pages, and cac…

### DIFF
--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -214,6 +214,8 @@ class PortalGenerator:
         self._generate_schemas()
         self._generate_agents_md()
         self._generate_llms_txt()
+        self._generate_markdown_pages()
+        self._generate_headers()
         self._generate_css()
         self._generate_js()
         self._copy_images()
@@ -734,11 +736,101 @@ class PortalGenerator:
         content = template.render(
             base_url=self.base_url,
             apis=self.public_apis,
+            mcp_servers=self.public_mcps,
             all_skills=self.all_skills,
         )
         output_path = self.output_dir / 'llms.txt'
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(content)
+
+    def _generate_markdown_pages(self):
+        """Generate .md alternatives for all HTML pages (AI-readiness)."""
+        print("  ✓ Generating markdown page alternatives...")
+        count = 0
+
+        # Homepage
+        tmpl = self.env.get_template('markdown/homepage.md.html')
+        md = tmpl.render(
+            base_url=self.base_url,
+            apis=self.public_apis,
+            mcp_servers=self.public_mcps,
+            all_skills=self.all_skills,
+            terraform_providers=self.terraform_providers,
+        )
+        (self.output_dir / 'index.md').write_text(md, encoding='utf-8')
+        count += 1
+
+        # API pages
+        api_tmpl = self.env.get_template('markdown/api_page.md.html')
+        for api in self.public_apis:
+            md = api_tmpl.render(base_url=self.base_url, api=api)
+            (self.output_dir / 'apis' / f"{api['slug']}.md").write_text(md, encoding='utf-8')
+            count += 1
+
+        # MCP pages
+        if self.public_mcps:
+            mcp_tmpl = self.env.get_template('markdown/mcp_page.md.html')
+            for mcp in self.public_mcps:
+                md = mcp_tmpl.render(base_url=self.base_url, mcp=mcp)
+                (self.output_dir / 'mcps' / f"{mcp['slug']}.md").write_text(md, encoding='utf-8')
+                count += 1
+
+        # Skill pages
+        skill_tmpl = self.env.get_template('markdown/skill_page.md.html')
+        for skill in self.all_skills:
+            md = skill_tmpl.render(base_url=self.base_url, skill=skill)
+            (self.output_dir / 'skills' / f"{skill['slug']}.md").write_text(md, encoding='utf-8')
+            count += 1
+
+        print(f"    • {count} markdown pages generated")
+
+    def _generate_headers(self):
+        """Generate _headers file for CDN/hosting cache control."""
+        print("  ✓ Generating _headers file...")
+        headers = """/llms.txt
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/plain; charset=utf-8
+
+/AGENTS.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/registry.json
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/index.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/apis/*.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/mcps/*.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/skills/*.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/apis/*.yaml
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/mcps/*/mcp.yaml
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+
+/skills/*/SKILL.md
+  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
+  Content-Type: text/markdown; charset=utf-8
+
+/schemas/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/assets/*
+  Cache-Control: public, max-age=604800, immutable
+"""
+        (self.output_dir / '_headers').write_text(headers, encoding='utf-8')
 
     def _generate_css(self):
         """Generate styles.css"""

--- a/scripts/portal_generator/templates/base.html
+++ b/scripts/portal_generator/templates/base.html
@@ -4,33 +4,18 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="build-label" content="{{ build_label|default('unknown') }}">
-    <link rel="stylesheet" href="https://www.mulesoft.com/oneTrust/assets/onetrust.min.css">
-    <link rel="stylesheet" href="https://www.mulesoft.com/oneTrust/assets/onetrust-mulesoft-custom.css">
-    
-    <script>  
-    var script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = 'https://www.mulesoft.com/oneTrust/scripttemplates/otSDKStub.js';   
-    script.setAttribute('data-domain-script', 'fc594183-7384-4f03-8c43-1f81571521b7');
-    document.getElementsByTagName('body')[0].appendChild(script);
-    
-    function OptanonWrapper() {
-        localStorage.setItem('otsettings', OptanonActiveGroups);
-    }
-    </script>
+    <link rel="llms-txt" href="{{ base_url|default('') }}/llms.txt">
     <link rel="alternate" type="application/json" href="{{ base_url|default('') }}/registry.json" title="Document Registry">
     <link rel="help" href="{{ base_url|default('') }}/AGENTS.md" title="Agent Guide">
-    <link rel="help" type="text/plain" href="{{ base_url|default('') }}/llms.txt" title="LLM Discovery (llmstxt.org)">
+    {% block markdown_alternate %}{% endblock %}
     <meta name="robots" content="index, follow">
     <link rel="icon" type="image/x-icon" href="https://www.mulesoft.com/c/public/exp/app/favicon.ico">
     <title>{% block title %}Anypoint Platform APIs{% endblock %}</title>
+    <link rel="stylesheet" href="{{ css_path }}">
     {% if chrome and chrome.dependencies %}
     {{ chrome.dependencies|safe }}
     {% endif %}
-    <link rel="stylesheet" href="{{ css_path }}">
     {% block extra_styles %}{% endblock %}
-
-    <!-- Dark Mode: Apply theme before render to prevent flash (only when ?darkmode=true) -->
     <script>
         (function() {
             if (new URLSearchParams(window.location.search).get('darkmode') !== 'true') return;
@@ -41,17 +26,6 @@
                 document.documentElement.setAttribute('data-theme', 'dark');
             }
         })();
-    </script>
-
-    <!-- Ace Editor -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/ace.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-json.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-yaml.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-xml.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/theme-textmate.min.js"></script>
-
-    <script>
-        window.aceEditors = {};
     </script>
     {% block head_scripts %}{% endblock %}
 </head>
@@ -66,6 +40,22 @@
     {{ chrome.footer|safe }}
     {% endif %}
     {% block footer %}{% endblock %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/ace.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-json.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-yaml.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/mode-xml.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.32.2/theme-textmate.min.js" defer></script>
+    <script>window.aceEditors = {};</script>
+    <link rel="stylesheet" href="https://www.mulesoft.com/oneTrust/assets/onetrust.min.css">
+    <link rel="stylesheet" href="https://www.mulesoft.com/oneTrust/assets/onetrust-mulesoft-custom.css">
+    <script>
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.src = 'https://www.mulesoft.com/oneTrust/scripttemplates/otSDKStub.js';
+    script.setAttribute('data-domain-script', 'fc594183-7384-4f03-8c43-1f81571521b7');
+    document.getElementsByTagName('body')[0].appendChild(script);
+    function OptanonWrapper() { localStorage.setItem('otsettings', OptanonActiveGroups); }
+    </script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/scripts/portal_generator/templates/detail_page.html
+++ b/scripts/portal_generator/templates/detail_page.html
@@ -2,6 +2,10 @@
 
 {% block title %}{{ api.name }} - Anypoint Platform APIs{% endblock %}
 
+{% block markdown_alternate %}
+<link rel="alternate" type="text/markdown" href="{{ base_url }}/apis/{{ api.slug }}.md">
+{% endblock %}
+
 {% block body_attrs %} class="detail-page"{% endblock %}
 
 {% block head_scripts %}

--- a/scripts/portal_generator/templates/homepage.html
+++ b/scripts/portal_generator/templates/homepage.html
@@ -2,6 +2,10 @@
 
 {% block title %}MuleSoft Developer Portal{% endblock %}
 
+{% block markdown_alternate %}
+<link rel="alternate" type="text/markdown" href="{{ base_url }}/index.md">
+{% endblock %}
+
 {% block head_scripts %}
 <script src="assets/jsonpath-plus.min.js" defer></script>
 <script src="assets/portal.js" defer></script>

--- a/scripts/portal_generator/templates/llms_txt.html
+++ b/scripts/portal_generator/templates/llms_txt.html
@@ -1,7 +1,7 @@
 # Anypoint Platform API Portal
 
 > Machine-readable API reference for MuleSoft's Anypoint Platform.
-> Contains OpenAPI 3.0 specs, agent skills (JTBD workflows), and dynamic enum schemas.
+> Contains OpenAPI 3.0 specs, agent skills (JTBD workflows), MCP servers, and dynamic enum schemas.
 
 ## Agent Guide
 
@@ -9,6 +9,7 @@
 
 ## Discovery
 
+- [Portal Homepage]({{ base_url }}/index.md): Full catalog of APIs, MCP servers, and skills
 - [registry.json]({{ base_url }}/registry.json): Document registry with URN-based IDs for all APIs, skills, and schemas
 
 ## Schemas
@@ -17,6 +18,21 @@
 - [JTBD Skill Schema]({{ base_url }}/schemas/jtbd-schema.md): Agent skill / Jobs-to-be-Done format definition
 - [Skill Template]({{ base_url }}/schemas/jtbd-template.md): Template for creating new SKILL.md files
 
-## Full Index
+## APIs
+{% for api in apis %}
+- [{{ api.name }}]({{ base_url }}/apis/{{ api.slug }}.md): {{ api.description }}
+{% endfor %}
 
-See [registry.json]({{ base_url }}/registry.json) for the complete machine-readable list of all APIs, MCP servers, and skills.
+{% if mcp_servers %}
+## MCP Servers
+{% for mcp in mcp_servers %}
+- [{{ mcp.name }}]({{ base_url }}/mcps/{{ mcp.slug }}.md): {{ mcp.description }}
+{% endfor %}
+{% endif %}
+
+{% if all_skills %}
+## Skills
+{% for skill in all_skills %}
+- [{{ skill.name }}]({{ base_url }}/skills/{{ skill.slug }}.md): {{ skill.description }}
+{% endfor %}
+{% endif %}

--- a/scripts/portal_generator/templates/markdown/api_page.md.html
+++ b/scripts/portal_generator/templates/markdown/api_page.md.html
@@ -1,0 +1,43 @@
+# {{ api.name }}
+
+{{ api.description }}
+
+- **Version:** {{ api.version }}
+- **Category:** {{ api.category|default('Uncategorized') }}
+- **OpenAPI Spec:** [api.yaml]({{ base_url }}/apis/{{ api.slug }}/api.yaml)
+
+{% if api.servers %}
+## Servers
+{% for server in api.servers %}
+- `{{ server.url }}`{% if server.description %} — {{ server.description }}{% endif %}
+
+{% endfor %}
+{% endif %}
+
+## Operations ({{ api.operations|length }})
+{% for op in api.operations %}
+### {{ op.method|upper }} {{ op.path }}
+
+**Operation ID:** `{{ op.operationId }}`
+{% if op.summary %}
+{{ op.summary }}
+{% endif %}
+{% if op.description %}
+{{ op.description }}
+{% endif %}
+{% if op.parameters %}
+
+**Parameters:**
+{% for param in op.parameters %}
+| `{{ param.name }}` | {{ param.location|default('query') }} | {{ param.description|default('') }} | {% if param.required %}required{% else %}optional{% endif %} |
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+
+{% if api.skills %}
+## Related Skills
+{% for skill in api.skills %}
+- [{{ skill.name }}]({{ base_url }}/skills/{{ skill.slug }}.md) — {{ skill.description }}
+{% endfor %}
+{% endif %}

--- a/scripts/portal_generator/templates/markdown/homepage.md.html
+++ b/scripts/portal_generator/templates/markdown/homepage.md.html
@@ -1,0 +1,35 @@
+# MuleSoft Developer Portal
+
+> Discover, interact, and build with Anypoint Platform APIs, MCP Servers, and Skills.
+
+## APIs ({{ apis|length }})
+{% for api in apis %}
+- [{{ api.name }}]({{ base_url }}/apis/{{ api.slug }}.md) — {{ api.description }} (v{{ api.version }})
+{% endfor %}
+
+{% if mcp_servers %}
+## MCP Servers ({{ mcp_servers|length }})
+{% for mcp in mcp_servers %}
+- [{{ mcp.name }}]({{ base_url }}/mcps/{{ mcp.slug }}.md) — {{ mcp.description }}
+{% endfor %}
+{% endif %}
+
+{% if all_skills %}
+## Skills ({{ all_skills|length }})
+{% for skill in all_skills %}
+- [{{ skill.name }}]({{ base_url }}/skills/{{ skill.slug }}.md) — {{ skill.description }}
+{% endfor %}
+{% endif %}
+
+{% if terraform_providers %}
+## Terraform Providers ({{ terraform_providers|length }})
+{% for provider in terraform_providers %}
+- [{{ provider.name }}]({{ base_url }}/terraform/{{ provider.slug }}.html) — {{ provider.description|default('Terraform provider') }}
+{% endfor %}
+{% endif %}
+
+## Machine-Readable Resources
+
+- [AGENTS.md]({{ base_url }}/AGENTS.md) — Complete guide for AI agents
+- [registry.json]({{ base_url }}/registry.json) — Document registry with URN-based IDs
+- [llms.txt]({{ base_url }}/llms.txt) — LLM discovery file

--- a/scripts/portal_generator/templates/markdown/mcp_page.md.html
+++ b/scripts/portal_generator/templates/markdown/mcp_page.md.html
@@ -1,0 +1,63 @@
+# {{ mcp.name }}
+
+{{ mcp.description }}
+
+- **Version:** {{ mcp.version }}
+- **MCP Spec:** [mcp.yaml]({{ base_url }}/mcps/{{ mcp.slug }}/mcp.yaml)
+{% if mcp.servers %}
+- **Endpoints:**{% for server in mcp.servers %} `{{ server.url }}`{% endfor %}
+
+{% endif %}
+
+{% if mcp.tools %}
+## Tools ({{ mcp.tools|length }})
+{% for tool in mcp.tools %}
+### {{ tool.name }}
+{% if tool.title %}
+**{{ tool.title }}**
+{% endif %}
+
+{{ tool.description|default('') }}
+{% if tool.inputSchema and tool.inputSchema.properties %}
+
+**Input Parameters:**
+
+| Parameter | Type | Description | Required |
+|-----------|------|-------------|----------|
+{% for pname, pdef in tool.inputSchema.properties.items() %}| `{{ pname }}` | {{ pdef.type|default('string') }} | {{ pdef.description|default('') }} | {% if pname in (tool.inputSchema.required or []) %}yes{% else %}no{% endif %} |
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
+{% if mcp.prompts %}
+## Prompts ({{ mcp.prompts|length }})
+{% for prompt in mcp.prompts %}
+### {{ prompt.name }}
+
+{{ prompt.description|default('') }}
+{% if prompt.arguments %}
+
+**Arguments:**
+{% for arg in prompt.arguments %}
+- `{{ arg.name }}`{% if arg.required %} (required){% endif %} — {{ arg.description|default('') }}
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
+{% if mcp.resources %}
+## Resources ({{ mcp.resources|length }})
+{% for resource in mcp.resources %}
+- `{{ resource.uri }}` — {{ resource.description|default(resource.name) }}
+{% endfor %}
+{% endif %}
+
+{% if mcp.resource_templates %}
+## Resource Templates ({{ mcp.resource_templates|length }})
+{% for tmpl in mcp.resource_templates %}
+- `{{ tmpl.uriTemplate }}` — {{ tmpl.description|default(tmpl.name) }}
+{% endfor %}
+{% endif %}

--- a/scripts/portal_generator/templates/markdown/skill_page.md.html
+++ b/scripts/portal_generator/templates/markdown/skill_page.md.html
@@ -1,0 +1,45 @@
+# {{ skill.name }}
+
+{{ skill.description }}
+
+{% if skill.api_refs %}- **APIs:** {% for ref in skill.api_refs %}[{{ ref }}]({{ base_url }}/apis/{{ ref }}.md){% if not loop.last %}, {% endif %}{% endfor %}
+{% endif %}
+{% if skill.mcp_refs %}- **MCP Servers:** {% for ref in skill.mcp_refs %}[{{ ref }}]({{ base_url }}/mcps/{{ ref }}.md){% if not loop.last %}, {% endif %}{% endfor %}
+{% endif %}
+- **Skill Source:** [SKILL.md]({{ base_url }}/skills/{{ skill.skill_rel_path|default(skill.slug) }}/SKILL.md)
+
+{% if skill.step_details %}
+## Steps
+{% for step in skill.step_details %}
+### Step {{ loop.index }}: {{ step.title }}
+{% if step.description %}
+{{ step.description }}
+{% endif %}
+{% if step.yaml %}
+{% if step.yaml.api %}**API:** `{{ step.yaml.api }}`{% endif %}
+{% if step.yaml.operationId %}
+**Operation:** `{{ step.yaml.operationId }}`{% endif %}
+{% if step.yaml.inputs %}
+
+**Inputs:**
+{% if step.yaml.inputs is mapping %}
+{% for iname, idef in step.yaml.inputs.items() %}
+- `{{ iname }}` — {{ idef.description|default('') }}
+{% endfor %}
+{% else %}
+{% for inp in step.yaml.inputs %}
+- `{{ inp.name }}` — {{ inp.description|default('') }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if step.yaml.outputs %}
+
+**Outputs:**
+{% for out in step.yaml.outputs %}
+- `{{ out.name }}` (`{{ out.path }}`) — {{ out.description|default('') }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/scripts/portal_generator/templates/mcp_detail_page.html
+++ b/scripts/portal_generator/templates/mcp_detail_page.html
@@ -2,6 +2,10 @@
 
 {% block title %}{{ mcp.name }} - Anypoint Platform MCP Servers{% endblock %}
 
+{% block markdown_alternate %}
+<link rel="alternate" type="text/markdown" href="{{ base_url }}/mcps/{{ mcp.slug }}.md">
+{% endblock %}
+
 {% block body_attrs %} class="detail-page mcp-detail-page"{% endblock %}
 
 {% block head_scripts %}

--- a/scripts/portal_generator/templates/skill_page.html
+++ b/scripts/portal_generator/templates/skill_page.html
@@ -3,6 +3,10 @@
 
 {% block title %}{{ skill_name }} - Anypoint Platform APIs{% endblock %}
 
+{% block markdown_alternate %}
+<link rel="alternate" type="text/markdown" href="{{ base_url }}/skills/{{ skill.slug }}.md">
+{% endblock %}
+
 {% block body_attrs %} class="detail-page skill-page"{% endblock %}
 
 {% block head_scripts %}

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -416,7 +416,7 @@ class TestHomepageAgentLinks:
     def test_has_llms_txt_head_link(self):
         link = self.soup.find('link', attrs={'href': lambda v: v and 'llms.txt' in v})
         assert link is not None
-        assert link.get('type') == 'text/plain'
+        assert link.get('rel') == ['llms-txt']
 
     def test_has_registry_json_head_link(self):
         link = self.soup.find('link', attrs={'href': lambda v: v and 'registry.json' in v})


### PR DESCRIPTION
…he headers

- Add <link rel="llms-txt"> directive to all HTML pages
- Add <link rel="alternate" type="text/markdown"> per page
- Generate .md alternatives for all HTML pages (APIs, MCPs, skills, homepage)
- Expand llms.txt to list all pages with markdown URLs
- Generate _headers file for CDN cache control
- Move Ace Editor scripts to end of body to reduce content-start position