### PR TITLE
feat: @W-22617454 styled error pages (404/500/generic)

### DIFF
--- a/scripts/portal_generator/assets/components/coming-soon-badge.css
+++ b/scripts/portal_generator/assets/components/coming-soon-badge.css
@@ -1,0 +1,144 @@
+/* ============================================================================
+   Coming Soon Badge — Reusable Component
+   ============================================================================
+   Usage:
+     1. Add class "coming-soon-parent" to the parent element (must be position: relative)
+     2. Include the badge partial inside it
+     3. Optionally set tooltip text via data-tooltip attribute on the parent
+
+   HTML structure:
+     <button class="coming-soon-parent" data-tooltip="Custom tooltip text">
+       Label
+       <span class="coming-soon-badge">Coming Soon</span>
+     </button>
+   ============================================================================ */
+
+/* Parent setup */
+.coming-soon-parent {
+    position: relative;
+    overflow: visible;
+    cursor: not-allowed;
+    pointer-events: auto;
+}
+
+/* Badge */
+.coming-soon-badge {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-size: 200% 200%;
+    color: white;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 4px 8px;
+    border-radius: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+    z-index: 10;
+}
+
+/* Hover effects on parent */
+.coming-soon-parent:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 16px rgba(102, 126, 234, 0.25);
+}
+
+.coming-soon-parent:hover .coming-soon-badge {
+    animation: pulse-badge 2s ease-in-out infinite, gradient-shift 3s ease infinite;
+}
+
+@keyframes pulse-badge {
+    0%, 100% {
+        transform: scale(1);
+        box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4);
+    }
+    50% {
+        transform: scale(1.05);
+        box-shadow: 0 4px 12px rgba(102, 126, 234, 0.6);
+    }
+}
+
+@keyframes gradient-shift {
+    0%, 100% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+}
+
+/* Tooltip — liquid glass effect */
+.coming-soon-parent::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: -40px;
+    left: 50%;
+    transform: translateX(-50%) translateY(10px);
+    background: linear-gradient(135deg,
+        rgba(255, 255, 255, 0.4) 0%,
+        rgba(255, 255, 255, 0.2) 50%,
+        rgba(255, 255, 255, 0.3) 100%);
+    padding: 10px 16px;
+    border-radius: 14px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 1000;
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.1),
+        inset 0 1px 0 rgba(255, 255, 255, 0.5),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background-image: linear-gradient(90deg,
+        #5E5CE6 0%,
+        #4E7BDB 25%,
+        #3E9AD0 50%,
+        #2EB9C5 75%,
+        #00C7BE 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.coming-soon-parent:hover::after {
+    opacity: 1;
+    transform: translateX(-50%) translateY(5px);
+}
+
+/* Dark mode */
+[data-theme="dark"] .coming-soon-badge {
+    background: linear-gradient(135deg, #7c3aed 0%, #a855f7 100%);
+    box-shadow: 0 2px 8px rgba(124, 58, 237, 0.5);
+}
+
+[data-theme="dark"] .coming-soon-parent:hover {
+    box-shadow: 0 4px 16px rgba(124, 58, 237, 0.3);
+}
+
+[data-theme="dark"] .coming-soon-parent::after {
+    background: linear-gradient(135deg,
+        rgba(255, 255, 255, 0.15) 0%,
+        rgba(255, 255, 255, 0.1) 50%,
+        rgba(255, 255, 255, 0.12) 100%);
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background-image: linear-gradient(90deg,
+        #5E5CE6 0%,
+        #4E7BDB 25%,
+        #3E9AD0 50%,
+        #2EB9C5 75%,
+        #00C7BE 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}

--- a/scripts/portal_generator/assets/icons/astronaut-404.svg
+++ b/scripts/portal_generator/assets/icons/astronaut-404.svg
@@ -1,0 +1,56 @@
+<svg width="304" height="192" viewBox="0 0 304 192" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M53.265 40.5117C53.5175 39.8294 54.4825 39.8294 54.735 40.5117L55.8937 43.6433C55.9731 43.8578 56.1422 44.0269 56.3567 44.1063L59.4883 45.265C60.1706 45.5175 60.1706 46.4825 59.4883 46.735L56.3567 47.8937C56.1422 47.9731 55.9731 48.1422 55.8937 48.3567L54.735 51.4883C54.4825 52.1706 53.5175 52.1706 53.265 51.4883L52.1063 48.3567C52.0269 48.1422 51.8578 47.9731 51.6433 47.8937L48.5117 46.735C47.8294 46.4825 47.8294 45.5175 48.5117 45.265L51.6433 44.1063C51.8578 44.0269 52.0269 43.8578 52.1063 43.6433L53.265 40.5117Z" fill="#2E52B4"/>
+<path d="M244.477 56.3319C244.313 55.8894 243.687 55.8894 243.523 56.3319L242.742 58.4422C242.691 58.5813 242.581 58.691 242.442 58.7424L240.332 59.5233C239.889 59.6871 239.889 60.3129 240.332 60.4767L242.442 61.2576C242.581 61.309 242.691 61.4187 242.742 61.5578L243.523 63.6681C243.687 64.1106 244.313 64.1106 244.477 63.6681L245.258 61.5578C245.309 61.4187 245.419 61.309 245.558 61.2576L247.668 60.4767C248.111 60.3129 248.111 59.6871 247.668 59.5233L245.558 58.7424C245.419 58.691 245.309 58.5813 245.258 58.4422L244.477 56.3319Z" fill="#2E52B4"/>
+<path d="M240.698 137.786C240.458 137.138 239.542 137.138 239.302 137.786L237.757 141.962C237.621 142.33 237.33 142.621 236.962 142.757L232.786 144.302C232.138 144.542 232.138 145.458 232.786 145.698L236.962 147.243C237.33 147.379 237.621 147.67 237.757 148.038L239.302 152.214C239.542 152.862 240.458 152.862 240.698 152.214L242.243 148.038C242.379 147.67 242.67 147.379 243.038 147.243L247.214 145.698C247.862 145.458 247.862 144.542 247.214 144.302L243.038 142.757C242.67 142.621 242.379 142.33 242.243 141.962L240.698 137.786Z" stroke="#7097FF" stroke-width="0.6"/>
+<circle cx="128" cy="96" r="48" fill="#C1D5FF"/>
+<path d="M32 104C32 95.5131 35.3714 87.3737 41.3726 81.3726C47.3737 75.3714 55.5131 72 64 72C72.4869 72 80.6263 75.3714 86.6274 81.3726C92.6286 87.3737 96 95.5131 96 104L64 104L32 104Z" fill="#DFEAFE"/>
+<path d="M200 104C200 95.5131 203.371 87.3737 209.373 81.3726C215.374 75.3714 223.513 72 232 72C240.487 72 248.626 75.3714 254.627 81.3726C260.629 87.3737 264 95.5131 264 104L232 104L200 104Z" fill="#DFEAFE"/>
+<path d="M184 152C184 144.839 181.155 137.972 176.092 132.908C171.028 127.845 164.161 125 157 125C149.839 125 142.972 127.845 137.908 132.908C132.845 137.972 130 144.839 130 152L157 152L184 152Z" fill="#DFEAFE"/>
+<path d="M88 104C88 99.7565 89.6857 95.6869 92.6863 92.6863C95.6869 89.6857 99.7565 88 104 88C108.243 88 112.313 89.6857 115.314 92.6863C118.314 95.6869 120 99.7565 120 104L104 104L88 104Z" fill="#DFEAFE"/>
+<path d="M140 152C140 148.287 138.525 144.726 135.899 142.101C133.274 139.475 129.713 138 126 138C122.287 138 118.726 139.475 116.101 142.101C113.475 144.726 112 148.287 112 152L126 152L140 152Z" fill="#DFEAFE"/>
+<g filter="url(#filter0_ddddii_739_2108)">
+<circle cx="176" cy="96" r="48" fill="url(#paint0_linear_739_2108)"/>
+</g>
+<defs>
+<filter id="filter0_ddddii_739_2108" x="125.994" y="45.6591" width="127.1" height="124.425" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.33764" dy="1.00323"/>
+<feGaussianBlur stdDeviation="1.67205"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_739_2108"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4.68174" dy="4.01292"/>
+<feGaussianBlur stdDeviation="3.00969"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.21 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_739_2108" result="effect2_dropShadow_739_2108"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="10.7011" dy="9.02906"/>
+<feGaussianBlur stdDeviation="4.18012"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.13 0"/>
+<feBlend mode="normal" in2="effect2_dropShadow_739_2108" result="effect3_dropShadow_739_2108"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="19.0614" dy="16.0517"/>
+<feGaussianBlur stdDeviation="5.01615"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="effect3_dropShadow_739_2108" result="effect4_dropShadow_739_2108"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect4_dropShadow_739_2108" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1.00323" dy="-1.00323"/>
+<feGaussianBlur stdDeviation="0.501615"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="shape" result="effect5_innerShadow_739_2108"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.00323" dy="1.00323"/>
+<feGaussianBlur stdDeviation="0.501615"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="effect5_innerShadow_739_2108" result="effect6_innerShadow_739_2108"/>
+</filter>
+<linearGradient id="paint0_linear_739_2108" x1="128" y1="48" x2="222.433" y2="145.518" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A4BCFF"/>
+<stop offset="1" stop-color="#648EFF"/>
+</linearGradient>
+</defs>
+</svg>

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -413,7 +413,7 @@ class PortalGenerator:
         print("  ✓ Generating 404 page...")
         template = self.env.get_template('404.html')
         html = template.render(
-            css_path='assets/styles.css',
+            **self._asset_paths(0),
             build_label=self.build_label,
             base_url=self.base_url,
             chrome={k: v for k, v in self.chrome.items() if k != 'header'} if self.chrome else None,

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -381,6 +381,8 @@ class PortalGenerator:
         self._css_filename = self._generate_css()
         self._js_filename, self._jsonpath_filename = self._generate_js()
         self._generate_404()
+        self._generate_500()
+        self._generate_error_page()
         self._generate_homepage()
         self._generate_detail_pages_parallel()
         self._generate_registry()
@@ -408,19 +410,31 @@ class PortalGenerator:
             'jsonpath_js_path': f"{prefix}assets/{self._jsonpath_filename}",
         }
 
-    def _generate_404(self):
-        """Generate 404.html error page."""
-        print("  ✓ Generating 404 page...")
-        template = self.env.get_template('404.html')
+    def _generate_static_error_page(self, template_name: str, output_name: str) -> None:
+        """Render a static error page template to output_dir/output_name."""
+        template = self.env.get_template(template_name)
         html = template.render(
             **self._asset_paths(0),
             build_label=self.build_label,
             base_url=self.base_url,
             chrome={k: v for k, v in self.chrome.items() if k != 'header'} if self.chrome else None,
         )
-        output_path = self.output_dir / '404.html'
-        with open(output_path, 'w', encoding='utf-8') as f:
-            f.write(html)
+        (self.output_dir / output_name).write_text(html, encoding='utf-8')
+
+    def _generate_404(self):
+        """Generate 404.html error page."""
+        print("  ✓ Generating 404 page...")
+        self._generate_static_error_page('404.html', '404.html')
+
+    def _generate_500(self):
+        """Generate 500.html error page."""
+        print("  ✓ Generating 500 page...")
+        self._generate_static_error_page('500.html', '500.html')
+
+    def _generate_error_page(self):
+        """Generate error.html generic fallback error page."""
+        print("  ✓ Generating generic error page...")
+        self._generate_static_error_page('error.html', 'error.html')
 
     def _generate_homepage(self):
         """Generate index.html"""

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -416,7 +416,7 @@ class PortalGenerator:
             css_path='assets/styles.css',
             build_label=self.build_label,
             base_url=self.base_url,
-            chrome=self.chrome,
+            chrome={k: v for k, v in self.chrome.items() if k != 'header'} if self.chrome else None,
         )
         output_path = self.output_dir / '404.html'
         with open(output_path, 'w', encoding='utf-8') as f:

--- a/scripts/portal_generator/generator.py
+++ b/scripts/portal_generator/generator.py
@@ -380,6 +380,7 @@ class PortalGenerator:
         print(f"\n📝 Generating portal files (workers={self.workers})...")
         self._css_filename = self._generate_css()
         self._js_filename, self._jsonpath_filename = self._generate_js()
+        self._generate_404()
         self._generate_homepage()
         self._generate_detail_pages_parallel()
         self._generate_registry()
@@ -406,6 +407,20 @@ class PortalGenerator:
             'portal_js_path': f"{prefix}assets/{self._js_filename}",
             'jsonpath_js_path': f"{prefix}assets/{self._jsonpath_filename}",
         }
+
+    def _generate_404(self):
+        """Generate 404.html error page."""
+        print("  ✓ Generating 404 page...")
+        template = self.env.get_template('404.html')
+        html = template.render(
+            css_path='assets/styles.css',
+            build_label=self.build_label,
+            base_url=self.base_url,
+            chrome=self.chrome,
+        )
+        output_path = self.output_dir / '404.html'
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(html)
 
     def _generate_homepage(self):
         """Generate index.html"""

--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -6,6 +6,10 @@
 <script src="assets/portal.js" defer></script>
 {% endblock %}
 
+{% block header %}
+{% include "partials/homepage_header.html" %}
+{% endblock %}
+
 {% block extra_styles %}
 <style>
     .error-page {

--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+
+{% block title %}Page not found — Anypoint Platform APIs{% endblock %}
+
+{% block extra_styles %}
+<style>
+    .error-page {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - 80px);
+        padding: var(--space-xl) var(--space-md);
+        text-align: center;
+        background: var(--color-bg-primary);
+    }
+
+    .error-illustration {
+        margin-bottom: var(--space-xl);
+    }
+
+    .error-illustration svg {
+        width: 240px;
+        height: 200px;
+    }
+
+    .error-code {
+        font-family: var(--font-mono);
+        font-size: 5rem;
+        font-weight: var(--font-weight-bold);
+        color: var(--color-text-primary);
+        line-height: 1;
+        margin: 0 0 var(--space-sm) 0;
+        letter-spacing: -0.02em;
+    }
+
+    .error-title {
+        font-size: var(--font-size-8);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-primary);
+        margin: 0 0 var(--space-md) 0;
+    }
+
+    .error-description {
+        font-size: var(--font-size-5);
+        color: var(--color-text-secondary);
+        max-width: 460px;
+        margin: 0 auto var(--space-lg) auto;
+        line-height: var(--reading-line-height);
+    }
+
+    .error-url {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: var(--font-size-3);
+        color: var(--color-text-tertiary);
+        background: var(--color-bg-surface);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius-medium);
+        padding: var(--space-xs) var(--space-sm);
+        margin-bottom: var(--space-xl);
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        word-break: break-all;
+    }
+
+    .error-actions {
+        display: flex;
+        gap: var(--space-md);
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .error-illustration img {
+        width: 100%;
+        max-width: 304px;
+        height: auto;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<main class="error-page" id="main-content">
+    <div class="error-illustration">
+        <img src="assets/icons/astronaut-404.svg" alt="" aria-hidden="true"/>
+    </div>
+
+    <p class="error-code">404</p>
+    <h1 class="error-title">Page not found</h1>
+    <p class="error-description">
+        This page doesn't exist. It may have been moved, the URL might contain a typo, or the link you followed is no longer valid.
+    </p>
+
+    <p class="error-url" id="attempted-url"></p>
+
+    <div class="error-actions">
+        <button class="btn-copy-curl" onclick="history.back()">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10 12L6 8l4-4"/>
+            </svg>
+            Go back
+        </button>
+        <a href="{{ base_url|default('.') }}/index.html" class="btn-send" style="text-decoration: none;">
+            Browse all services
+        </a>
+    </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    (function() {
+        var urlEl = document.getElementById('attempted-url');
+        var path = window.location.pathname + window.location.search;
+        if (path && path !== '/' && path !== '/404.html') {
+            urlEl.textContent = window.location.origin + path;
+            urlEl.style.display = 'inline-block';
+        } else {
+            urlEl.style.display = 'none';
+        }
+    })();
+</script>
+{% endblock %}

--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -3,7 +3,7 @@
 {% block title %}Page not found — Anypoint Platform APIs{% endblock %}
 
 {% block head_scripts %}
-<script src="assets/portal.js" defer></script>
+<script src="{{ portal_js_path }}" defer></script>
 {% endblock %}
 
 {% block header %}
@@ -107,7 +107,7 @@
 {% block content %}
 <main class="error-page" id="main-content">
     <div class="error-illustration">
-        <img src="assets/icons/astronaut-404.svg" alt="" aria-hidden="true"/>
+        <img src="{{ icons_path }}/astronaut-404.svg" alt="" aria-hidden="true"/>
     </div>
 
     <p class="error-code">404</p>

--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "partials/error_page.html" import error_page %}
 
 {% block title %}Page not found — Anypoint Platform APIs{% endblock %}
 
@@ -11,125 +12,17 @@
 {% endblock %}
 
 {% block extra_styles %}
-<style>
-    .error-page {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        min-height: calc(100vh - 80px);
-        padding: var(--space-xl) var(--space-md);
-        text-align: center;
-        background: var(--color-bg-primary);
-    }
-
-    .error-illustration {
-        margin-bottom: var(--space-xl);
-    }
-
-    .error-illustration svg {
-        width: 240px;
-        height: 200px;
-    }
-
-    .error-code {
-        font-family: var(--font-mono);
-        font-size: 5rem;
-        font-weight: var(--font-weight-bold);
-        color: var(--color-text-primary);
-        line-height: 1;
-        margin: 0 0 var(--space-sm) 0;
-        letter-spacing: -0.02em;
-    }
-
-    .error-title {
-        font-size: var(--font-size-8);
-        font-weight: var(--font-weight-semibold);
-        color: var(--color-text-primary);
-        margin: 0 0 var(--space-md) 0;
-    }
-
-    .error-description {
-        font-size: var(--font-size-5);
-        color: var(--color-text-secondary);
-        max-width: 460px;
-        margin: 0 auto var(--space-lg) auto;
-        line-height: var(--reading-line-height);
-    }
-
-    .error-url {
-        display: inline-block;
-        font-family: var(--font-mono);
-        font-size: var(--font-size-3);
-        color: var(--color-text-tertiary);
-        background: var(--color-bg-surface);
-        border: 1px solid var(--color-border-primary);
-        border-radius: var(--radius-medium);
-        padding: var(--space-xs) var(--space-sm);
-        margin-bottom: var(--space-xl);
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        word-break: break-all;
-    }
-
-    .error-actions {
-        display: flex;
-        gap: var(--space-md);
-        flex-wrap: wrap;
-        justify-content: center;
-    }
-
-    .error-illustration img {
-        width: 100%;
-        max-width: 304px;
-        height: auto;
-    }
-
-    /* Dark mode adjustments */
-    [data-theme="dark"] .error-page {
-        background: var(--color-bg-primary);
-    }
-
-    [data-theme="dark"] .error-illustration img {
-        filter: brightness(0.75) saturate(1.2);
-    }
-
-    [data-theme="dark"] .error-url {
-        background: var(--color-bg-surface);
-        border-color: var(--color-border-primary);
-        color: var(--color-text-tertiary);
-    }
-</style>
+{% include "partials/error_styles.html" %}
 {% endblock %}
 
 {% block content %}
-<main class="error-page" id="main-content">
-    <div class="error-illustration">
-        <img src="{{ icons_path }}/astronaut-404.svg" alt="" aria-hidden="true"/>
-    </div>
-
-    <p class="error-code">404</p>
-    <h1 class="error-title">Page not found</h1>
-    <p class="error-description">
-        This page doesn't exist. It may have been moved, the URL might contain a typo, or the link you followed is no longer valid.
-    </p>
-
-    <p class="error-url" id="attempted-url"></p>
-
-    <div class="error-actions">
-        <button class="btn-copy-curl" onclick="history.back()">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M10 12L6 8l4-4"/>
-            </svg>
-            Go back
-        </button>
-        <a href="{{ base_url|default('.') }}/index.html" class="btn-send" style="text-decoration: none;">
-            Browse all services
-        </a>
-    </div>
-</main>
+{{ error_page(
+    error_code="404",
+    title="Page not found",
+    description="This page doesn't exist. It may have been moved, the URL might contain a typo, or the link you followed is no longer valid.",
+    show_url=True,
+    icon_src=icons_path + "/astronaut-404.svg"
+) }}
 {% endblock %}
 
 {% block scripts %}

--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -2,6 +2,10 @@
 
 {% block title %}Page not found — Anypoint Platform APIs{% endblock %}
 
+{% block head_scripts %}
+<script src="assets/portal.js" defer></script>
+{% endblock %}
+
 {% block extra_styles %}
 <style>
     .error-page {
@@ -77,6 +81,21 @@
         width: 100%;
         max-width: 304px;
         height: auto;
+    }
+
+    /* Dark mode adjustments */
+    [data-theme="dark"] .error-page {
+        background: var(--color-bg-primary);
+    }
+
+    [data-theme="dark"] .error-illustration img {
+        filter: brightness(0.75) saturate(1.2);
+    }
+
+    [data-theme="dark"] .error-url {
+        background: var(--color-bg-surface);
+        border-color: var(--color-border-primary);
+        color: var(--color-text-tertiary);
     }
 </style>
 {% endblock %}

--- a/scripts/portal_generator/templates/500.html
+++ b/scripts/portal_generator/templates/500.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% from "partials/error_page.html" import error_page %}
+
+{% block title %}Something went wrong — Anypoint Platform APIs{% endblock %}
+
+{% block head_scripts %}
+<script src="{{ portal_js_path }}" defer></script>
+{% endblock %}
+
+{% block header %}
+{% include "partials/homepage_header.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "partials/error_styles.html" %}
+{% endblock %}
+
+{% block content %}
+{{ error_page(
+    error_code="500",
+    title="Something went wrong",
+    description="An unexpected error occurred on our end. Please try again in a moment. If the problem persists, contact support.",
+    show_url=False,
+    icon_src=icons_path + "/astronaut-404.svg"
+) }}
+{% endblock %}

--- a/scripts/portal_generator/templates/error.html
+++ b/scripts/portal_generator/templates/error.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% from "partials/error_page.html" import error_page %}
+
+{% block title %}Error — Anypoint Platform APIs{% endblock %}
+
+{% block head_scripts %}
+<script src="{{ portal_js_path }}" defer></script>
+{% endblock %}
+
+{% block header %}
+{% include "partials/homepage_header.html" %}
+{% endblock %}
+
+{% block extra_styles %}
+{% include "partials/error_styles.html" %}
+{% endblock %}
+
+{% block content %}
+{{ error_page(
+    error_code="",
+    title="Something went wrong",
+    description="We encountered an unexpected issue. Please go back or return to the homepage.",
+    show_url=False,
+    icon_src=icons_path + "/astronaut-404.svg"
+) }}
+{% endblock %}

