### PR TITLE
chore: @W-22548194 migrate aeh-consumer and aeh-management securitySchemes to shared fragment

### DIFF
--- a/apis/api-experience-hub-consumer/api.yaml
+++ b/apis/api-experience-hub-consumer/api.yaml
@@ -2852,6 +2852,4 @@ components:
           description: Whether an application with the given name already exists
   securitySchemes:
     bearerAuth:
-      type: http
-      description: Anypoint Platform bearer token obtained from Access Management
-      scheme: bearer
+      $ref: ../../fragments/anypoint_fragment.yaml#/components/securitySchemes/bearerAuth

--- a/apis/api-experience-hub-management/api.yaml
+++ b/apis/api-experience-hub-management/api.yaml
@@ -2563,6 +2563,4 @@ components:
           example: rest-api
   securitySchemes:
     bearerAuth:
-      type: http
-      description: Anypoint Platform bearer token obtained from Access Management
-      scheme: bearer
+      $ref: ../../fragments/anypoint_fragment.yaml#/components/securitySchemes/bearerAuth


### PR DESCRIPTION
## Summary
- Replaces inline `bearerAuth` securityScheme in `api-experience-hub-consumer/api.yaml` with `$ref` to shared fragment
- Replaces inline `bearerAuth` securityScheme in `api-experience-hub-management/api.yaml` with `$ref` to shared fragment
- Completes the fragment migration started in #108 for the two AEH APIs that were missed

## Test Plan
- [x] `make validate-api API=apis/api-experience-hub-consumer` — 0 violations
- [x] `make validate-api API=apis/api-experience-hub-management` — 0 violations
- [x] Portal generates successfully (`make generate-portal`)