### PR TITLE
Fix CODEOWNERS to require approval from either api-manager or acm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
 #ECCN:Open Source
 #GUSINFO: MS API Manager
-* @mulesoft/team-api-manager
-* @mulesoft/team-acm 
+* @mulesoft/team-api-manager @mulesoft/team-acm
 
 # Mule DX team owns the mule-development skills bundle.
 # CODEOWNERS uses last-match-wins, so this overrides the default above.


### PR DESCRIPTION
## Summary
- Combine `@mulesoft/team-api-manager` and `@mulesoft/team-acm` onto a single `*` rule so a PR needs approval from **either** team, not both.
- Previously two separate `*` lines caused last-match-wins to make `team-acm` the only required approver.

## Test plan
- [ ] Open a test PR and confirm GitHub requests review from either team (not both required).