### PR TITLE
fix: error page Browse all services link on nested URLs

### DIFF
--- a/scripts/portal_generator/templates/404.html
+++ b/scripts/portal_generator/templates/404.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "partials/error_page.html" import error_page %}
+{% from "partials/error_page.html" import error_page with context %}
 
 {% block title %}Page not found — Anypoint Platform APIs{% endblock %}
 

--- a/scripts/portal_generator/templates/500.html
+++ b/scripts/portal_generator/templates/500.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "partials/error_page.html" import error_page %}
+{% from "partials/error_page.html" import error_page with context %}
 
 {% block title %}Something went wrong — Anypoint Platform APIs{% endblock %}
 

--- a/scripts/portal_generator/templates/error.html
+++ b/scripts/portal_generator/templates/error.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "partials/error_page.html" import error_page %}
+{% from "partials/error_page.html" import error_page with context %}
 
 {% block title %}Error — Anypoint Platform APIs{% endblock %}
 

--- a/scripts/portal_generator/templates/partials/error_page.html
+++ b/scripts/portal_generator/templates/partials/error_page.html
@@ -33,7 +33,7 @@
             </svg>
             Go back
         </button>
-        <a href="{{ base_url|default('.') }}/index.html" class="btn-send" style="text-decoration: none;">
+        <a href="{{ base_url|default('') }}/" class="btn-send" style="text-decoration: none;">
             Browse all services
         </a>
         {{ extra_actions|safe }}

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -1226,8 +1226,10 @@ class TestErrorPages:
         )
 
     def test_404_has_go_home_link(self):
-        links = self.soup.find_all('a')
-        assert any('index.html' in (l.get('href', '')) for l in links)
+        links = self.soup.find_all('a', class_='btn-send')
+        assert links, "404 page missing Browse all services link"
+        href = links[0].get('href', '')
+        assert href.endswith('/'), f"Browse all services link should point to site root, got {href!r}"
 
     def test_404_has_main_element(self):
         assert self.soup.find('main') is not None


### PR DESCRIPTION
## Summary

- The `error_page` macro renders `Browse all services` as `{{ base_url|default('.') }}/index.html`, but the three consuming templates (`404.html`, `500.html`, `error.html`) imported the macro **without `with context`**. Jinja macros don't inherit template variables unless imported with context, so `base_url` was undefined inside the macro and the `|default('.')` fallback kicked in.
- The rendered link on the deployed portal was `<a href="./index.html">`. From a nested path like `https://dev-portal.mulesoft.com/apis/access-managemen`, `./index.html` resolves to `/apis/index.html` — another 404. Reported by Julieta De Simone.
- Fix adds `with context` to the three macro imports so `base_url` propagates. Verified render now emits the absolute URL: `href="https://dev-portal.mulesoft.com/index.html"`.

## Test plan

- [x] `pytest tests/test_smoke.py::TestErrorPages` — 11/11 pass
- [x] Pre-push (full `test-portal` + `validate-all-governed`) — pass
- [ ] Reviewer: visit any 404 URL after deploy, click **Browse all services**, land on `/`