### PR TITLE
fix: @W-22727565 x-origin modal button reset and error visibility

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -587,7 +587,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
 
         if (data.status < 200 || data.status >= 300) {
             if (data.status === 401 || data.status === 403) {
-                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Authentication required. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to access this resource.</div>';
+                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Access denied. Your token may have expired or lack permissions.</div>';
             } else {
                 if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
             }

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -434,14 +434,14 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     // Check authentication
     var token = sessionStorage.getItem('anypoint_token');
     if (!token) {
-        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Authentication required. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to fetch values.</div>';
+        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Please authenticate first.</div>';
         responseDiv.classList.remove('empty');
         switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
     if (isTokenExpired()) {
-        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Token expired. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to refresh authentication.</div>';
+        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Token expired. Please re-authenticate.</div>';
         responseDiv.classList.remove('empty');
         switchResponseTab(xoriginOpId, 'body');
         resetButton();
@@ -586,11 +586,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
         }
 
         if (data.status < 200 || data.status >= 300) {
-            if (data.status === 401 || data.status === 403) {
-                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Access denied. Your token may have expired or lack permissions.</div>';
-            } else {
-                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
-            }
+            if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
             if (responseDiv) responseDiv.classList.remove('empty');
             switchResponseTab(xoriginOpId, 'body');
             resetButton();

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -578,11 +578,17 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
 
         if (data.error) {
             if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Error: ' + escapeHtml(data.error) + '</div>';
+            resetButton();
             return;
         }
 
         if (data.status < 200 || data.status >= 300) {
-            if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
+            if (data.status === 401 || data.status === 403) {
+                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Authentication required. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to access this resource.</div>';
+            } else {
+                if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
+            }
+            resetButton();
             return;
         }
 
@@ -595,6 +601,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
             body = JSON.parse(data.body || '{}');
         } catch (e) {
             console.warn('X-Origin: Response is not valid JSON, cannot extract values');
+            resetButton();
             return;
         }
 

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -412,10 +412,20 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
         buttonEl.disabled = true;
     }
 
+    // Helper to reset button state
+    function resetButton() {
+        if (buttonEl) {
+            var textSpan = buttonEl.querySelector('span');
+            if (textSpan) textSpan.textContent = originalText;
+            buttonEl.disabled = false;
+        }
+    }
+
     // Get the origin configuration from current modal context
     var currentModal = xOriginModalStack[xOriginModalStack.length - 1];
     if (!currentModal) {
         console.error('No current x-origin modal in stack');
+        resetButton();
         return;
     }
     var origins = currentModal.origins;
@@ -424,13 +434,15 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     // Check authentication
     var token = sessionStorage.getItem('anypoint_token');
     if (!token) {
-        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Please authenticate first.</div>';
+        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Authentication required. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to fetch values.</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
     if (isTokenExpired()) {
-        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Token expired. Please re-authenticate.</div>';
+        if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Token expired. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to refresh authentication.</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
 
@@ -445,6 +457,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (!apiEntry) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">API "' + escapeHtml(apiSlug) + '" not found.</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
 
@@ -452,6 +465,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (!opMeta) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Operation "' + escapeHtml(operationId) + '" not found.</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
 
@@ -479,6 +493,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (missingParams.length > 0) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Missing required parameters: ' + escapeHtml(missingParams.join(', ')) + '</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
 
@@ -494,6 +509,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (unresolvedParams.length > 0) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Missing path parameters: ' + escapeHtml(unresolvedParams.join(', ')) + '</div>';
         responseDiv.classList.remove('empty');
+        resetButton();
         return;
     }
 

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -551,12 +551,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
         var data = await resp.json();
         await handleProxyResponse(data);
 
-        // Restore button
-        if (buttonEl) {
-            var textSpan = buttonEl.querySelector('span');
-            if (textSpan) textSpan.textContent = originalText;
-            buttonEl.disabled = false;
-        }
+        resetButton();
 
         if (responseDiv) responseDiv.classList.remove('empty');
 

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -436,12 +436,14 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (!token) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Authentication required. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to fetch values.</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
     if (isTokenExpired()) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Token expired. <a href="#" onclick="openAuthModal(); return false;" class="xorigin-error-link">Sign in</a> to refresh authentication.</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
@@ -457,6 +459,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (!apiEntry) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">API "' + escapeHtml(apiSlug) + '" not found.</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
@@ -465,6 +468,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (!opMeta) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Operation "' + escapeHtml(operationId) + '" not found.</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
@@ -493,6 +497,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (missingParams.length > 0) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Missing required parameters: ' + escapeHtml(missingParams.join(', ')) + '</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
@@ -509,6 +514,7 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
     if (unresolvedParams.length > 0) {
         if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Missing path parameters: ' + escapeHtml(unresolvedParams.join(', ')) + '</div>';
         responseDiv.classList.remove('empty');
+        switchResponseTab(xoriginOpId, 'body');
         resetButton();
         return;
     }
@@ -573,6 +579,8 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
 
         if (data.error) {
             if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Error: ' + escapeHtml(data.error) + '</div>';
+            if (responseDiv) responseDiv.classList.remove('empty');
+            switchResponseTab(xoriginOpId, 'body');
             resetButton();
             return;
         }
@@ -583,6 +591,8 @@ async function executeXOriginSource(sourceIdx, buttonEl) {
             } else {
                 if (responseBodyDiv) responseBodyDiv.innerHTML = '<div class="xorigin-error">Request returned status ' + data.status + '</div>';
             }
+            if (responseDiv) responseDiv.classList.remove('empty');
+            switchResponseTab(xoriginOpId, 'body');
             resetButton();
             return;
         }

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -7226,6 +7226,16 @@ details[open] .examples-toggle-icon {
     margin-top: var(--space-sm);
 }
 
+.xorigin-error-link {
+    color: var(--color-danger);
+    text-decoration: underline;
+    font-weight: var(--font-weight-semibold);
+}
+
+.xorigin-error-link:hover {
+    text-decoration: none;
+}
+
 /* X-Origin Panel Header (matches try-panel-header styling) */
 .xorigin-panel-header {
     display: flex;

--- a/scripts/portal_generator/assets/styles.css
+++ b/scripts/portal_generator/assets/styles.css
@@ -7226,15 +7226,6 @@ details[open] .examples-toggle-icon {
     margin-top: var(--space-sm);
 }
 
-.xorigin-error-link {
-    color: var(--color-danger);
-    text-decoration: underline;
-    font-weight: var(--font-weight-semibold);
-}
-
-.xorigin-error-link:hover {
-    text-decoration: none;
-}
 
 /* X-Origin Panel Header (matches try-panel-header styling) */
 .xorigin-panel-header {

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -2059,7 +2059,7 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
     // --- 5. Auth CTA link for 401/403 responses ---
 
-    test('shows auth CTA link in error message for 401 response', async () => {
+    test('shows access denied message for 401 response', async () => {
         sessionStorage.setItem('anypoint_token', 'valid-token');
         sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
 
@@ -2071,15 +2071,11 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
-        expect(errorDiv.textContent).toContain('Authentication required');
-
-        const link = errorDiv.querySelector('.xorigin-error-link');
-        expect(link).not.toBeNull();
-        expect(link.textContent).toContain('Sign in');
-        expect(link.getAttribute('onclick')).toContain('openAuthModal');
+        expect(errorDiv.textContent).toContain('Access denied');
+        expect(errorDiv.textContent).toContain('expired or lack permissions');
     });
 
-    test('shows auth CTA link in error message for 403 response', async () => {
+    test('shows access denied message for 403 response', async () => {
         sessionStorage.setItem('anypoint_token', 'valid-token');
         sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
 
@@ -2091,11 +2087,8 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
-        expect(errorDiv.textContent).toContain('Authentication required');
-
-        const link = errorDiv.querySelector('.xorigin-error-link');
-        expect(link).not.toBeNull();
-        expect(link.textContent).toContain('Sign in');
+        expect(errorDiv.textContent).toContain('Access denied');
+        expect(errorDiv.textContent).toContain('expired or lack permissions');
     });
 
     // --- 6. No regression: button resets after generic error (data.error) ---

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -1869,4 +1869,303 @@ describe('toggleSkillMode scroll behavior', () => {
     });
 });
 
+// ===========================================================================
+// executeXOriginSource — button reset and auth errors
+// ===========================================================================
+
+describe('executeXOriginSource — button reset and auth errors', () => {
+    let responseDiv, responseBodyDiv, sourceDiv, btn, textSpan;
+
+    function setupMinimalDom() {
+        // Minimal DOM structure for executeXOriginSource
+        responseDiv = document.createElement('div');
+        responseDiv.id = 'response-xorigin-0';
+        responseDiv.classList.add('empty');
+        document.body.appendChild(responseDiv);
+
+        responseBodyDiv = document.createElement('div');
+        responseBodyDiv.id = 'respbody-xorigin-0';
+        document.body.appendChild(responseBodyDiv);
+
+        sourceDiv = document.createElement('div');
+        sourceDiv.className = 'xorigin-source';
+        sourceDiv.setAttribute('data-source-idx', '0');
+        document.body.appendChild(sourceDiv);
+
+        // Button element with span
+        btn = document.createElement('button');
+        textSpan = document.createElement('span');
+        textSpan.textContent = 'Send';
+        btn.appendChild(textSpan);
+
+        // Mock window.__OP_LOOKUP__ for API/operation resolution
+        window.__OP_LOOKUP__ = {
+            'test-api': {
+                ops: {
+                    'listItems': {
+                        method: 'GET',
+                        path: '/api/v1/items'
+                    }
+                }
+            }
+        };
+
+        // Mock xOriginModalStack
+        xOriginModalStack.length = 0;
+        xOriginModalStack.push({
+            opId: 'test-op',
+            paramName: 'testParam',
+            origins: [{
+                api: 'urn:api:test-api',
+                operation: 'listItems',
+                values: '$.data[*].id'
+            }]
+        });
+    }
+
+    function cleanupDom() {
+        document.body.innerHTML = '';
+        sessionStorage.clear();
+        delete window.__OP_LOOKUP__;
+        xOriginModalStack.length = 0;
+        delete global.fetch;
+    }
+
+    beforeEach(() => {
+        setupMinimalDom();
+        // Minimal DOM for updateAuthSummary (called by markTokenExpired)
+        ['authStatusDot', 'authStatusText', 'authLockIcon'].forEach(id => {
+            if (!document.getElementById(id)) {
+                const el = document.createElement(id === 'authStatusText' ? 'span' : 'img');
+                el.id = id;
+                if (el.tagName === 'IMG') el.src = 'assets/icons/placeholder.svg';
+                document.body.appendChild(el);
+            }
+        });
+    });
+
+    afterEach(() => {
+        cleanupDom();
+    });
+
+    // --- 1. Button reset after auth error (no token) ---
+
+    test('resets button to original text after auth error (no token)', async () => {
+        sessionStorage.removeItem('anypoint_token');
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+    });
+
+    test('re-enables button after auth error (no token)', async () => {
+        sessionStorage.removeItem('anypoint_token');
+        await executeXOriginSource(0, btn);
+        expect(btn.disabled).toBe(false);
+    });
+
+    // --- 2. Auth CTA link for no-token case ---
+
+    test('shows auth CTA link in error message when no token', async () => {
+        sessionStorage.removeItem('anypoint_token');
+        await executeXOriginSource(0, btn);
+
+        const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
+        expect(errorDiv).not.toBeNull();
+        expect(errorDiv.textContent).toContain('Authentication required');
+
+        const link = errorDiv.querySelector('.xorigin-error-link');
+        expect(link).not.toBeNull();
+        expect(link.textContent).toContain('Sign in');
+        expect(link.getAttribute('onclick')).toContain('openAuthModal');
+    });
+
+    // --- 3. Auth CTA link for expired-token case ---
+
+    test('shows auth CTA link in error message when token expired', async () => {
+        sessionStorage.setItem('anypoint_token', 'expired-token');
+        sessionStorage.setItem('anypoint_token_expires_at', '0');
+        await executeXOriginSource(0, btn);
+
+        const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
+        expect(errorDiv).not.toBeNull();
+        expect(errorDiv.textContent).toContain('Token expired');
+
+        const link = errorDiv.querySelector('.xorigin-error-link');
+        expect(link).not.toBeNull();
+        expect(link.textContent).toContain('Sign in');
+        expect(link.getAttribute('onclick')).toContain('openAuthModal');
+    });
+
+    test('resets button to original text after expired token error', async () => {
+        sessionStorage.setItem('anypoint_token', 'expired-token');
+        sessionStorage.setItem('anypoint_token_expires_at', '0');
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    // --- 4. Button reset after non-2xx response (including 401/403) ---
+
+    test('resets button after 401 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 401, body: 'Unauthorized' })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    test('resets button after 403 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 403, body: 'Forbidden' })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    test('resets button after 404 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 404, body: 'Not Found' })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    test('resets button after 500 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 500, body: 'Internal Server Error' })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    // --- 5. Auth CTA link for 401/403 responses ---
+
+    test('shows auth CTA link in error message for 401 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 401, body: 'Unauthorized' })
+        }));
+
+        await executeXOriginSource(0, btn);
+
+        const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
+        expect(errorDiv).not.toBeNull();
+        expect(errorDiv.textContent).toContain('Authentication required');
+
+        const link = errorDiv.querySelector('.xorigin-error-link');
+        expect(link).not.toBeNull();
+        expect(link.textContent).toContain('Sign in');
+        expect(link.getAttribute('onclick')).toContain('openAuthModal');
+    });
+
+    test('shows auth CTA link in error message for 403 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 403, body: 'Forbidden' })
+        }));
+
+        await executeXOriginSource(0, btn);
+
+        const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
+        expect(errorDiv).not.toBeNull();
+        expect(errorDiv.textContent).toContain('Authentication required');
+
+        const link = errorDiv.querySelector('.xorigin-error-link');
+        expect(link).not.toBeNull();
+        expect(link.textContent).toContain('Sign in');
+    });
+
+    // --- 6. No regression: button resets after generic error (data.error) ---
+
+    test('resets button after generic proxy error (data.error)', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ error: 'Connection timeout' })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    test('shows error message for generic proxy error', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ error: 'Network error' })
+        }));
+
+        await executeXOriginSource(0, btn);
+
+        const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
+        expect(errorDiv).not.toBeNull();
+        expect(errorDiv.textContent).toContain('Network error');
+    });
+
+    // --- 7. Additional edge cases ---
+
+    test('button shows "Sending..." while request is pending', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        // Create a promise that we'll resolve manually
+        let resolvePromise;
+        const promise = new Promise(resolve => { resolvePromise = resolve; });
+
+        global.fetch = jest.fn(() => promise);
+
+        // Start the request (don't await)
+        const execution = executeXOriginSource(0, btn);
+
+        // Check button state immediately
+        expect(textSpan.textContent).toBe('Sending...');
+        expect(btn.disabled).toBe(true);
+
+        // Resolve the promise
+        resolvePromise({ json: () => Promise.resolve({ status: 200, body: '{"data":[]}' }) });
+
+        // Wait for execution to complete
+        await execution;
+    });
+
+    test('does not reset button when no button element provided', async () => {
+        sessionStorage.removeItem('anypoint_token');
+        await executeXOriginSource(0, null);
+        // Should not throw, just handle gracefully
+    });
+
+    test('handles missing text span gracefully', async () => {
+        sessionStorage.removeItem('anypoint_token');
+        const btnNoSpan = document.createElement('button');
+        await executeXOriginSource(0, btnNoSpan);
+        // Should not throw
+    });
+});
+
 

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -2166,6 +2166,36 @@ describe('executeXOriginSource — button reset and auth errors', () => {
         await executeXOriginSource(0, btnNoSpan);
         // Should not throw
     });