--- a/scripts/portal_generator/templates/partials/coming_soon_badge.html
+++ b/scripts/portal_generator/templates/partials/coming_soon_badge.html
@@ -1,0 +1,13 @@
+{#
+  Coming Soon Badge — Reusable component
+
+  Usage: {% include "partials/coming_soon_badge.html" %}
+
+  Place inside a position:relative parent (e.g., a button or card).
+  The parent needs class "coming-soon-parent" for hover effects.
+
+  Parameters (set before include):
+    - badge_text: (optional) defaults to "Coming Soon"
+    - tooltip_text: (optional) defaults to "In final testing - launching this month"
+#}
+<span class="coming-soon-badge">{{ badge_text | default("Coming Soon") }}</span>

--- a/scripts/portal_generator/templates/partials/error_page.html
+++ b/scripts/portal_generator/templates/partials/error_page.html
@@ -1,0 +1,42 @@
+{#
+  Error page macro — shared layout for 404, 500, and generic error pages.
+
+  Parameters:
+    error_code      — numeric string, e.g. "404", "500" (or empty for generic)
+    title           — H1 text, e.g. "Page not found"
+    description     — paragraph text
+    show_url        — bool, whether to show the attempted URL (404 only)
+    icon_src        — path to illustration SVG
+    icon_alt        — alt text (use "" since illustrations are decorative)
+    extra_actions   — optional HTML injected after the Go back / Browse buttons
+#}
+{% macro error_page(error_code, title, description, show_url=False, icon_src='', icon_alt='', extra_actions='') %}
+<main class="error-page" id="main-content">
+    <div class="error-illustration">
+        <img src="{{ icon_src if icon_src else 'assets/icons/astronaut-404.svg' }}" alt="{{ icon_alt }}" {% if not icon_alt %}aria-hidden="true"{% endif %}/>
+    </div>
+
+    {% if error_code %}
+    <p class="error-code">{{ error_code }}</p>
+    {% endif %}
+    <h1 class="error-title">{{ title }}</h1>
+    <p class="error-description">{{ description }}</p>
+
+    {% if show_url %}
+    <p class="error-url" id="attempted-url"></p>
+    {% endif %}
+
+    <div class="error-actions">
+        <button class="btn-copy-curl" onclick="history.back()">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10 12L6 8l4-4"/>
+            </svg>
+            Go back
+        </button>
+        <a href="{{ base_url|default('.') }}/index.html" class="btn-send" style="text-decoration: none;">
+            Browse all services
+        </a>
+        {{ extra_actions|safe }}
+    </div>
+</main>
+{% endmacro %}

--- a/scripts/portal_generator/templates/partials/error_styles.html
+++ b/scripts/portal_generator/templates/partials/error_styles.html
@@ -1,0 +1,85 @@
+<style>
+    .error-page {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - 80px);
+        padding: var(--space-xl) var(--space-md);
+        text-align: center;
+        background: var(--color-bg-primary);
+    }
+
+    .error-illustration {
+        margin-bottom: var(--space-xl);
+    }
+
+    .error-illustration img {
+        width: 100%;
+        max-width: 304px;
+        height: auto;
+    }
+
+    .error-code {
+        font-family: var(--font-mono);
+        font-size: 5rem;
+        font-weight: var(--font-weight-bold);
+        color: var(--color-text-primary);
+        line-height: 1;
+        margin: 0 0 var(--space-sm) 0;
+        letter-spacing: -0.02em;
+    }
+
+    .error-title {
+        font-size: var(--font-size-8);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-primary);
+        margin: 0 0 var(--space-md) 0;
+    }
+
+    .error-description {
+        font-size: var(--font-size-5);
+        color: var(--color-text-secondary);
+        max-width: 460px;
+        margin: 0 auto var(--space-lg) auto;
+        line-height: var(--reading-line-height);
+    }
+
+    .error-url {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: var(--font-size-3);
+        color: var(--color-text-tertiary);
+        background: var(--color-bg-surface);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius-medium);
+        padding: var(--space-xs) var(--space-sm);
+        margin-bottom: var(--space-xl);
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        word-break: break-all;
+    }
+
+    .error-actions {
+        display: flex;
+        gap: var(--space-md);
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    [data-theme="dark"] .error-page {
+        background: var(--color-bg-primary);
+    }
+
+    [data-theme="dark"] .error-illustration img {
+        filter: brightness(0.75) saturate(1.2);
+    }
+
+    [data-theme="dark"] .error-url {
+        background: var(--color-bg-surface);
+        border-color: var(--color-border-primary);
+        color: var(--color-text-tertiary);
+    }
+</style>

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -1184,6 +1184,44 @@ class TestErrorPages:
     def test_404_has_main_element(self):
         assert self.soup.find('main') is not None
 
+    def test_500_exists(self, generated_portal):
+        assert (generated_portal / '500.html').exists()
+
+    def test_error_exists(self, generated_portal):
+        assert (generated_portal / 'error.html').exists()
+
+    def test_500_has_main_element(self, generated_portal):
+        html = (generated_portal / '500.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        assert soup.find('main') is not None
+
+    def test_error_has_main_element(self, generated_portal):
+        html = (generated_portal / 'error.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        assert soup.find('main') is not None
+
+    def test_500_uses_hashed_css(self, generated_portal):
+        assert self.css_files, "No hashed CSS file found"
+        hashed_name = self.css_files[0].name
+        html = (generated_portal / '500.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        link = soup.find('link', rel='stylesheet')
+        assert link is not None
+        assert hashed_name in link['href'], (
+            f"500.html references unhashed CSS; expected {hashed_name} in href"
+        )
+
+    def test_error_uses_hashed_css(self, generated_portal):
+        assert self.css_files, "No hashed CSS file found"
+        hashed_name = self.css_files[0].name
+        html = (generated_portal / 'error.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        link = soup.find('link', rel='stylesheet')
+        assert link is not None
+        assert hashed_name in link['href'], (
+            f"error.html references unhashed CSS; expected {hashed_name} in href"
+        )
+
 
 def test_multi_version_anchor_map_marks_unique_resources(tmp_path):
     """The version_anchors emitted in the page lists each version's docs.

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -1148,6 +1148,43 @@ def test_homepage_terraform_card_links_to_index(generated_portal):
     assert soup.select_one(".tf-card-version") is None
 
 
+class TestErrorPages:
+    @pytest.fixture(autouse=True)
+    def _parse_404(self, generated_portal):
+        html = (generated_portal / '404.html').read_text(encoding='utf-8')
+        self.soup = BeautifulSoup(html, 'html.parser')
+        self.css_files = list((generated_portal / 'assets').glob('styles.*.css'))
+
+    def test_404_exists(self, generated_portal):
+        assert (generated_portal / '404.html').exists()
+
+    def test_404_uses_hashed_css(self):
+        assert self.css_files, "No hashed CSS file found"
+        hashed_name = self.css_files[0].name
+        link = self.soup.find('link', rel='stylesheet')
+        assert link is not None
+        assert hashed_name in link['href'], (
+            f"404.html references unhashed CSS; expected {hashed_name} in href"
+        )
+
+    def test_404_uses_hashed_js(self, generated_portal):
+        js_files = list((generated_portal / 'assets').glob('portal.*.js'))
+        assert js_files, "No hashed JS file found"
+        hashed_js = js_files[0].name
+        scripts = self.soup.find_all('script', src=True)
+        js_srcs = [s['src'] for s in scripts]
+        assert any(hashed_js in src for src in js_srcs), (
+            f"404.html references unhashed JS; expected {hashed_js} in one of {js_srcs}"
+        )
+
+    def test_404_has_go_home_link(self):
+        links = self.soup.find_all('a')
+        assert any('index.html' in (l.get('href', '')) for l in links)
+
+    def test_404_has_main_element(self):
+        assert self.soup.find('main') is not None
+
+
 def test_multi_version_anchor_map_marks_unique_resources(tmp_path):
     """The version_anchors emitted in the page lists each version's docs.
 


### PR DESCRIPTION
## Summary

- **404.html**: Fixed hardcoded asset paths (now uses content-hashed CSS/JS via `_asset_paths(0)`), updated to use shared macro and styles
- **500.html** (new): Server error page using shared macro — human-friendly message, Go back + Browse all services CTAs
- **error.html** (new): Generic fallback error page for unknown error types
- **Shared macro** (`partials/error_page.html`): Single Jinja2 macro for all error page layouts — error code, title, description, optional URL display, CTA buttons
- **Shared styles** (`partials/error_styles.html`): All error page CSS extracted to one include — design system tokens, light + dark mode support
- **Generator** (`generator.py`): Refactored to `_generate_static_error_page()` helper, wires `_generate_404()`, `_generate_500()`, `_generate_error_page()` in `generate()`
- **Tests** (`test_smoke.py`): 11 new tests in `TestErrorPages` covering existence, hashed asset paths, main element presence, and Go home link

## Acceptance criteria

- ✅ Dedicated error page templates (404, 500, generic fallback)
- ✅ Portal header/nav included on all pages
- ✅ Human-friendly error messages with descriptive copy
- ✅ CTAs: "Go back" (history.back()) + "Browse all services" (→ index.html)
- ✅ Matches portal design system — semantic tokens, light + dark mode
- ✅ No raw "Not Found" / "Error response" text

## Test plan

- `make test-portal` — all pytest tests pass (11/11 new TestErrorPages + full suite)
- `./test-branch.sh 8090` — 62/62 visual regression tests pass (chromium)
- Manual: http://localhost:8090/404.html, /500.html, /error.html