### PR TITLE
fix: cache-busting for static assets on new releases

### DIFF
--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -16,6 +16,7 @@ from .builders.tree_builder import build_operation_tree
 from .assets import get_css, get_js, get_jsonpath_js
 from .template_env import create_env, _skill_title
 from .mulesoft_chrome import fetch_mulesoft_chrome
+from .utils import hash_asset_filename
 
 _SKILL_SKIP_DIRS = {'node_modules', '__pycache__', '.git', '.sdd'}
 _SKILL_SKIP_FILES = {'.DS_Store'}
@@ -142,8 +143,7 @@ def _render_api_page(args: Dict) -> None:
     api = args['api']
     operation_tree = build_operation_tree(api['operations'])
     html = template.render(
-        css_path='../assets/styles.css',
-        icons_path='../assets/icons',
+        **args['asset_paths'],
         api=api,
         api_meta=_build_api_meta(api),
         op_lookup=args['op_lookup'],
@@ -169,8 +169,7 @@ def _render_mcp_page(args: Dict) -> None:
 
     mcp_meta = args['mcp_meta']
     html = template.render(
-        css_path='../assets/styles.css',
-        icons_path='../assets/icons',
+        **args['asset_paths'],
         mcp=mcp,
         mcp_meta=mcp_meta,
         op_lookup=args['op_lookup'],
@@ -196,8 +195,7 @@ def _render_skill_page(args: Dict) -> None:
     skill_name = _skill_title(skill.get('name', skill['slug']))
 
     html = template.render(
-        css_path='../assets/styles.css',
-        icons_path='../assets/icons',
+        **args['asset_paths'],
         skill=skill,
         skill_name=skill_name,
         api_meta=args['api_meta'],
@@ -233,8 +231,7 @@ def _render_terraform_page(args: Dict) -> None:
     provider = args['provider']
 
     html = template.render(
-        css_path='../assets/styles.css',
-        icons_path='../assets/icons',
+        **args['asset_paths'],
         provider=provider,
         nav_tree=provider['nav_tree'],
         nav_tree_by_type=provider['nav_tree_by_type'],
@@ -350,6 +347,8 @@ class PortalGenerator:
 
         # Generate files
         print(f"\n📝 Generating portal files (workers={self.workers})...")
+        self._css_filename = self._generate_css()
+        self._js_filename, self._jsonpath_filename = self._generate_js()
         self._generate_homepage()
         self._generate_detail_pages_parallel()
         self._generate_registry()
@@ -358,8 +357,6 @@ class PortalGenerator:
         self._generate_llms_txt()
         self._generate_markdown_pages()
         self._generate_headers()
-        self._generate_css()
-        self._generate_js()
         self._copy_images()
 
         print("\n" + "=" * 60)
@@ -368,6 +365,16 @@ class PortalGenerator:
         print(f"🌐 Open: {self.output_dir}/index.html")
         print(f"📋 Registry: {self.output_dir}/registry.json")
         print(f"🤖 Agent guide: {self.output_dir}/AGENTS.md")
+
+    def _asset_paths(self, depth: int = 1) -> dict:
+        """Return template variables for hashed asset paths at the given directory depth."""
+        prefix = '../' * depth if depth > 0 else ''
+        return {
+            'css_path': f"{prefix}assets/{self._css_filename}",
+            'icons_path': f"{prefix}assets/icons",
+            'portal_js_path': f"{prefix}assets/{self._js_filename}",
+            'jsonpath_js_path': f"{prefix}assets/{self._jsonpath_filename}",
+        }
 
     def _generate_homepage(self):
         """Generate index.html"""
@@ -402,8 +409,7 @@ class PortalGenerator:
         all_items.sort(key=lambda x: x.get('name', '').lower())
 
         html = template.render(
-            css_path='assets/styles.css',
-            icons_path='assets/icons',
+            **self._asset_paths(0),
             apis=self.public_apis,
             mcp_servers=self.public_mcps,
             stats=self.stats,
@@ -473,6 +479,7 @@ class PortalGenerator:
                 'chrome': chrome,
                 'repo_url': self.REPO_URL,
                 'repo_branch': self.REPO_BRANCH,
+                'asset_paths': self._asset_paths(1),
                 'output_path': str(self.output_dir / 'apis' / f"{api['slug']}.html"),
             }))
 
@@ -496,6 +503,7 @@ class PortalGenerator:
                     'chrome': chrome,
                     'repo_url': self.REPO_URL,
                     'repo_branch': self.REPO_BRANCH,
+                    'asset_paths': self._asset_paths(1),
                     'output_path': str(self.output_dir / 'mcps' / f"{mcp['slug']}.html"),
                 }))
 
