### PR TITLE
feat: add India (in1) region to portal auth panel

### DIFF
--- a/scripts/portal_generator/assets/portal.js
+++ b/scripts/portal_generator/assets/portal.js
@@ -3611,7 +3611,7 @@ function toggleTryItOutExpand(opId) {
 // so the matrix stays self-describing.
 var DOMAIN_REGIONS = {
     anypoint: ['us', 'eu1'],
-    platform: ['ca1', 'jp1']
+    platform: ['ca1', 'jp1', 'in1']
 };
 
 function _getDomainKeyFromUrl(url) {
@@ -3792,7 +3792,8 @@ function getServerForApi(apiSlug) {
 var _REGION_LABELS = {
     eu1: 'Europe (eu1)',
     ca1: 'Canada (ca1)',
-    jp1: 'Japan (jp1)'
+    jp1: 'Japan (jp1)',
+    in1: 'India (in1)'
 };
 
 function _regionLabel(r) {

--- a/scripts/portal_generator/templates/partials/auth_panel.html
+++ b/scripts/portal_generator/templates/partials/auth_panel.html
@@ -175,6 +175,7 @@
                     <select id="regionPreset" onchange="onRegionPresetChange()" class="server-select region-preset-select" aria-label="Select region">
                         <option id="regionDefaultOption" value="eu1">Europe (eu1)</option>
                         <option value="jp1">Japan (jp1)</option>
+                        <option value="in1">India (in1)</option>
                         <option value="custom">Custom</option>
                     </select>
                     <input type="text" id="regionCustomInput" class="server-var-input" placeholder="e.g. eu1" style="display:none" aria-label="Custom region">

--- a/scripts/tests/portal.test.js
+++ b/scripts/tests/portal.test.js
@@ -410,6 +410,12 @@ describe('isServerValidForRegion', () => {
         expect(isServerValidForRegion(platformRegional, 'jp1')).toBe(true);
     });
 
+    test('in1: only platform, NOT anypoint regional', () => {
+        expect(isServerValidForRegion(anypointGlobal, 'in1')).toBe(false);
+        expect(isServerValidForRegion(anypointRegional, 'in1')).toBe(false);
+        expect(isServerValidForRegion(platformRegional, 'in1')).toBe(true);
+    });
+
     test('legacy hardcoded eu1 server is valid for eu1', () => {
         expect(isServerValidForRegion(anypointLegacyEu, 'eu1')).toBe(true);
         expect(isServerValidForRegion(anypointLegacyEu, 'ca1')).toBe(false);
@@ -451,6 +457,10 @@ describe('filterServersForRegion', () => {
         expect(filterServersForRegion(all, 'jp1')).toEqual([platformRegional]);
     });
 
+    test('in1 keeps only platform regional', () => {
+        expect(filterServersForRegion(all, 'in1')).toEqual([platformRegional]);
+    });
+
     test('null region (us) returns all', () => {
         expect(filterServersForRegion(all, null)).toEqual(all);
     });
@@ -470,8 +480,8 @@ describe('getValidRegionsForServerType', () => {
         expect(getValidRegionsForServerType('eu')).toEqual(['eu1']);
     });
 
-    test('platform type → platform regions including jp1', () => {
-        expect(getValidRegionsForServerType('platform')).toEqual(['ca1', 'jp1']);
+    test('platform type → platform regions including jp1 and in1', () => {
+        expect(getValidRegionsForServerType('platform')).toEqual(['ca1', 'jp1', 'in1']);
     });
 
     test('us type → empty (no region needed)', () => {


### PR DESCRIPTION
## Summary

- Add `in1` to `DOMAIN_REGIONS.platform` matrix in `portal.js` — filters server dropdown correctly for India region
- Add `India (in1)` label to `_REGION_LABELS` map so the dynamic dropdown shows the full label
- Add `<option value="in1">India (in1)</option>` to `auth_panel.html` regionPreset dropdown
- Add 3 tests covering `isServerValidForRegion`, `filterServersForRegion`, and `getValidRegionsForServerType` for `in1`

Follows the same pattern used for `jp1` (PR #131). No spec changes needed — region logic is portal-only.

## Test plan

- [ ] 224 Jest tests pass (`npx jest tests/portal.test.js`)
- [ ] Auth panel dropdown shows `Canada (ca1)`, `Japan (jp1)`, `India (in1)` when `Regional (platform.mulesoft.com)` is selected
- [ ] Other server types (`anypoint`, `eu`) do not show `in1`