### PR TITLE
fix: @W-22617786 dark mode toggle icon when OS prefers dark

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -8361,7 +8361,7 @@ function clearAllVariables(slug) {
     if (savedTheme === 'dark') {
         document.documentElement.setAttribute('data-theme', 'dark');
     } else if (savedTheme === 'light') {
-        document.documentElement.removeAttribute('data-theme');
+        document.documentElement.setAttribute('data-theme', 'light');
     }
     // Create and inject dark mode toggle button
     var toggleButton = document.createElement('button');
@@ -8391,11 +8391,7 @@ function clearAllVariables(slug) {
         var currentTheme = document.documentElement.getAttribute('data-theme');
         var newTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
-        if (newTheme === 'dark') {
-            document.documentElement.setAttribute('data-theme', 'dark');
-        } else {
-            document.documentElement.removeAttribute('data-theme');
-        }
+        document.documentElement.setAttribute('data-theme', newTheme);
 
         localStorage.setItem('theme', newTheme);
         updateToggleButton();
@@ -8419,11 +8415,7 @@ function clearAllVariables(slug) {
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
             // Only auto-switch if user hasn't manually set a preference
             if (!localStorage.getItem('theme')) {
-                if (e.matches) {
-                    document.documentElement.setAttribute('data-theme', 'dark');
-                } else {
-                    document.documentElement.removeAttribute('data-theme');
-                }
+                document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
                 updateToggleButton();
                 updateAllAceEditors();
             }

--- a/scripts/portal_generator/templates/base.html
+++ b/scripts/portal_generator/templates/base.html
@@ -21,9 +21,7 @@
             var savedTheme = localStorage.getItem('theme');
             var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var initialTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light');
-            if (initialTheme === 'dark') {
-                document.documentElement.setAttribute('data-theme', 'dark');
-            }
+            document.documentElement.setAttribute('data-theme', initialTheme);
         })();
     </script>
     {% block head_scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- Toggle now alternates between moon (light) and sun (dark) regardless of OS `prefers-color-scheme`.
- Root cause: `toggleDarkMode()` removed the `data-theme` attribute when switching to light, letting the `prefers-color-scheme: dark` media query fall through and keep showing the sun icon.
- Fix: always set `data-theme` explicitly to `light` or `dark` (in `portal.js` init/toggle/system-listener and in the `base.html` head script). The `:root:not([data-theme])` media-query rule remains as a defensive fallback.

## GUS
W-22617786

## Test plan
- [x] `make test-portal` (435 pytest + 186 jest) passes
- [ ] OS dark mode → click toggle → icon becomes moon, page becomes light
- [ ] OS dark mode + cleared `localStorage.theme` → first paint is dark with sun icon
- [ ] OS light mode → toggle → icon becomes sun, page becomes dark