@@ -546,6 +554,7 @@ class PortalGenerator:
                 'chrome': chrome,
                 'repo_url': self.REPO_URL,
                 'repo_branch': self.REPO_BRANCH,
+                'asset_paths': self._asset_paths(1),
                 'output_path': str(self.output_dir / 'skills' / f"{skill['slug']}.html"),
                 'skill_source_dir': str(skill_source_dir) if skill_source_dir.is_dir() else None,
                 'manifest_output_dir': str(self.output_dir / 'skills' / skill_rel),
@@ -564,6 +573,7 @@ class PortalGenerator:
                     'chrome': {'footer': self.chrome.get('footer', ''), 'dependencies': self.chrome.get('dependencies', '')} if self.chrome else None,
                     'repo_url': self.REPO_URL,
                     'repo_branch': self.REPO_BRANCH,
+                    'asset_paths': self._asset_paths(1),
                     'source_path': f"terraform/{provider['slug']}",
                 }))
 
@@ -593,8 +603,7 @@ class PortalGenerator:
             api_meta = _build_api_meta(api)
             operation_tree = build_operation_tree(api['operations'])
             html = template.render(
-                css_path='../assets/styles.css',
-                icons_path='../assets/icons',
+                **self._asset_paths(1),
                 api=api,
                 api_meta=api_meta,
                 op_lookup=op_lookup,
@@ -686,8 +695,7 @@ class PortalGenerator:
             mcp_lookup = {s: full_mcp_lookup[s] for s in mcp_refs if s in full_mcp_lookup}
 
             html = template.render(
-                css_path='../assets/styles.css',
-                icons_path='../assets/icons',
+                **self._asset_paths(1),
                 mcp=mcp,
                 mcp_meta=mcp_meta,
                 op_lookup=op_lookup,
@@ -751,8 +759,7 @@ class PortalGenerator:
                     })
 
             html = template.render(
-                css_path='../assets/styles.css',
-                icons_path='../assets/icons',
+                **self._asset_paths(1),
                 skill=skill,
                 skill_name=skill_name,
                 api_meta=api_meta,
@@ -811,8 +818,7 @@ class PortalGenerator:
             nav_tree_by_type = provider['nav_tree_by_type']
 
             html = template.render(
-                css_path='../assets/styles.css',
-                icons_path='../assets/icons',
+                **self._asset_paths(1),
                 provider=provider,
                 nav_tree=nav_tree,
                 nav_tree_by_type=nav_tree_by_type,
@@ -1106,22 +1112,31 @@ class PortalGenerator:
 """
         (self.output_dir / '_headers').write_text(headers, encoding='utf-8')
 
-    def _generate_css(self):
-        """Generate styles.css"""
+    def _generate_css(self) -> str:
+        """Generate styles.css with content-hashed filename."""
         print("  ✓ Generating CSS...")
-        output_path = self.output_dir / 'assets' / 'styles.css'
+        content = get_css()
+        hashed_name = hash_asset_filename('styles.css', content)
+        output_path = self.output_dir / 'assets' / hashed_name
         with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(get_css())
+            f.write(content)
+        return hashed_name
 
-    def _generate_js(self):
-        """Generate portal.js and jsonpath-plus library"""
+    def _generate_js(self) -> tuple:
+        """Generate portal.js and jsonpath-plus library with content-hashed filenames."""
         print("  ✓ Generating JavaScript...")
-        output_path = self.output_dir / 'assets' / 'portal.js'
+        js_content = get_js()
+        js_name = hash_asset_filename('portal.js', js_content)
+        output_path = self.output_dir / 'assets' / js_name
         with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(get_js())
-        jsonpath_path = self.output_dir / 'assets' / 'jsonpath-plus.min.js'
+            f.write(js_content)
+
+        jsonpath_content = get_jsonpath_js()
+        jsonpath_name = hash_asset_filename('jsonpath-plus.min.js', jsonpath_content)
+        jsonpath_path = self.output_dir / 'assets' / jsonpath_name
         with open(jsonpath_path, 'w', encoding='utf-8') as f:
-            f.write(get_jsonpath_js())
+            f.write(jsonpath_content)
+        return (js_name, jsonpath_name)
 
     def _copy_images(self):
         

--- a/scripts/portal_generator/templates/detail_page.html
+++ b/scripts/portal_generator/templates/detail_page.html
@@ -10,8 +10,8 @@
 
 {% block head_scripts %}
 {% include "partials/prism_head.html" %}
-<script src="../assets/jsonpath-plus.min.js" defer></script>
-<script src="../assets/portal.js" defer></script>
+<script src="{{ jsonpath_js_path }}" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 {% endblock %}
 
 {% block header %}

--- a/scripts/portal_generator/templates/homepage.html
+++ b/scripts/portal_generator/templates/homepage.html
@@ -7,8 +7,8 @@
 {% endblock %}
 
 {% block head_scripts %}
-<script src="assets/jsonpath-plus.min.js" defer></script>
-<script src="assets/portal.js" defer></script>
+<script src="{{ jsonpath_js_path }}" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 {% endblock %}
 
 {% block header %}

--- a/scripts/portal_generator/templates/mcp_detail_page.html
+++ b/scripts/portal_generator/templates/mcp_detail_page.html
@@ -10,8 +10,8 @@
 
 {% block head_scripts %}
 {% include "partials/prism_head.html" %}
-<script src="../assets/jsonpath-plus.min.js" defer></script>
-<script src="../assets/portal.js" defer></script>
+<script src="{{ jsonpath_js_path }}" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     if (typeof wrapMcpCodeBlocks === 'function') wrapMcpCodeBlocks();

--- a/scripts/portal_generator/templates/skill_page.html
+++ b/scripts/portal_generator/templates/skill_page.html
@@ -13,10 +13,10 @@
 {% include "partials/prism_head.html" %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" defer></script>
 {% if not prose_only %}
-<script src="../assets/jsonpath-plus.min.js" defer></script>
+<script src="{{ jsonpath_js_path }}" defer></script>
 {% endif %}
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" defer></script>
-<script src="../assets/portal.js" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 {% endblock %}
 
 {% block header %}

--- a/scripts/portal_generator/templates/terraform_page.html
+++ b/scripts/portal_generator/templates/terraform_page.html
@@ -6,7 +6,7 @@
 
 {% block head_scripts %}
 {% include "partials/prism_head.html" %}
-<script src="../assets/portal.js" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 {% endblock %}
 
 {% block header %}

--- a/scripts/portal_generator/utils.py
+++ b/scripts/portal_generator/utils.py
@@ -52,7 +52,9 @@ def get_category(api_name: str) -> str:
 def hash_asset_filename(filename: str, content: str) -> str:
     """Return filename with 8-char content hash inserted before the final extension."""
     dot_pos = filename.rfind('.')
+    digest = hashlib.md5(content.encode('utf-8')).hexdigest()[:8]  # noqa: S324
+    if dot_pos == -1:
+        return f"{filename}.{digest}"
     base = filename[:dot_pos]
     ext = filename[dot_pos:]
-    digest = hashlib.md5(content.encode('utf-8')).hexdigest()[:8]
     return f"{base}.{digest}{ext}"

--- a/scripts/portal_generator/utils.py
+++ b/scripts/portal_generator/utils.py
@@ -2,6 +2,7 @@
 Utility functions and constants for the portal generator.
 """
 
+import hashlib
 from typing import Dict
 
 # ============================================================================
@@ -46,3 +47,12 @@ CATEGORY_MAPPING = {
 def get_category(api_name: str) -> str:
     """Get category for an API"""
     return CATEGORY_MAPPING.get(api_name, 'Platform')
+
+
+def hash_asset_filename(filename: str, content: str) -> str:
+    """Return filename with 8-char content hash inserted before the final extension."""
+    dot_pos = filename.rfind('.')
+    base = filename[:dot_pos]
+    ext = filename[dot_pos:]
+    digest = hashlib.md5(content.encode('utf-8')).hexdigest()[:8]
+    return f"{base}.{digest}{ext}"

--- a/scripts/tests/test_cache_busting.py
+++ b/scripts/tests/test_cache_busting.py
@@ -1,0 +1,36 @@
+"""Tests for cache-busting asset filename hashing."""
+import pytest
+from portal_generator.utils import hash_asset_filename
+
+
+class TestHashAssetFilename:
+    def test_simple_css(self):
+        result = hash_asset_filename('styles.css', 'body { color: red; }')
+        assert result.startswith('styles.')
+        assert result.endswith('.css')
+        parts = result.split('.')
+        assert len(parts) == 3
+        assert len(parts[1]) == 8
+
+    def test_deterministic(self):
+        content = 'body { color: red; }'
+        r1 = hash_asset_filename('styles.css', content)
+        r2 = hash_asset_filename('styles.css', content)
+        assert r1 == r2
+
+    def test_different_content_different_hash(self):
+        r1 = hash_asset_filename('styles.css', 'body { color: red; }')
+        r2 = hash_asset_filename('styles.css', 'body { color: blue; }')
+        assert r1 != r2
+
+    def test_js_extension(self):
+        result = hash_asset_filename('portal.js', 'console.log("hi")')
+        assert result.startswith('portal.')
+        assert result.endswith('.js')
+
+    def test_dotted_filename(self):
+        result = hash_asset_filename('jsonpath-plus.min.js', 'var x=1;')
+        assert result.startswith('jsonpath-plus.min.')
+        assert result.endswith('.js')
+        parts = result.rsplit('.', 2)
+        assert len(parts[1]) == 8

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -69,17 +69,18 @@ class TestGeneratedFiles:
         assert (generated_portal / 'apis' / 'test-api.html').exists()
 
     def test_css_exists(self, generated_portal):
-        css = generated_portal / 'assets' / 'styles.css'
-        assert css.exists()
-        assert css.stat().st_size > 0
+        css_files = list((generated_portal / 'assets').glob('styles.*.css'))
+        assert len(css_files) == 1
+        assert css_files[0].stat().st_size > 0
 
     def test_portal_js_exists(self, generated_portal):
-        js = generated_portal / 'assets' / 'portal.js'
-        assert js.exists()
-        assert js.stat().st_size > 0
+        js_files = list((generated_portal / 'assets').glob('portal.*.js'))
+        assert len(js_files) == 1
+        assert js_files[0].stat().st_size > 0
 
     def test_jsonpath_js_exists(self, generated_portal):
-        assert (generated_portal / 'assets' / 'jsonpath-plus.min.js').exists()
+        jp_files = list((generated_portal / 'assets').glob('jsonpath-plus.min.*.js'))
+        assert len(jp_files) == 1
 
 
 class TestHomepageStructure:

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -1025,3 +1025,42 @@ class TestMaliciousTerraformSmokeRawHtml:
         for s in soup.find_all('script'):
             body = s.string or ''
             assert 'evil.example' not in body
+
+
+class TestCacheBustingIntegration:
+    """Verify generated HTML pages reference the correct hashed asset filenames."""
+
+    def test_homepage_references_hashed_css(self, generated_portal):
+        html = (generated_portal / 'index.html').read_text(encoding='utf-8')
+        css_files = list((generated_portal / 'assets').glob('styles.*.css'))
+        assert len(css_files) == 1
+        css_name = css_files[0].name
+        assert f'assets/{css_name}' in html
+
+    def test_homepage_references_hashed_js(self, generated_portal):
+        html = (generated_portal / 'index.html').read_text(encoding='utf-8')
+        js_files = list((generated_portal / 'assets').glob('portal.*.js'))
+        assert len(js_files) == 1
+        assert js_files[0].name in html
+
+    def test_detail_page_references_hashed_css(self, generated_portal):
+        detail_pages = list((generated_portal / 'apis').glob('*.html'))
+        assert len(detail_pages) > 0
+        html = detail_pages[0].read_text(encoding='utf-8')
+        css_files = list((generated_portal / 'assets').glob('styles.*.css'))
+        css_name = css_files[0].name
+        assert f'assets/{css_name}' in html
+
+    def test_detail_page_references_hashed_js(self, generated_portal):
+        detail_pages = list((generated_portal / 'apis').glob('*.html'))
+        assert len(detail_pages) > 0
+        html = detail_pages[0].read_text(encoding='utf-8')
+        js_files = list((generated_portal / 'assets').glob('portal.*.js'))
+        assert js_files[0].name in html
+
+    def test_no_unhashed_asset_references(self, generated_portal):
+        for html_file in generated_portal.rglob('*.html'):
+            content = html_file.read_text(encoding='utf-8')
+            assert 'assets/styles.css' not in content, f"{html_file} still references unhashed styles.css"
+            assert 'assets/portal.js' not in content, f"{html_file} still references unhashed portal.js"
+            assert 'assets/jsonpath-plus.min.js' not in content, f"{html_file} still references unhashed jsonpath-plus.min.js"


### PR DESCRIPTION
## Summary
- Add content-hash fingerprinting to generated CSS/JS files (`styles.<hash>.css`, `portal.<hash>.js`, `jsonpath-plus.min.<hash>.js`)
- Eliminates stale-cache issues where users see broken layouts after a deploy until they hard-reload
- All HTML templates reference hashed filenames via template variables instead of hardcoded paths

## Problem
After a deploy, browsers/CDN serve the old `styles.css` from cache (same filename = cache hit). Users see broken layout until hard-reload.

## Solution
Each generated asset now has an 8-char MD5 content hash in its filename. When content changes, the filename changes, forcing a fresh fetch. The `_headers` file already sets `Cache-Control: immutable` on `/assets/*`, which pairs perfectly with content-hashed filenames.

## Test plan
- [x] 445 pytest + 184 jest pass (zero regressions)
- [x] 5 new integration tests verify no HTML references unhashed assets
- [x] 62 visual regression screenshots match master baseline
- [x] Manual verification: portal renders correctly with hashed assets
- [x] Verified: changing CSS content produces different hash in output filename