### PR TITLE
@W-23431001: rename operationIds and add summaries in tokenization-cr…

### DIFF
--- a/apis/tokenization-creation-and-mgmt/api.yaml
+++ b/apis/tokenization-creation-and-mgmt/api.yaml
@@ -149,7 +149,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createFormats
+      summary: Create tokenization format
+      operationId: createFormat
     get:
       description: Get a list of formats.
       parameters:
@@ -285,6 +286,7 @@ paths:
                 - code: 0
                   field: string
                   message: string
+      summary: List tokenization formats
       operationId: getFormats
   /formats/{formatId}:
     description: Get an entity representing a format
@@ -388,7 +390,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getFormatsByFormatid
+      summary: Get tokenization format
+      operationId: getFormatById
     put:
       parameters:
       - name: formatId
@@ -496,7 +499,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateFormatsByFormatid
+      summary: Update tokenization format
+      operationId: updateFormatById
       description: Replaces a formats.
     delete:
       parameters:
@@ -566,7 +570,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteFormatsByFormatid
+      summary: Delete tokenization format
+      operationId: deleteFormatById
       description: Deletes a formats.
   /services:
     description: The collection of services
@@ -646,6 +651,7 @@ paths:
                 - code: 0
                   field: string
                   message: string
+      summary: List tokenization services
       operationId: getServices
   /environments/{envId}:
     parameters:
@@ -810,7 +816,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createEnvironmentsByEnvidServices
+      summary: Create tokenization service
+      operationId: createService
     get:
       description: Get a list of services.
       parameters:
@@ -1033,7 +1040,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidServices
+      summary: List services in environment
+      operationId: getEnvironmentServices
   /environments/{envId}/services/{serviceId}:
     description: Get an entity representing a service
     get:
@@ -1177,7 +1185,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidServicesByServiceid
+      summary: Get service by ID
+      operationId: getServiceById
     patch:
       description: To perform rekey of a VDP table associated with a service.
       parameters:
@@ -1311,7 +1320,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: patchEnvironmentsByEnvidServicesByServiceid
+      summary: Rekey service VDP table
+      operationId: rekeyService
     put:
       parameters:
       - name: desiredStatus
@@ -1505,7 +1515,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateEnvironmentsByEnvidServicesByServiceid
+      summary: Update tokenization service
+      operationId: updateService
       description: Replaces a services.
     delete:
       parameters:
@@ -1576,7 +1587,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteEnvironmentsByEnvidServicesByServiceid
+      summary: Delete tokenization service
+      operationId: deleteService
       description: Deletes a services.
   /environments/{envId}/deployments:
     get:
@@ -1722,7 +1734,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeployments
+      summary: List tokenization deployments
+      operationId: listDeployments
   /environments/{envId}/deployments/{deploymentId}:
     description: 'Access detailed operations of a particular deployment.
 
@@ -1847,7 +1860,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeploymentsByDeploymentid
+      summary: Get deployment by ID
+      operationId: getDeploymentById
   /environments/{envId}/deployments/{deploymentId}/specs:
     description: Get an entity representing a spec
     get:
@@ -1954,7 +1968,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeploymentsByDeploymentidSpecs
+      summary: List deployment specs
+      operationId: listDeploymentSpecs
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
…eation-and-mgmt

Renames (13 operations):
- Services: getEnvironmentServices, createService, getServiceById, updateService, deleteService, rekeyService
- Deployments: listDeployments, getDeploymentById, listDeploymentSpecs
- Formats: createFormat, getFormatById, updateFormatById, deleteFormatById

Summaries added to all 15 operations. getServices and getFormats kept as-is.