### PR TITLE
feat: add repo-scoped skills for PR review and issue triage

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: review-pr
+description: Use when reviewing, validating, or approving a PR in this repo — runs deterministic validators (OAS governance, x-origin, JTBD) then a structured AI code review across 7 angles (correctness, removed behavior, cross-refs, duplication, consistency). Accepts a single PR number or reviews all open non-approved PRs. Can filter by author or date.
+---
+
+# Review PR(s) — mulesoft/mulesoft-dx
+
+## Inputs (provided by caller or inferred)
+
+| Parameter | How to supply | Default |
+|-----------|--------------|---------|
+| `PR_NUMBER` | "review PR #123" | — reviews all open PRs |
+| `SINCE` | "since 2026-06-18T09:00:00Z" | no date filter |
+| `SKIP_AUTHOR` | "skip PRs by leandrogilcarrano" | none |
+
+## Step 1 — Discover PRs
+
+**Single PR:** skip discovery, go to Step 2 with that number.
+
+**Bulk review:** fetch open, non-approved PRs:
+
+```bash
+gh pr list \
+  --repo mulesoft/mulesoft-dx \
+  --state open \
+  --json number,title,author,updatedAt,reviewDecision \
+  --jq "[.[] | select(.reviewDecision != \"APPROVED\")]"
+```
+
+Apply filters if provided:
+- `SKIP_AUTHOR`: exclude `.author.login == SKIP_AUTHOR`
+- `SINCE`: keep only `.updatedAt > SINCE` (exclude PRs with no changes since that timestamp)
+
+If no PRs remain: report "No PRs to review." and exit.
+
+## Step 2 — Checkout and identify changes
+
+```bash
+gh pr checkout <PR_NUMBER>
+git diff master...HEAD --name-only
+```
+
+Categorize changed files:
+- `apis/**` → API spec changes
+- `skills/**` → JTBD/prose skill changes
+- `mcps/**` → MCP server changes
+- `scripts/**` → portal generator changes
+
+## Step 3 — Deterministic validators (before any AI analysis)
+
+Run in parallel:
+
+### OAS governance
+```bash
+make validate-all-governed 2>&1 | tail -20
+# Or targeted if only specific APIs changed:
+make validate-api API=apis/<changed-api-dir>
+```
+
+### x-origin annotations
+```bash
+python3 scripts/build/validate_xorigin.py 2>&1
+```
+
+### JTBD skills
+```bash
+for job in skills/*/SKILL.md skills/*/*/SKILL.md; do
+  [ -f "$job" ] && python3 scripts/build/validate_jtbd.py "$job" . 2>&1
+done
+```
+
+### Skill quality (when `skills/**` files changed)
+
+For every `skills/**/SKILL.md` modified in the PR, run the `skill-quality-review` skill. This covers content quality (token efficiency, discoverability, calibration) — the JTBD validator only covers structure.
+
+Notes:
+- If Anypoint CLI is not installed, skip OAS validation and note it.
+- Prose-type skills (`type: prose`) skip JTBD validation but still run `skill-quality-review`.
+
+## Step 4 — AI review (7 angles)
+
+**A — Line-by-line diff scan**
+Read every hunk. For API specs: operationId uniqueness, missing descriptions, broken `$ref` links, missing examples, schema issues. For skills: step numbering, YAML block structure, broken `urn:api:` references, stale cross-skill references.
+
+**B — Removed behavior**
+For every deleted line, identify the invariant it enforced. Check if re-established elsewhere. Flag dropped validations, removed steps, deleted required fields.
+
+**C — Cross-file tracer**
+For skills referencing APIs via `urn:api:` or file links, verify those targets exist and operationIds are valid. Check `x-origin` references point to real operations.
+
+**D — Reuse**
+Flag duplication — skills that replicate steps already in another skill, API schemas defined inline when they could `$ref` a shared schema.
+
+**E — Simplification**
+Unnecessary complexity — redundant YAML blocks, over-nested structures, dead steps left behind.
+
+**F — Consistency**
+Does the change follow repo patterns? (camelCase operationIds, semver in `exchange.json`, imperative voice in descriptions, `urn:api:` format for cross-references)
+
+**G — Altitude**
+Is the fix at the right level? A skill patching around a missing API operation should instead add the operation.
+
+## Step 5 — Verify findings (1-vote, 3-state)
+
+- **CONFIRMED** — can reproduce with specific inputs/state
+- **PLAUSIBLE** — mechanism real, trigger uncertain
+- **REFUTED** — guarded elsewhere or factually wrong
+
+Drop REFUTED findings.
+
+## Step 6 — Output
+
+**Never post to GitHub.** Do NOT call `gh pr review`, `gh pr comment`, or any GitHub write command.
+
+```
+## PR #<number> — <title>
+**Author:** <author> | https://github.com/mulesoft/mulesoft-dx/pull/<number>
+
+### Validators
+- OAS: ✅ / ❌ <error summary> / ⏭️ skipped (Anypoint CLI not installed)
+- x-origin: ✅ / ❌
+- JTBD: ✅ / ❌ / ⏭️ skipped (prose-type skill)
+
+### Findings
+**Must fix:**
+- `<file>:<line>` — <description>
+
+**Nice to fix:**
+- `<file>:<line>` — <description>
+
+### Your action
+- ✅ Approve — no blockers. Ready to approve.
+- 🔄 Request changes — paste as PR comment:
+  > <ready-to-paste comment text>
+- ⏭️ Skip — already approved or no changes needed.
+```
+
+After all PRs reviewed, restore repo:
+```bash
+git checkout master
+```

