### PR TITLE
feat: add India (in1) region to portal auth panel

### DIFF
--- a/.claude/skills/skill-quality-review/SKILL.md
+++ b/.claude/skills/skill-quality-review/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: skill-quality-review
+description: Review a SKILL.md file for adherence to Anthropic's official agent-skill best practices. Use when the user asks to "review a skill", "check skill quality", "audit skill", "validate skill quality", or before merging a PR that adds or modifies a skill in skills/. Complements the deterministic structural validator (validate_skills.py) by judging content quality — concision, description discoverability, naming, freedom calibration, progressive disclosure.
+metadata:
+  version: 1.0.0
+  author: Leandro Gil
+---
+
+# Skill Quality Review
+
+Use this skill to evaluate a SKILL.md file against Anthropic's [agent-skill best practices](references/anthropic-best-practices.md). This is a **content-quality** review — token efficiency, discoverability, calibration. It is NOT a structural validator (the deterministic R1–R7 checks live in `scripts/build/validate_skills.py` and run in CI).
+
+## When to Use
+
+- Reviewing a PR that adds or modifies a `skills/<name>/SKILL.md` file in `mulesoft/mulesoft-dx`.
+- Auditing an existing skill that the user suspects is bloated, vague, or hard to trigger.
+- Before publishing a new skill to the bundle.
+
+Do NOT use this skill for:
+- Pure structural checks (frontmatter present, code fences balanced) — that's `make validate-skills`.
+- API-spec reviews — use `api-spec-validator`.
+- Generic prose editing — this is specifically about agent-skill ergonomics.
+
+## How to Run
+
+1. **Load references**:
+   - `references/anthropic-best-practices.md` (vendored Anthropic doc, ~1100 lines) — generic agent-skill best practices, source of truth for dimensions 1-8.
+   - `docs/job-template.md` and `docs/jobs-readme.md` from the repo root — repo-specific JTBD conventions.
+   - `skills/skills-metadata.yaml` — declares which skills are `jtbd` vs `prose`. Determines which extra rules apply.
+2. **Identify the target skill(s)**: the caller will name a path (e.g. `skills/omni-gateway/install-omni-gateway/SKILL.md`) or a list of paths. If the caller asks to review every skill changed in the current branch, resolve the list with `git diff --name-only <base>... -- 'skills/**/SKILL.md'`.
+3. **Determine skill type** by reading `skills-metadata.yaml` (or the parent bundle's): `jtbd` (default) or `prose` (override). The type drives which extra checks apply (see "Type-specific dimensions" below).
+4. **Read the full SKILL.md** plus any referenced files (`references/`, `scripts/`) — progressive disclosure means a top-level SKILL.md is only half the picture.
+5. **Evaluate against each dimension below**, in order. For each dimension, decide: PASS / WARN / FAIL, with a one-line rationale and a quote from the SKILL.md.
+6. **Return the findings to the caller** in the structure shown in "Output Format" below. Do not create or write to any file unless the caller explicitly asks for it — the caller decides whether to display the report, append it to a review document, attach it to a PR comment, or use it to revise a skill in-flight.
+
+## Review Dimensions
+
+For each, cite the exact best-practices section and quote the offending text from SKILL.md. Do not invent rules — if a check isn't grounded in the reference doc, don't include it.
+
+### 1. Concision (Core principles → "Concise is key")
+- Is every paragraph earning its tokens? Flag prose that explains things Claude already knows (what a PDF is, what a library is, what HTTP is).
+- Is SKILL.md body under ~500 lines? If over, is the overflow content split into `references/` files that load on demand?
+- Are there redundant restatements of the same instruction?
+
+### 2. Description quality (Skill structure → "Writing effective descriptions")
+- **Third person** — flag any "I can…" or "You can…" or "Use this to…" framings.
+- **Specific + trigger-rich** — does the description list both *what* the skill does and *when* to use it (concrete user-phrasings, file types, scenarios)?
+- **Length** — under 1024 chars but specific enough that Claude can disambiguate from 100+ other skills.
+- **Vague rejects** — "Helps with X", "Manages Y", "Does stuff with Z" → fail.
+
+### 3. Naming (Skill structure → "Naming conventions")
+- Lowercase + hyphens + numbers only.
+- No reserved words: `anthropic`, `claude`.
+- Prefer gerund form (`processing-pdfs`) or noun phrases (`pdf-processing`); flag `helper`, `utils`, `tools`.
+- The `name:` field must match the directory.
+
+### 4. Degree-of-freedom calibration (Core principles → "Set appropriate degrees of freedom")
+- **Fragile / one-true-path** operations (DB migrations, build commands, exact env setup) should be **low freedom** — exact scripts, "do not modify".
+- **Judgment calls** (code review, design decisions) should be **high freedom** — heuristics + criteria, not lockstep steps.
+- Flag mismatches: a code-review skill with 17 rigid steps, or a `mvn deploy` skill that says "use whatever flags seem right".
+
+### 5. Progressive disclosure (Skill structure → "Pattern 1/2/3")
+- Long reference content (catalogs, error tables, schemas) belongs in `references/foo.md`, loaded on demand.
+- Helper logic belongs in `scripts/`, executed not loaded.
+- Flag a 1500-line SKILL.md where the bottom 1000 lines are reference material that should have been split.
+
+### 6. Discoverability triggers (Skill structure → "Writing effective descriptions" + "How Skills work")
+- Description should contain the **literal terms** a user is likely to type ("validate", "review", "deploy", "Mule", "OAS") so Claude's selector matches.
+- If the skill applies to a specific tool/format/file extension, that should appear verbatim.
+
+### 7. Cross-references (skill-bundle pattern in this repo)
+- If SKILL.md references other skills by name, those skills must exist in the same bundle (or be marked "coming in vX.Y").
+- URLs and file paths inside the skill must resolve.
+- Trigger phrases listed in the description should be plausible — not invented.
+
+### 8. Tone consistency (Skill structure → third person)
+- Any first-person ("I'll do…") or second-person command framing aimed at the human ("you should…") within instructions block is a red flag — instructions are for Claude.
+
+## Type-specific dimensions
+
+This repo classifies skills as **`jtbd`** (default) or **`prose`** in `skills/skills-metadata.yaml` (or the bundle-level `<bundle>/skills-metadata.yaml`). Apply only the dimensions that match the declared type. Type↔structure coherence (does the content match the type?) is already enforced by R7 of the deterministic validator — flag here only when the AI reading detects subtler drift.
+
+> **Scope reminder:** the deterministic validators (`validate_skills.py`, `validate_jtbd.py`) already enforce structural correctness — step numbering gaps, frontmatter parseability, kebab-case names, bundle metadata, `urn:` resolution, step dependency order, type-vs-structure coherence. **Do not re-check those.** If a finding can be expressed as a regex/AST rule, it belongs in the deterministic layer, not here. Below are only judgment calls.
+
+### JTBD-specific (when `type: jtbd`)
+- **Imperative voice in step titles** — "Search Exchange" is correct; "Searching Exchange", "How to search Exchange", "Exchange search" are not. Determinístic check can't tell a verb from a gerund — that's why this is here. Apply the same criteria as `validate-imperative-format` does for API descriptions.
+- **`inputs:` / `outputs:` capture the real dependency, not just the obvious ones** — if Step 7's prose says "use the GAV from Step 4", but Step 4 declares no `outputs.gav` and Step 7 declares no `inputs.gav`, the data flow is invisible to the agent. Determinístic checks see the YAML structure but can't read the prose to detect the mismatch.
+- **Step prose stays consistent with step numbering after renumbering** — when a PR renumbers steps, internal references like "as in Step 5" or "Step 8 will use this" must point to the *new* step numbers. Determinístic validators don't know what Step 5 *was about*; an LLM does.
+- **Phase boundaries are real, not decorative** — if a JTBD declares a "user-approval gate" between phases, the gate must actually mean something (the next step refuses to proceed without explicit user input). Cosmetic phase headings without enforcement are a smell.
+
+### Prose-specific (when `type: prose`)
+- **The skill is genuinely prose, not a JTBD wearing a costume** — if a prose skill has 8 sequential `### Step N` headings with bash commands and explicit ordering, it should probably be `type: jtbd`. R7 only flags binary mismatches (has steps / has none); the gradual slippage requires reading.
+- **Decision-routing structure exists in bundle-root prose skills** — for a multi-skill bundle (like `omni-gateway/SKILL.md`), the root should route the agent to sub-skills via a decision table or mermaid flowchart. A bundle-root prose skill that's just a paragraph of "this bundle does X, Y, Z" without routing wastes the entry point.
+- **Mermaid diagrams render** — confirm fenced as ` ```mermaid ` (not in YAML frontmatter) and that node references match labels. Mermaid in frontmatter is the bug we hit on PR #129.
+
+### Bundle-level (when reviewing a whole bundle, not a single skill)
+- **The bundle's `SKILL.md` (root) actually adds value** — if it's just a list of sub-skill names, the agent could discover those from descriptions alone. The root should help disambiguate, route, or set shared context.
+- **CHANGELOG entry matches the actual user-visible change** — a CHANGELOG that says "improved error handling" when the diff added a new sub-skill is misleading. R-level validators don't read the CHANGELOG semantically.
+
+## Output Format
+
+Return findings as a markdown block per skill reviewed, using this exact structure. The block goes in the response to the caller; do not write it to a file.
+
+```markdown
+### Quality review — `<path/to/SKILL.md>`
+
+**Blocking findings**
+- **<short title>** — Best-practice violated: *<section name>*. Quote: "<offending text>". Why it harms the agent: <1 sentence>. Suggested fix: <1 sentence>.
+
+**Should fix**
+- (same shape)
+
+**Optional polish**
+- (same shape, only if non-trivial)
+
+**Verdict**: Approve / Approve with comments / Request changes
+```
+
+When reviewing more than one skill in the same call, emit one such block per skill, in the order they were named.
+
+Keep findings **action-oriented**. A finding like "the prose feels long" is not actionable; "lines 40-90 explain what XML namespaces are — Claude knows. Cut to one line referencing the canonical XSD section" is actionable.
+
+## Anti-Patterns to Avoid in the Review Itself
+
+- **Do not invent rules** beyond `references/anthropic-best-practices.md`. If something feels wrong but doesn't violate a documented principle, don't flag it as a finding — at most note as optional polish with that caveat.
+- **Do not nit-pick prose style** (Oxford commas, sentence length). Best-practices doc is about token efficiency and discoverability, not English-teacher polish.
+- **Do not over-trigger**. If the SKILL.md is short and clear, just say "Approve — no findings" and move on. Padding the review with weak findings dilutes the strong ones.
+- **Cite literally**. Every finding must include a real quote from the SKILL.md and a real section name from the best-practices reference.
+
+## Reference
+
+- [`references/anthropic-best-practices.md`](references/anthropic-best-practices.md) — vendored copy of Anthropic's [official agent-skill best-practices doc](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) (fetched 2026-06-10). Re-fetch with `defuddle parse <url> --md` if Anthropic publishes updates.
+- `docs/job-template.md` — repo-canonical JTBD template; new JTBD skills should structurally match it.
+- `docs/jobs-readme.md` — guide explaining the JTBD format and its triple purpose (AI skill, doc, executable spec).
+- `docs/x-jobs-to-be-done-schema.md` — JTBD schema reference.
+- `skills/skills-metadata.yaml` (and per-bundle `<bundle>/skills-metadata.yaml`) — declares `type: jtbd` (default) or `type: prose` per skill. Drives type-specific review dimensions.
+- `scripts/build/validate_skills.py` — deterministic R1–R7 structural validator (R1: name↔dir, R2: kebab-case, R3: uniqueness, R4: required metadata, R5: cross-refs, R6: type resolvable, R7: type↔structure). This skill complements those checks; it does not duplicate them.
+- `scripts/build/validate_jtbd.py` — deterministic JTBD-format validator (frontmatter, step numbering, YAML step blocks, dependencies). Run before this skill — fix structural errors first.
+- `.claude/skills/validate-imperative-format/SKILL.md` — sibling skill that validates API `info.description` imperative voice. Same principle applies to JTBD step titles; reuse its criteria there.

--- a/.claude/skills/skill-quality-review/references/anthropic-best-practices.md
+++ b/.claude/skills/skill-quality-review/references/anthropic-best-practices.md
@@ -1,0 +1,1102 @@
+Good Skills are concise, well-structured, and tested with real usage. This guide provides practical authoring decisions to help you write Skills that Claude can discover and use effectively.
+
+For conceptual background on how Skills work, see the [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview).
+
+## Core principles
+
+### Concise is key
+
+The [context window](https://platform.claude.com/docs/en/build-with-claude/context-windows) is a public good. Your Skill shares the context window with everything else Claude needs to know, including:
+
+- The system prompt
+- Conversation history
+- Other Skills' metadata
+- Your actual request
+
+Not every token in your Skill has an immediate cost. At startup, only the metadata (name and description) from all Skills is pre-loaded. Claude reads SKILL.md only when the Skill becomes relevant, and reads additional files only as needed. However, being concise in SKILL.md still matters: once Claude loads it, every token competes with conversation history and other context.
+
+**Default assumption:** Claude is already very smart
+
+Only add context Claude doesn't already have. Challenge each piece of information:
+
+- "Does Claude really need this explanation?"
+- "Can I assume Claude knows this?"
+- "Does this paragraph justify its token cost?"
+
+**Good example: Concise** (approximately 50 tokens):
+
+```
+## Extract PDF text
+
+Use pdfplumber for text extraction:
+
+\`\`\`python
+import pdfplumber
+
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+\`\`\`
+```
+
+**Bad example: Too verbose** (approximately 150 tokens):
+
+```
+## Extract PDF text
+
+PDF (Portable Document Format) files are a common file format that contains
+text, images, and other content. To extract text from a PDF, you'll need to
+use a library. There are many libraries available for PDF processing, but
+pdfplumber is recommended because it's easy to use and handles most cases well.
+First, you'll need to install it using pip. Then you can use the code below...
+```
+
+The concise version assumes Claude knows what PDFs are and how libraries work.
+
+### Set appropriate degrees of freedom
+
+Match the level of specificity to the task's fragility and variability.
+
+**High freedom** (text-based instructions):
+
+Use when:
+
+- Multiple approaches are valid
+- Decisions depend on context
+- Heuristics guide the approach
+
+Example:
+
+```
+## Code review process
+
+1. Analyze the code structure and organization
+2. Check for potential bugs or edge cases
+3. Suggest improvements for readability and maintainability
+4. Verify adherence to project conventions
+```
+
+**Medium freedom** (pseudocode or scripts with parameters):
+
+Use when:
+
+- A preferred pattern exists
+- Some variation is acceptable
+- Configuration affects behavior
+
+Example:
+
+```
+## Generate report
+
+Use this template and customize as needed:
+
+\`\`\`python
+def generate_report(data, format="markdown", include_charts=True):
+    # Process data
+    # Generate output in specified format
+    # Optionally include visualizations
+\`\`\`
+```
+
+**Low freedom** (specific scripts, few or no parameters):
+
+Use when:
+
+- Operations are fragile and error-prone
+- Consistency is critical
+- A specific sequence must be followed
+
+Example:
+
+```
+## Database migration
+
+Run exactly this script:
+
+\`\`\`bash
+python scripts/migrate.py --verify --backup
+\`\`\`
+
+Do not modify the command or add additional flags.
+```
+
+**Analogy:** Think of Claude as a robot exploring a path:
+
+- **Narrow bridge with cliffs on both sides:** There's only one safe way forward. Provide specific guardrails and exact instructions (low freedom). Example: database migrations that must run in exact sequence.
+- **Open field with no hazards:** Many paths lead to success. Give general direction and trust Claude to find the best route (high freedom). Example: code reviews where context determines the best approach.
+
+### Test with all models you plan to use
+
+Skills act as additions to models, so effectiveness depends on the underlying model. Test your Skill with all the models you plan to use it with.
+
+**Testing considerations by model:**
+
+- **Claude Haiku** (fast, economical): Does the Skill provide enough guidance?
+- **Claude Sonnet** (balanced): Is the Skill clear and efficient?
+- **Claude Opus** (powerful reasoning): Does the Skill avoid over-explaining?
+
+What works perfectly for Opus might need more detail for Haiku. If you plan to use your Skill across multiple models, aim for instructions that work well with all of them.
+
+## Skill structure
+
+**YAML Frontmatter:** The SKILL.md frontmatter requires two fields:
+
+`name`:
+
+- Maximum 64 characters
+- Must contain only lowercase letters, numbers, and hyphens
+- Cannot contain XML tags
+- Cannot contain reserved words: "anthropic", "claude"
+
+`description`:
+
+- Must be non-empty
+- Maximum 1024 characters
+- Cannot contain XML tags
+- Should describe what the Skill does and when to use it
+
+For complete Skill structure details, see the [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure).
+
+### Naming conventions
+
+Use consistent naming patterns to make Skills easier to reference and discuss. Consider using **gerund form** (verb + -ing) for Skill names, as this clearly describes the activity or capability the Skill provides.
+
+Remember that the `name` field must use lowercase letters, numbers, and hyphens only.
+
+**Good naming examples (gerund form):**
+
+- `processing-pdfs`
+- `analyzing-spreadsheets`
+- `managing-databases`
+- `testing-code`
+- `writing-documentation`
+
+**Acceptable alternatives:**
+
+- Noun phrases: `pdf-processing`, `spreadsheet-analysis`
+- Action-oriented: `process-pdfs`, `analyze-spreadsheets`
+
+**Avoid:**
+
+- Vague names: `helper`, `utils`, `tools`
+- Overly generic: `documents`, `data`, `files`
+- Reserved words: `anthropic-helper`, `claude-tools`
+- Inconsistent patterns within your skill collection
+
+Consistent naming makes it easier to:
+
+- Reference Skills in documentation and conversations
+- Understand what a Skill does at a glance
+- Organize and search through multiple Skills
+- Maintain a professional, cohesive skill library
+
+### Writing effective descriptions
+
+The `description` field enables Skill discovery and should include both what the Skill does and when to use it.
+
+**Always write in third person**. The description is injected into the system prompt, and inconsistent point-of-view can cause discovery problems.
+
+- **Good:** "Processes Excel files and generates reports"
+- **Avoid:** "I can help you process Excel files"
+- **Avoid:** "You can use this to process Excel files"
+
+**Be specific and include key terms**. Include both what the Skill does and specific triggers/contexts for when to use it.
+
+Each Skill has exactly one description field. The description is critical for skill selection: Claude uses it to choose the right Skill from potentially 100+ available Skills. Your description must provide enough detail for Claude to know when to select this Skill, while the rest of SKILL.md provides the implementation details.
+
+Effective examples:
+
+**PDF Processing skill:**
+
+```
+description: Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+```
+
+**Excel Analysis skill:**
+
+```
+description: Analyze Excel spreadsheets, create pivot tables, generate charts. Use when analyzing Excel files, spreadsheets, tabular data, or .xlsx files.
+```
+
+**Git Commit Helper skill:**
+
+```
+description: Generate descriptive commit messages by analyzing git diffs. Use when the user asks for help writing commit messages or reviewing staged changes.
+```
+
+Avoid vague descriptions like these:
+
+```
+description: Helps with documents
+```
+
+```
+description: Processes data
+```
+
+```
+description: Does stuff with files
+```
+
+SKILL.md serves as an overview that points Claude to detailed materials as needed, like a table of contents in an onboarding guide. For an explanation of how progressive disclosure works, see [How Skills work](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work) in the overview.
+
+**Practical guidance:**
+
+- Keep SKILL.md body under 500 lines for optimal performance
+- Split content into separate files when approaching this limit
+- Use the patterns below to organize instructions, code, and resources effectively
+
+#### Visual overview: From simple to complex
+
+A basic Skill starts with just a SKILL.md file containing metadata and instructions:
+
+![Simple SKILL.md file showing YAML frontmatter and markdown body](https://platform.claude.com/docs/images/agent-skills-simple-file.png)
+
+As your Skill grows, you can bundle additional content that Claude loads only when needed:
+
+![Bundling additional reference files like reference.md and forms.md.](https://platform.claude.com/docs/images/agent-skills-bundling-content.png)
+
+The complete Skill directory structure might look like this:
+
+```
+pdf/
+├── SKILL.md              # Main instructions (loaded when triggered)
+├── FORMS.md              # Form-filling guide (loaded as needed)
+├── reference.md          # API reference (loaded as needed)
+├── examples.md           # Usage examples (loaded as needed)
+└── scripts/
+    ├── analyze_form.py   # Utility script (executed, not loaded)
+    ├── fill_form.py      # Form filling script
+    └── validate.py       # Validation script
+```
+
+#### Pattern 1: High-level guide with references
+
+```
+---
+name: pdf-processing
+description: Extracts text and tables from PDF files, fills forms, and merges documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.
+---
+
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+\`\`\`python
+import pdfplumber
+with pdfplumber.open("file.pdf") as pdf:
+    text = pdf.pages[0].extract_text()
+\`\`\`
+
+## Advanced features
+
+**Form filling**: See [FORMS.md](FORMS.md) for complete guide
+**API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+**Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+#### Pattern 2: Domain-specific organization
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context. When a user asks about sales metrics, Claude only needs to read sales-related schemas, not finance or marketing data. This keeps token usage low and context focused.
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+```
+# BigQuery Data Analysis
+
+## Available datasets
+
+**Finance**: Revenue, ARR, billing → See [reference/finance.md](reference/finance.md)
+**Sales**: Opportunities, pipeline, accounts → See [reference/sales.md](reference/sales.md)
+**Product**: API usage, features, adoption → See [reference/product.md](reference/product.md)
+**Marketing**: Campaigns, attribution, email → See [reference/marketing.md](reference/marketing.md)
+
+## Quick search
+
+Find specific metrics using grep:
+
+\`\`\`bash
+grep -i "revenue" reference/finance.md
+grep -i "pipeline" reference/sales.md
+grep -i "api usage" reference/product.md
+\`\`\`
+```
+
+#### Pattern 3: Conditional details
+
+Show basic content, link to advanced content:
+
+```
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+### Avoid deeply nested references
+
+Claude may partially read files when they're referenced from other referenced files. When encountering nested references, Claude might use commands like `head -100` to preview content rather than reading entire files, resulting in incomplete information.
+
+**Keep references one level deep from SKILL.md**. All reference files should link directly from SKILL.md to ensure Claude reads complete files when needed.
+
+**Bad example: Too deep**:
+
+```
+# SKILL.md
+See [advanced.md](advanced.md)...
+
+# advanced.md
+See [details.md](details.md)...
+
+# details.md
+Here's the actual information...
+```
+
+**Good example: One level deep**:
+
+```
+# SKILL.md
+
+**Basic usage**: [instructions in SKILL.md]
+**Advanced features**: See [advanced.md](advanced.md)
+**API reference**: See [reference.md](reference.md)
+**Examples**: See [examples.md](examples.md)
+```
+
+For reference files longer than 100 lines, include a table of contents at the top. This ensures Claude can see the full scope of available information even when previewing with partial reads.
+
+**Example:**
+
+```
+# API Reference
+
+## Contents
+- Authentication and setup
+- Core methods (create, read, update, delete)
+- Advanced features (batch operations, webhooks)
+- Error handling patterns
+- Code examples
+
+## Authentication and setup
+...
+
+## Core methods
+...
+```
+
+Claude can then read the complete file or jump to specific sections as needed.
+
+For details on how this filesystem-based architecture enables progressive disclosure, see the [Runtime environment](#runtime-environment) section in the Advanced section below.
+
+### Use workflows for complex tasks
+
+Break complex operations into clear, sequential steps. For particularly complex workflows, provide a checklist that Claude can copy into its response and check off as it progresses.
+
+**Example 1: Research synthesis workflow** (for Skills without code):
+
+```
+## Research synthesis workflow
+
+Copy this checklist and track your progress:
+
+\`\`\`
+Research Progress:
+- [ ] Step 1: Read all source documents
+- [ ] Step 2: Identify key themes
+- [ ] Step 3: Cross-reference claims
+- [ ] Step 4: Create structured summary
+- [ ] Step 5: Verify citations
+\`\`\`
+
+**Step 1: Read all source documents**
+
+Review each document in the \`sources/\` directory. Note the main arguments and supporting evidence.
+
+**Step 2: Identify key themes**
+
+Look for patterns across sources. What themes appear repeatedly? Where do sources agree or disagree?
+
+**Step 3: Cross-reference claims**
+
+For each major claim, verify it appears in the source material. Note which source supports each point.
+
+**Step 4: Create structured summary**
+
+Organize findings by theme. Include:
+- Main claim
+- Supporting evidence from sources
+- Conflicting viewpoints (if any)
+
+**Step 5: Verify citations**
+
+Check that every claim references the correct source document. If citations are incomplete, return to Step 3.
+```
+
+This example shows how workflows apply to analysis tasks that don't require code. The checklist pattern works for any complex, multi-step process.
+
+**Example 2: PDF form filling workflow** (for Skills with code):
+
+```
+## PDF form filling workflow
+
+Copy this checklist and check off items as you complete them:
+
+\`\`\`
+Task Progress:
+- [ ] Step 1: Analyze the form (run analyze_form.py)
+- [ ] Step 2: Create field mapping (edit fields.json)
+- [ ] Step 3: Validate mapping (run validate_fields.py)
+- [ ] Step 4: Fill the form (run fill_form.py)
+- [ ] Step 5: Verify output (run verify_output.py)
+\`\`\`
+
+**Step 1: Analyze the form**
+
+Run: \`python scripts/analyze_form.py input.pdf\`
+
+This extracts form fields and their locations, saving to \`fields.json\`.
+
+**Step 2: Create field mapping**
+
+Edit \`fields.json\` to add values for each field.
+
+**Step 3: Validate mapping**
+
+Run: \`python scripts/validate_fields.py fields.json\`
+
+Fix any validation errors before continuing.
+
+**Step 4: Fill the form**
+
+Run: \`python scripts/fill_form.py input.pdf fields.json output.pdf\`
+
+**Step 5: Verify output**
+
+Run: \`python scripts/verify_output.py output.pdf\`
+
+If verification fails, return to Step 2.
+```
+
+Clear steps prevent Claude from skipping critical validation. The checklist helps both Claude and you track progress through multi-step workflows.
+
+**Common pattern:** Run validator → fix errors → repeat
+
+This pattern greatly improves output quality.
+
+**Example 1: Style guide compliance** (for Skills without code):
+
+```
+## Content review process
+
+1. Draft your content following the guidelines in STYLE_GUIDE.md
+2. Review against the checklist:
+   - Check terminology consistency
+   - Verify examples follow the standard format
+   - Confirm all required sections are present
+3. If issues found:
+   - Note each issue with specific section reference
+   - Revise the content
+   - Review the checklist again
+4. Only proceed when all requirements are met
+5. Finalize and save the document
+```
+
+This shows the validation loop pattern using reference documents instead of scripts. The "validator" is STYLE\_GUIDE.md, and Claude performs the check by reading and comparing.
+
+**Example 2: Document editing process** (for Skills with code):
+
+```
+## Document editing process
+
+1. Make your edits to \`word/document.xml\`
+2. **Validate immediately**: \`python ooxml/scripts/validate.py unpacked_dir/\`
+3. If validation fails:
+   - Review the error message carefully
+   - Fix the issues in the XML
+   - Run validation again
+4. **Only proceed when validation passes**
+5. Rebuild: \`python ooxml/scripts/pack.py unpacked_dir/ output.docx\`
+6. Test the output document
+```
+
+The validation loop catches errors early.
+
+## Content guidelines
+
+### Avoid time-sensitive information
+
+Don't include information that will become outdated:
+
+**Bad example: Time-sensitive** (will become wrong):
+
+```
+If you're doing this before August 2025, use the old API.
+After August 2025, use the new API.
+```
+
+**Good example** (use "old patterns" section):
+
+```
+## Current method
+
+Use the v2 API endpoint: \`api.example.com/v2/messages\`
+
+## Old patterns
+
+<details>
+<summary>Legacy v1 API (deprecated 2025-08)</summary>
+
+The v1 API used: \`api.example.com/v1/messages\`
+
+This endpoint is no longer supported.
+</details>
+```
+
+The old patterns section provides historical context without cluttering the main content.
+
+### Use consistent terminology
+
+Choose one term and use it throughout the Skill:
+
+**Good - Consistent:**
+
+- Always "API endpoint"
+- Always "field"
+- Always "extract"
+
+**Bad - Inconsistent:**
+
+- Mix "API endpoint", "URL", "API route", "path"
+- Mix "field", "box", "element", "control"
+- Mix "extract", "pull", "get", "retrieve"
+
+Consistency helps Claude understand and follow instructions.
+
+## Common patterns
+
+### Template pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements** (like API responses or data formats):
+
+```
+## Report structure
+
+ALWAYS use this exact template structure:
+
+\`\`\`markdown
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+\`\`\`
+```
+
+**For flexible guidance** (when adaptation is useful):
+
+```
+## Report structure
+
+Here is a sensible default format, but use your best judgment based on the analysis:
+
+\`\`\`markdown
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+\`\`\`
+
+Adjust sections as needed for the specific analysis type.
+```
+
+### Examples pattern
+
+For Skills where output quality depends on seeing examples, provide input/output pairs just like in regular prompting:
+
+```
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+\`\`\`
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+\`\`\`
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+\`\`\`
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+\`\`\`
+
+**Example 3:**
+Input: Updated dependencies and refactored error handling
+Output:
+\`\`\`
+chore: update dependencies and refactor error handling
+
+- Upgrade lodash to 4.17.21
+- Standardize error response format across endpoints
+\`\`\`
+
+Follow this style: type(scope): brief description, then detailed explanation.
+```
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.
+
+### Conditional workflow pattern
+
+Guide Claude through decision points:
+
+```
+## Document modification workflow
+
+1. Determine the modification type:
+
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow:
+   - Use docx-js library
+   - Build document from scratch
+   - Export to .docx format
+
+3. Editing workflow:
+   - Unpack existing document
+   - Modify XML directly
+   - Validate after each change
+   - Repack when complete
+```
+
+If workflows become large or complicated with many steps, consider pushing them into separate files and tell Claude to read the appropriate file based on the task at hand.
+
+## Evaluation and iteration
+
+### Build evaluations first
+
+**Create evaluations BEFORE writing extensive documentation.** This ensures your Skill solves real problems rather than documenting imagined ones.
+
+**Evaluation-driven development:**
+
+1. **Identify gaps:** Run Claude on representative tasks without a Skill. Document specific failures or missing context
+2. **Create evaluations:** Build three scenarios that test these gaps
+3. **Establish baseline:** Measure Claude's performance without the Skill
+4. **Write minimal instructions:** Create just enough content to address the gaps and pass evaluations
+5. **Iterate:** Execute evaluations, compare against baseline, and refine
+
+This approach ensures you're solving actual problems rather than anticipating requirements that may never materialize.
+
+**Evaluation structure:**
+
+```
+{
+  "skills": ["pdf-processing"],
+  "query": "Extract all text from this PDF file and save it to output.txt",
+  "files": ["test-files/document.pdf"],
+  "expected_behavior": [
+    "Successfully reads the PDF file using an appropriate PDF processing library or command-line tool",
+    "Extracts text content from all pages in the document without missing any pages",
+    "Saves the extracted text to a file named output.txt in a clear, readable format"
+  ]
+}
+```
+
+This example demonstrates a data-driven evaluation with a simple testing rubric. There is not currently a built-in way to run these evaluations. Users can create their own evaluation system. Evaluations are your source of truth for measuring Skill effectiveness.
+
+### Develop Skills iteratively with Claude
+
+The most effective Skill development process involves Claude itself. Work with one instance of Claude ("Claude A") to create a Skill that is used by other instances ("Claude B"). Claude A helps you design and refine instructions, while Claude B tests them in real tasks. This works because Claude models understand both how to write effective agent instructions and what information agents need.
+
+**Creating a new Skill:**
+
+1. **Complete a task without a Skill:** Work through a problem with Claude A using normal prompting. As you work, you'll naturally provide context, explain preferences, and share procedural knowledge. Notice what information you repeatedly provide.
+2. **Identify the reusable pattern:** After completing the task, identify what context you provided that would be useful for similar future tasks.
+	**Example:** If you worked through a BigQuery analysis, you might have provided table names, field definitions, filtering rules (like "always exclude test accounts"), and common query patterns.
+3. **Ask Claude A to create a Skill:** "Create a Skill that captures this BigQuery analysis pattern we just used. Include the table schemas, naming conventions, and the rule about filtering test accounts."
+	Claude models understand the Skill format and structure natively. You don't need special system prompts or a "writing skills" skill to get Claude to help create Skills. Simply ask Claude to create a Skill and it generates properly structured SKILL.md content with appropriate frontmatter and body content.
+4. **Review for conciseness:** Check that Claude A hasn't added unnecessary explanations. Ask: "Remove the explanation about what win rate means - Claude already knows that."
+5. **Improve information architecture:** Ask Claude A to organize the content more effectively. For example: "Organize this so the table schema is in a separate reference file. We might add more tables later."
+6. **Test on similar tasks:** Use the Skill with Claude B (a fresh instance with the Skill loaded) on related use cases. Observe whether Claude B finds the right information, applies rules correctly, and handles the task successfully.
+7. **Iterate based on observation:** If Claude B struggles or misses something, return to Claude A with specifics: "When Claude used this Skill, it forgot to filter by date for Q4. Should we add a section about date filtering patterns?"
+
+**Iterating on existing Skills:**
+
+The same hierarchical pattern continues when improving Skills. You alternate between:
+
+- **Working with Claude A** (the expert who helps refine the Skill)
+- **Testing with Claude B** (the agent using the Skill to perform real work)
+- **Observing Claude B's behavior** and bringing insights back to Claude A
+1. **Use the Skill in real workflows:** Give Claude B (with the Skill loaded) actual tasks, not test scenarios
+2. **Observe Claude B's behavior:** Note where it struggles, succeeds, or makes unexpected choices
+	**Example observation:** "When I asked Claude B for a regional sales report, it wrote the query but forgot to filter out test accounts, even though the Skill mentions this rule."
+3. **Return to Claude A for improvements:** Share the current SKILL.md and describe what you observed. Ask: "I noticed Claude B forgot to filter test accounts when I asked for a regional report. The Skill mentions filtering, but maybe it's not prominent enough?"
+4. **Review Claude A's suggestions:** Claude A might suggest reorganizing to make rules more prominent, using stronger language like "MUST filter" instead of "always filter", or restructuring the workflow section.
+5. **Apply and test changes:** Update the Skill with Claude A's refinements, then test again with Claude B on similar requests
+6. **Repeat based on usage:** Continue this observe-refine-test cycle as you encounter new scenarios. Each iteration improves the Skill based on real agent behavior, not assumptions.
+
+**Gathering team feedback:**
+
+1. Share Skills with teammates and observe their usage
+2. Ask: Does the Skill activate when expected? Are instructions clear? What's missing?
+3. Incorporate feedback to address blind spots in your own usage patterns
+
+**Why this approach works:** Claude A understands agent needs, you provide domain expertise, Claude B reveals gaps through real usage, and iterative refinement improves Skills based on observed behavior rather than assumptions.
+
+As you iterate on Skills, pay attention to how Claude actually uses them in practice. Watch for:
+
+- **Unexpected exploration paths:** Does Claude read files in an order you didn't anticipate? This might indicate your structure isn't as intuitive as you thought
+- **Missed connections:** Does Claude fail to follow references to important files? Your links might need to be more explicit or prominent
+- **Overreliance on certain sections:** If Claude repeatedly reads the same file, consider whether that content should be in the main SKILL.md instead
+- **Ignored content:** If Claude never accesses a bundled file, it might be unnecessary or poorly signaled in the main instructions
+
+Iterate based on these observations rather than assumptions. The 'name' and 'description' in your Skill's metadata are particularly critical. Claude uses these when deciding whether to trigger the Skill in response to the current task. Make sure they clearly describe what the Skill does and when it should be used.
+
+## Anti-patterns to avoid
+
+### Avoid Windows-style paths
+
+Always use forward slashes in file paths, even on Windows:
+
+- ✓ **Good:** `scripts/helper.py`, `reference/guide.md`
+- ✗ **Avoid:** `scripts\helper.py`, `reference\guide.md`
+
+Unix-style paths work across all platforms, while Windows-style paths cause errors on Unix systems.
+
+### Avoid offering too many options
+
+Don't present multiple approaches unless necessary:
+
+```
+**Bad example: Too many choices** (confusing):
+"You can use pypdf, or pdfplumber, or PyMuPDF, or pdf2image, or..."
+
+**Good example: Provide a default** (with escape hatch):
+"Use pdfplumber for text extraction:
+\`\`\`python
+import pdfplumber
+\`\`\`
+
+For scanned PDFs requiring OCR, use pdf2image with pytesseract instead."
+```
+
+## Advanced: Skills with executable code
+
+The sections below focus on Skills that include executable scripts. If your Skill uses only markdown instructions, skip to [Checklist for effective Skills](#checklist-for-effective-skills).
+
+### Solve, don't punt
+
+When writing scripts for Skills, handle error conditions rather than punting to Claude.
+
+**Good example: Handle errors explicitly:**
+
+```
+def process_file(path):
+    """Process a file, creating it if it doesn't exist."""
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        # Create file with default content instead of failing
+        print(f"File {path} not found, creating default")
+        with open(path, "w") as f:
+            f.write("")
+        return ""
+    except PermissionError:
+        # Provide alternative instead of failing
+        print(f"Cannot access {path}, using default")
+        return ""
+```
+
+**Bad example: Punt to Claude:**
+
+```
+def process_file(path):
+    # Just fail and let Claude figure it out
+    return open(path).read()
+```
+
+Configuration parameters should also be justified and documented to avoid "voodoo constants" (Ousterhout's law). If you don't know the right value, how will Claude determine it?
+
+**Good example: Self-documenting:**
+
+```
+# HTTP requests typically complete within 30 seconds
+# Longer timeout accounts for slow connections
+REQUEST_TIMEOUT = 30
+
+# Three retries balances reliability vs speed
+# Most intermittent failures resolve by the second retry
+MAX_RETRIES = 3
+```
+
+**Bad example: Magic numbers:**
+
+```
+TIMEOUT = 47  # Why 47?
+RETRIES = 5  # Why 5?
+```
+
+### Provide utility scripts
+
+Even if Claude could write a script, pre-made scripts offer advantages:
+
+**Benefits of utility scripts:**
+
+- More reliable than generated code
+- Save tokens (no need to include code in context)
+- Save time (no code generation required)
+- Ensure consistency across uses
+
+![Bundling executable scripts alongside instruction files](https://platform.claude.com/docs/images/agent-skills-executable-scripts.png)
+
+The diagram above shows how executable scripts work alongside instruction files. The instruction file (forms.md) references the script, and Claude can execute it without loading its contents into context.
+
+**Important distinction:** Make clear in your instructions whether Claude should:
+
+- **Execute the script** (most common): "Run `analyze_form.py` to extract fields"
+- **Read it as reference** (for complex logic): "See `analyze_form.py` for the field extraction algorithm"
+
+For most utility scripts, execution is preferred because it's more reliable and efficient. See the [Runtime environment](#runtime-environment) section below for details on how script execution works.
+
+**Example:**
+
+```
+## Utility scripts
+
+**analyze_form.py**: Extract all form fields from PDF
+
+\`\`\`bash
+python scripts/analyze_form.py input.pdf > fields.json
+\`\`\`
+
+Output format:
+\`\`\`json
+{
+  "field_name": {"type": "text", "x": 100, "y": 200},
+  "signature": {"type": "sig", "x": 150, "y": 500}
+}
+\`\`\`
+
+**validate_boxes.py**: Check for overlapping bounding boxes
+
+\`\`\`bash
+python scripts/validate_boxes.py fields.json
+# Returns: "OK" or lists conflicts
+\`\`\`
+
+**fill_form.py**: Apply field values to PDF
+
+\`\`\`bash
+python scripts/fill_form.py input.pdf fields.json output.pdf
+\`\`\`
+```
+
+### Use visual analysis
+
+When inputs can be rendered as images, have Claude analyze them:
+
+```
+## Form layout analysis
+
+1. Convert PDF to images:
+   \`\`\`bash
+   python scripts/pdf_to_images.py form.pdf
+   \`\`\`
+
+2. Analyze each page image to identify form fields
+3. Claude can see field locations and types visually
+```
+
+In this example, you'd need to write the `pdf_to_images.py` script.
+
+Claude's vision capabilities help understand layouts and structures.
+
+### Create verifiable intermediate outputs
+
+When Claude performs complex, open-ended tasks, it can make mistakes. The "plan-validate-execute" pattern catches errors early by having Claude first create a plan in a structured format, then validate that plan with a script before executing it.
+
+**Example:** Imagine asking Claude to update 50 form fields in a PDF based on a spreadsheet. Without validation, Claude might reference non-existent fields, create conflicting values, miss required fields, or apply updates incorrectly.
+
+**Solution:** Use the workflow pattern shown above (PDF form filling), but add an intermediate `changes.json` file that gets validated before applying changes. The workflow becomes: analyze → **create plan file** → **validate plan** → execute → verify.
+
+**Why this pattern works:**
+
+- **Catches errors early:** Validation finds problems before changes are applied
+- **Machine-verifiable:** Scripts provide objective verification
+- **Reversible planning:** Claude can iterate on the plan without touching originals
+- **Clear debugging:** Error messages point to specific problems
+
+**When to use:** Batch operations, destructive changes, complex validation rules, high-stakes operations.
+
+**Implementation tip:** Make validation scripts verbose with specific error messages like "Field 'signature\_date' not found. Available fields: customer\_name, order\_total, signature\_date\_signed" to help Claude fix issues.
+
+### Package dependencies
+
+Skills run in the code execution environment with platform-specific limitations:
+
+- **claude.ai:** Can install packages from npm and PyPI and pull from GitHub repositories
+- **Claude API:** Has no network access and no runtime package installation
+
+List required packages in your SKILL.md and verify they're available in the [code execution tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool).
+
+### Runtime environment
+
+Skills run in a code execution environment with filesystem access, bash commands, and code execution capabilities. For the conceptual explanation of this architecture, see [The Skills architecture](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#the-skills-architecture) in the overview.
+
+**How this affects your authoring:**
+
+**How Claude accesses Skills:**
+
+1. **Metadata pre-loaded:** At startup, the name and description from all Skills' YAML frontmatter are loaded into the system prompt
+2. **Files read on-demand:** Claude uses bash Read tools to access SKILL.md and other files from the filesystem when needed
+3. **Scripts executed efficiently:** Utility scripts can be executed via bash without loading their full contents into context. Only the script's output consumes tokens
+4. **No context penalty for large files:** Reference files, data, or documentation don't consume context tokens until actually read
+- **File paths matter:** Claude navigates your skill directory like a filesystem. Use forward slashes (`reference/guide.md`), not backslashes
+- **Name files descriptively:** Use names that indicate content: `form_validation_rules.md`, not `doc2.md`
+- **Organize for discovery:** Structure directories by domain or feature
+	- Good: `reference/finance.md`, `reference/sales.md`
+		- Bad: `docs/file1.md`, `docs/file2.md`
+- **Bundle comprehensive resources:** Include complete API docs, extensive examples, large datasets; no context penalty until accessed
+- **Prefer scripts for deterministic operations:** Write `validate_form.py` rather than asking Claude to generate validation code
+- **Make execution intent clear:**
+	- "Run `analyze_form.py` to extract fields" (execute)
+		- "See `analyze_form.py` for the extraction algorithm" (read as reference)
+- **Test file access patterns:** Verify Claude can navigate your directory structure by testing with real requests
+
+**Example:**
+
+```
+bigquery-skill/
+├── SKILL.md (overview, points to reference files)
+└── reference/
+    ├── finance.md (revenue metrics)
+    ├── sales.md (pipeline data)
+    └── product.md (usage analytics)
+```
+
+When the user asks about revenue, Claude reads SKILL.md, sees the reference to `reference/finance.md`, and invokes bash to read just that file. The sales.md and product.md files remain on the filesystem, consuming zero context tokens until needed. This filesystem-based model is what enables progressive disclosure. Claude can navigate and selectively load exactly what each task requires.
+
+For complete details on the technical architecture, see [How Skills work](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work) in the Skills overview.
+
+### MCP tool references
+
+If your Skill uses MCP (Model Context Protocol) tools, always use fully qualified tool names to avoid "tool not found" errors.
+
+**Format:** `ServerName:tool_name`
+
+**Example:**
+
+```
+Use the BigQuery:bigquery_schema tool to retrieve table schemas.
+Use the GitHub:create_issue tool to create issues.
+```
+
+Where:
+
+- `BigQuery` and `GitHub` are MCP server names
+- `bigquery_schema` and `create_issue` are the tool names within those servers
+
+Without the server prefix, Claude may fail to locate the tool, especially when multiple MCP servers are available.
+
+### Avoid assuming tools are installed
+
+Don't assume packages are available:
+
+```
+**Bad example: Assumes installation**:
+"Use the pdf library to process the file."
+
+**Good example: Explicit about dependencies**:
+"Install required package: \`pip install pypdf\`
+
+Then use it:
+\`\`\`python
+from pypdf import PdfReader
+reader = PdfReader("file.pdf")
+\`\`\`"
+```
+
+## Technical notes
+
+The SKILL.md frontmatter requires `name` and `description` fields with specific validation rules:
+
+- `name`: Maximum 64 characters, lowercase letters/numbers/hyphens only, no XML tags, no reserved words
+- `description`: Maximum 1024 characters, non-empty, no XML tags
+
+See the [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#skill-structure) for complete structure details.
+
+### Token budgets
+
+Keep SKILL.md body under 500 lines for optimal performance. If your content exceeds this, split it into separate files using the progressive disclosure patterns described earlier. For architectural details, see the [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work).
+
+## Checklist for effective Skills
+
+Before sharing a Skill, verify:
+
+### Core quality
+
+- Description is specific and includes key terms
+- Description includes both what the Skill does and when to use it
+- SKILL.md body is under 500 lines
+- Additional details are in separate files (if needed)
+- No time-sensitive information (or in "old patterns" section)
+- Consistent terminology throughout
+- Examples are concrete, not abstract
+- File references are one level deep
+- Progressive disclosure used appropriately
+- Workflows have clear steps
+
+### Code and scripts
+
+- Scripts solve problems rather than punt to Claude
+- Error handling is explicit and helpful
+- No "voodoo constants" (all values justified)
+- Required packages listed in instructions and verified as available
+- Scripts have clear documentation
+- No Windows-style paths (all forward slashes)
+- Validation/verification steps for critical operations
+- Feedback loops included for quality-critical tasks

--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -3611,7 +3611,7 @@ function toggleTryItOutExpand(opId) {
 // so the matrix stays self-describing.
 var DOMAIN_REGIONS = {
     anypoint: ['us', 'eu1'],
-    platform: ['ca1', 'jp1']
+    platform: ['ca1', 'jp1', 'in1']
 };
 
 function _getDomainKeyFromUrl(url) {
@@ -3792,7 +3792,8 @@ function getServerForApi(apiSlug) {
 var _REGION_LABELS = {
     eu1: 'Europe (eu1)',
     ca1: 'Canada (ca1)',
-    jp1: 'Japan (jp1)'
+    jp1: 'Japan (jp1)',
+    in1: 'India (in1)'
 };
 
 function _regionLabel(r) {

--- a/scripts/portal_generator/templates/partials/auth_panel.html
+++ b/scripts/portal_generator/templates/partials/auth_panel.html
@@ -175,6 +175,7 @@
                     <select id="regionPreset" onchange="onRegionPresetChange()" class="server-select region-preset-select" aria-label="Select region">
                         <option id="regionDefaultOption" value="eu1">Europe (eu1)</option>
                         <option value="jp1">Japan (jp1)</option>
+                        <option value="in1">India (in1)</option>
                         <option value="custom">Custom</option>
                     </select>
                     <input type="text" id="regionCustomInput" class="server-var-input" placeholder="e.g. eu1" style="display:none" aria-label="Custom region">

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -410,6 +410,12 @@ describe('isServerValidForRegion', () => {
         expect(isServerValidForRegion(platformRegional, 'jp1')).toBe(true);
     });
 
+    test('in1: only platform, NOT anypoint regional', () => {
+        expect(isServerValidForRegion(anypointGlobal, 'in1')).toBe(false);
+        expect(isServerValidForRegion(anypointRegional, 'in1')).toBe(false);
+        expect(isServerValidForRegion(platformRegional, 'in1')).toBe(true);
+    });
+
     test('legacy hardcoded eu1 server is valid for eu1', () => {
         expect(isServerValidForRegion(anypointLegacyEu, 'eu1')).toBe(true);
         expect(isServerValidForRegion(anypointLegacyEu, 'ca1')).toBe(false);
@@ -451,6 +457,10 @@ describe('filterServersForRegion', () => {
         expect(filterServersForRegion(all, 'jp1')).toEqual([platformRegional]);
     });
 
+    test('in1 keeps only platform regional', () => {
+        expect(filterServersForRegion(all, 'in1')).toEqual([platformRegional]);
+    });
+
     test('null region (us) returns all', () => {
         expect(filterServersForRegion(all, null)).toEqual(all);
     });
@@ -470,8 +480,8 @@ describe('getValidRegionsForServerType', () => {
         expect(getValidRegionsForServerType('eu')).toEqual(['eu1']);
     });
 
-    test('platform type → platform regions including jp1', () => {
-        expect(getValidRegionsForServerType('platform')).toEqual(['ca1', 'jp1']);
+    test('platform type → platform regions including jp1 and in1', () => {
+        expect(getValidRegionsForServerType('platform')).toEqual(['ca1', 'jp1', 'in1']);
     });
 
     test('us type → empty (no region needed)', () => {


### PR DESCRIPTION
## Summary

- Add `in1` to `DOMAIN_REGIONS.platform` matrix in `portal.js` — filters server dropdown correctly for India region
- Add `India (in1)` label to `_REGION_LABELS` map so the dynamic dropdown shows the full label
- Add `<option value="in1">India (in1)</option>` to `auth_panel.html` regionPreset dropdown
- Add 3 tests covering `isServerValidForRegion`, `filterServersForRegion`, and `getValidRegionsForServerType` for `in1`

Follows the same pattern used for `jp1` (PR #131). No spec changes needed — region logic is portal-only.

## Test plan

- [ ] 224 Jest tests pass (`npx jest tests/portal.test.js`)
- [ ] Auth panel dropdown shows `Canada (ca1)`, `Japan (jp1)`, `India (in1)` when `Regional (platform.mulesoft.com)` is selected
- [ ] Other server types (`anypoint`, `eu`) do not show `in1`