### PR TITLE
@W-23431001: rename operationIds and add summaries in anypoint-mq-stats

### DIFF
--- a/apis/anypoint-mq-stats/api.yaml
+++ b/apis/anypoint-mq-stats/api.yaml
@@ -148,7 +148,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationid
+      summary: Get organization usage metrics
+      operationId: getOrganizationUsageMetrics
   /organizations/{organizationId}/environments:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -271,7 +272,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentid
+      summary: Get environment usage metrics
+      operationId: getEnvironmentUsageMetrics
   /organizations/{organizationId}/environments/{environmentId}/regions:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -346,7 +348,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidQueues
+      summary: List realtime queue stats
+      operationId: listQueueRealtimeStats
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/queues/{queueId}:
     description: Entity representing a queue
     get:
@@ -493,7 +496,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidQueuesByQueueid
+      summary: Get historic queue stats
+      operationId: getQueueHistoricStats
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/exchanges:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -604,7 +608,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidExchangesByExchangeid
+      summary: Get historic exchange stats
+      operationId: getExchangeHistoricStats
 components:
   securitySchemes:
     oauth_2_0:


### PR DESCRIPTION
Renames:
- getOrganizationsByOrganizationid -> getOrganizationUsageMetrics
- getOrganizationsByOrganizationidEnvironmentsByEnvironmentid -> getEnvironmentUsageMetrics
- ...RegionsByRegionidExchangesByExchangeid -> getExchangeHistoricStats
- ...RegionsByRegionidQueues -> listQueueRealtimeStats
- ...RegionsByRegionidQueuesByQueueid -> getQueueHistoricStats

Summaries added to all 5 operations.