--- a/.claude/skills/triage-github-issues/SKILL.md
+++ b/.claude/skills/triage-github-issues/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: triage-github-issues
+description: Use when triaging new GitHub issues in this repo — analyzes each issue, attempts reproduction, drafts a Salesforce GUS work item (bug), and awaits confirmation before creating. Accepts a since date or issue number. Works manually or from a schedule.
+---
+
+# Triage GitHub Issues — mulesoft/mulesoft-dx
+
+## Inputs (provided by caller or inferred)
+
+| Parameter | How to supply | Default |
+|-----------|--------------|---------|
+| `SINCE` | "since 2026-06-18T10:00:00Z" | 24 hours ago |
+| `ISSUE_NUMBER` | "triage issue #135" | — all new issues |
+| `SLACK_CHANNEL` | "post to #leandro-cu-bot" | no Slack |
+
+## Step 1 — Find issues
+
+**Single issue:** skip discovery, go to Step 2.
+
+**Bulk triage:** fetch open issues since `SINCE` (default: 24h ago):
+
+```bash
+# macOS/BSD:
+SINCE="${SINCE:-$(date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)}"
+# Linux fallback:
+SINCE="${SINCE:-$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)}"
+
+gh issue list \
+  --repo mulesoft/mulesoft-dx \
+  --state open \
+  --json number,title,body,createdAt,url,labels,author \
+  --jq "[.[] | select(.createdAt > \"$SINCE\")]"
+```
+
+If no issues: report "No new issues since $SINCE." and exit.
+
+## Step 2 — Dedup check against GUS
+
+Before analyzing, check if a GUS bug already exists:
+
+```bash
+sf data query --target-org gus \
+  --query "SELECT Id, Name FROM ADM_Work__c WHERE Name LIKE '%#<NUMBER>%' LIMIT 1" \
+  --json
+```
+
+If found: skip this issue silently, move to next.
+
+## Step 3 — Analyze and attempt reproduction
+
+```bash
+git checkout master && git pull
+```
+
+For each issue:
+
+**3a. Understand:**
+- Reported vs expected behavior
+- Steps to reproduce
+- Affected area: `[UI]`, `[API]`, `[Dev Portal]`, `[Infra]`
+
+**3b. Attempt reproduction:**
+- Find relevant code paths in the repo
+- Run portal generator if relevant: `make generate-portal BASE_URL=http://localhost:8080`
+- Run tests if relevant: `make test-portal`
+- Check recent commits: `git log --oneline -20`
+
+**3c. Assess reproducibility:**
+- **Confirmed** — found the code path, can explain exactly why
+- **Plausible** — mechanism makes sense but can't fully verify without running the app
+- **Cannot reproduce** — unclear, missing context, or unrelated to this repo
+
+If **Cannot reproduce**: skip GUS draft, note the reason.
+
+## Step 4 — Draft GUS bug
+
+For Confirmed or Plausible issues:
+
+```
+Subject: [<area>] <concise title> (GH#<number>)
+Type: Bug
+Epic: Mulesoft Dev Portal - Post GA
+Points: <1-5>
+Assignee: <YOUR_NAME>
+
+Steps to reproduce: <from issue or inferred>
+Expected: <from issue>
+Actual: <from issue>
+Notes: <code path, related commit, etc.>
+```
+
+## Step 5 — Confirm before creating
+
+**If SLACK_CHANNEL is provided:** post one message per issue to that channel:
+
+```
+*New GitHub Issue #<number>* — <title>
+<url>
+Reported by: <author> | Reproducibility: <Confirmed/Plausible>
+
+*Draft GUS bug:*
+> Subject: [<area>] <title> (GH#<number>)
+> Epic: Post GA | Points: <N>
+> Steps: <summary>
+> Expected: <expected>
+> Actual: <actual>
+
+Create this GUS bug? Reply *yes* or *no* in this thread.
+```
+
+Wait for reply. On **yes** → Step 6. On **no** → "Ok, skipped."
+
+**If no SLACK_CHANNEL:** show the draft in the session output and ask the user directly.
+
+## Step 6 — Create GUS bug
+
+Use the `gus-devportal-wi` skill to create the bug with the drafted details.
+
+After creation, report:
+```
+✅ Creado: <W-number> — <title>
+<GUS URL>
+```
+
+If Slack: reply in the same thread with the W-number and GUS URL.
+
+## Notes
+
+- Never create a GUS work item without explicit confirmation
+- One thread/message per issue — don't batch multiple issues in one message
+- Always restore repo to master after analysis


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/review-pr/SKILL.md` — runs OAS governance, x-origin, and JTBD validators then a 7-angle AI review on one or more PRs. Invokes `skill-quality-review` when `skills/**` files change. Output is classified as Must fix / Nice to fix with ready-to-paste comment text. Never posts to GitHub.
- Adds `.claude/skills/triage-github-issues/SKILL.md` — finds new GitHub issues since a given timestamp, deduplicates against GUS, attempts reproduction, drafts a GUS work item, and awaits explicit confirmation before creating anything. Works manually from the CLI or from a CU schedule.

Both skills are caller-agnostic: no CU-specific logic, no hardcoded paths or usernames.

## Test plan

- [ ] Invoke `review-pr` manually on an open PR and verify validator output + AI findings render correctly
- [ ] Invoke `triage-github-issues` on a recent issue and verify GUS dedup check runs before any draft
- [ ] Confirm neither skill posts anything to GitHub