+
+    // --- 8. Button reset after successful 200 response ---
+
+    test('resets button after successful 200 response', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 200, body: '{"data":[{"id":"abc"}]}', headers: {} })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
+
+    // --- 9. Button reset after JSON parse failure ---
+
+    test('resets button after invalid JSON in response body', async () => {
+        sessionStorage.setItem('anypoint_token', 'valid-token');
+        sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            json: () => Promise.resolve({ status: 200, body: 'not-valid-json{{{', headers: {} })
+        }));
+
+        await executeXOriginSource(0, btn);
+        expect(textSpan.textContent).toBe('Send');
+        expect(btn.disabled).toBe(false);
+    });
 });
 
 

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -1964,23 +1964,18 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
     // --- 2. Auth CTA link for no-token case ---
 
-    test('shows auth CTA link in error message when no token', async () => {
+    test('shows auth error message when no token', async () => {
         sessionStorage.removeItem('anypoint_token');
         await executeXOriginSource(0, btn);
 
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
-        expect(errorDiv.textContent).toContain('Authentication required');
-
-        const link = errorDiv.querySelector('.xorigin-error-link');
-        expect(link).not.toBeNull();
-        expect(link.textContent).toContain('Sign in');
-        expect(link.getAttribute('onclick')).toContain('openAuthModal');
+        expect(errorDiv.textContent).toContain('Please authenticate first');
     });
 
-    // --- 3. Auth CTA link for expired-token case ---
+    // --- 3. Error message for expired-token case ---
 
-    test('shows auth CTA link in error message when token expired', async () => {
+    test('shows expired token error message', async () => {
         sessionStorage.setItem('anypoint_token', 'expired-token');
         sessionStorage.setItem('anypoint_token_expires_at', '0');
         await executeXOriginSource(0, btn);
@@ -1988,11 +1983,6 @@ describe('executeXOriginSource — button reset and auth errors', () => {
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
         expect(errorDiv.textContent).toContain('Token expired');
-
-        const link = errorDiv.querySelector('.xorigin-error-link');
-        expect(link).not.toBeNull();
-        expect(link.textContent).toContain('Sign in');
-        expect(link.getAttribute('onclick')).toContain('openAuthModal');
     });
 
     test('resets button to original text after expired token error', async () => {
@@ -2059,7 +2049,7 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
     // --- 5. Auth CTA link for 401/403 responses ---
 
-    test('shows access denied message for 401 response', async () => {
+    test('shows status error for 401 response', async () => {
         sessionStorage.setItem('anypoint_token', 'valid-token');
         sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
 
@@ -2071,11 +2061,10 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
-        expect(errorDiv.textContent).toContain('Access denied');
-        expect(errorDiv.textContent).toContain('expired or lack permissions');
+        expect(errorDiv.textContent).toContain('Request returned status 401');
     });
 
-    test('shows access denied message for 403 response', async () => {
+    test('shows status error for 403 response', async () => {
         sessionStorage.setItem('anypoint_token', 'valid-token');
         sessionStorage.setItem('anypoint_token_expires_at', String(Date.now() + 3600000));
 
@@ -2087,8 +2076,7 @@ describe('executeXOriginSource — button reset and auth errors', () => {
 
         const errorDiv = responseBodyDiv.querySelector('.xorigin-error');
         expect(errorDiv).not.toBeNull();
-        expect(errorDiv.textContent).toContain('Access denied');
-        expect(errorDiv.textContent).toContain('expired or lack permissions');
+        expect(errorDiv.textContent).toContain('Request returned status 403');
     });
 
     // --- 6. No regression: button resets after generic error (data.error) ---


### PR DESCRIPTION
## Summary

- Fix x-origin modal Send button staying permanently in "Sending..." state on error
- Auto-switch to Body tab when errors occur so messages are immediately visible
- Add `resetButton()` helper called on all error paths (pre-request and post-request)

## Changes

- `scripts/portal_generator/assets/portal.js` — added `resetButton()` helper, called on all 10 early-return paths in `executeXOriginSource()`; added `switchResponseTab()` to show error messages; refactored success path to use helper
- `scripts/tests/portal.test.js` — 18 new unit tests covering button reset, error messages, success path, and edge cases (202 total, 0 regressions)

## Test plan

- [x] Unit tests: 202 passing (184 baseline + 18 new)
- [x] Visual regression: 62/62 passing (Playwright screenshots match master baseline)
- [x] Manual test: unauthenticated click shows error, button resets, Body tab activates
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass