### PR TITLE
@W-23431001: rename operationIds and add summaries in flex-gateway-ma…

### DIFF
--- a/apis/flex-gateway-manager/api.yaml
+++ b/apis/flex-gateway-manager/api.yaml
@@ -21,7 +21,8 @@ security:
 paths:
   /organizations/{organizationId}/usage/managed-gateways:
     get:
-      operationId: getOrganizationsByOrganizationidUsageManagedGateways
+      summary: Get managed gateway usage
+      operationId: getManagedGatewayUsage
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - name: size
@@ -66,7 +67,8 @@ paths:
       description: Retrieves a managed gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/runtime-configuration:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRuntimeConfiguration
+      summary: Get gateway runtime configuration
+      operationId: getGatewayRuntimeConfig
       description: Get the runtime configuration of a Managed or Self-Managed Omni Gateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -93,7 +95,8 @@ paths:
                 id: string
                 type: string
     put:
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRuntimeConfiguration
+      summary: Update gateway runtime configuration
+      operationId: updateGatewayRuntimeConfig
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -128,7 +131,8 @@ paths:
       description: Replaces a runtime configuration.
   /organizations/{organizationId}/environments/{environmentId}/gateways:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+      summary: List gateways
+      operationId: listGateways
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -187,7 +191,8 @@ paths:
                 type: string
       description: Retrieves a gateways.
     post:
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+      summary: Create gateway
+      operationId: createGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -220,7 +225,8 @@ paths:
       description: Creates a gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Get gateway by ID
+      operationId: getGatewayById
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -246,7 +252,8 @@ paths:
                 type: string
       description: Retrieves a gateways.
     put:
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Update gateway
+      operationId: updateGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -279,7 +286,8 @@ paths:
                 type: string
       description: Replaces a gateways.
     delete:
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Delete gateway
+      operationId: deleteGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -300,7 +308,8 @@ paths:
       description: Deletes a gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/registration:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRegistration
+      summary: Get gateway registration
+      operationId: getGatewayRegistration
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -332,7 +341,8 @@ paths:
       description: Retrieves a registration.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/status:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidStatus
+      summary: Get gateway status
+      operationId: getGatewayStatus
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -372,7 +382,8 @@ paths:
       description: Retrieves a status.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/desiredstatus:
     patch:
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidDesiredstatus
+      summary: Update gateway desired status
+      operationId: updateGatewayDesiredStatus
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -486,7 +497,7 @@ components:
         format: uuid
       x-origin:
       - api: urn:api:flex-gateway-manager
-        operation: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+        operation: listGateways
         description: GET `/organizations/{organizationId}/environments/{environmentId}/gateways` in this API; use `id` values as `gatewayId`.
         values: $.id
         labels: $.name


### PR DESCRIPTION
…nager

Renames 11 path-derived operationIds (52-101 chars each, all violating the id-max-length and id-no-path-repetition rules) to short intent-based names (≤26 chars), and adds imperative summaries (≤60 chars) to every operation.

Also updates the internal x-origin reference in
`components.parameters.XOrigin_targetGatewayId_Path` to point at the renamed `listGateways` operation.

No cross-references found in `skills/`, `mcps/`, or other `apis/*/api.yaml` x-origin blocks, so the rename is safe within this repo. External SDK consumers may need to regenerate.