### PR TITLE
@W-23431001: rename operationIds and add summaries in amc-application…

### DIFF
--- a/apis/amc-application-manager/api.yaml
+++ b/apis/amc-application-manager/api.yaml
@@ -97,7 +97,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlowname
+      summary: Update scheduler configuration
+      operationId: updateScheduler
     delete:
       tags:
       - Schedulers
@@ -152,7 +153,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlowname
+      summary: Reset scheduler to default
+      operationId: resetScheduler
   /organizations/{organizationId}/environments/{environmentId}/deployments:
     get:
       tags:
@@ -193,7 +195,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeployments
+      summary: List deployments
+      operationId: listDeployments
     post:
       tags:
       - Deployments
@@ -252,7 +255,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeployments
+      summary: Deploy a new application
+      operationId: createDeployment
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/schedulers/{flowName}/run:
     post:
       tags:
@@ -307,12 +311,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlownameRun
+      summary: Run scheduler immediately
+      operationId: runScheduler
   /organizations/{organizationId}/environments/{environmentId}/alerts:
     get:
       tags:
       - Alerts
-      summary: Retrieves Cloudhub 2.0 alerts
+      summary: List CloudHub 2.0 alerts
       parameters:
       - name: Authorization
         in: header
@@ -353,12 +358,12 @@ paths:
                 data:
                 - id: string
                   type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlerts
+      operationId: listAlerts
       description: Retrieves Cloudhub 2.0 alerts
     post:
       tags:
       - Alerts
-      summary: Creates a Cloudhub 2.0 alert
+      summary: Create CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -430,7 +435,7 @@ paths:
                 createdAt: 0
                 isSystem: true
                 productName: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlerts
+      operationId: createAlert
       description: Creates a Cloudhub 2.0 alert
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}:
     get:
@@ -514,7 +519,8 @@ paths:
                 - id: string
                   type: string
                 lastSuccessfulVersion: 0ef171b6-aad1-459b-8720-10c405b05ed1
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Get deployment by ID
+      operationId: getDeploymentById
     delete:
       tags:
       - Deployments
@@ -554,7 +560,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Delete deployment
+      operationId: deleteDeployment
     patch:
       tags:
       - Deployments
@@ -686,7 +693,8 @@ paths:
                 - id: string
                   type: string
                 lastSuccessfulVersion: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Update deployment
+      operationId: patchDeployment
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/schedulers:
     get:
       tags:
@@ -736,7 +744,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulers
+      summary: List deployment schedulers
+      operationId: listSchedulers
     patch:
       tags:
       - Schedulers
@@ -794,12 +803,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulers
+      summary: Enable or disable schedulers
+      operationId: patchSchedulers
   /organizations/{organizationId}/environments/{environmentId}/alerts/{alertId}:
     get:
       tags:
       - Alerts
-      summary: Retrieves a single Cloudhub 2.0 alert
+      summary: Get CloudHub 2.0 alert by ID
       parameters:
       - name: Authorization
         in: header
@@ -878,12 +888,12 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: getAlertById
       description: Retrieves a single Cloudhub 2.0 alert
     delete:
       tags:
       - Alerts
-      summary: Deletes a Cloudhub 2.0 alert
+      summary: Delete CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -932,12 +942,12 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: deleteAlert
       description: Deletes a Cloudhub 2.0 alert
     patch:
       tags:
       - Alerts
-      summary: Updates a Cloudhub 2.0 alert
+      summary: Update CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -1038,7 +1048,7 @@ paths:
                 createdAt: 0
                 isSystem: true
                 productName: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: patchAlert
       description: Updates a Cloudhub 2.0 alert
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs:
     get:
@@ -1083,12 +1093,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecs
+      summary: List deployment version specs
+      operationId: listDeploymentSpecs
   /organizations/{organizationId}/environments/{environmentId}/alerts/{alertId}/history:
     get:
       tags:
       - Alerts
-      summary: Retrieves a Cloudhub 2.0 alert history record
+      summary: Get CloudHub 2.0 alert history
       parameters:
       - name: Authorization
         in: header
@@ -1147,7 +1158,7 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertidHistory
+      operationId: getAlertHistory
       description: Retrieves a Cloudhub 2.0 alert history record
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/replicas/{replicaId}/diagnostics:
     post:
@@ -1182,12 +1193,13 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidReplicasByReplicaidDiagnostics
+      summary: Trigger replica thread dump diagnostic
+      operationId: triggerReplicaDiagnostic
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs/{specificationId}/logs:
     get:
       tags:
       - Logs
-      summary: Fetch logs from the Log Aggregator V2 API.
+      summary: Fetch deployment logs
       parameters:
       - $ref: '#/components/parameters/XOrigin_anotherContextOrganizationId_Path'
       - $ref: '#/components/parameters/XOrigin_anotherContextEnvironmentId_Path'
@@ -1227,13 +1239,13 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecsBySpecificationidLogs
+      operationId: getDeploymentLogs
       description: Fetch logs from the Log Aggregator V2 API.
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs/{specificationId}/logs/file:
     get:
       tags:
       - Logs
-      summary: Download log entries matching the search as text attachment, without pagination.
+      summary: Download log entries as text
       parameters:
       - $ref: '#/components/parameters/XOrigin_anotherContextOrganizationId_Path'
       - $ref: '#/components/parameters/XOrigin_anotherContextEnvironmentId_Path'
@@ -1273,7 +1285,7 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecsBySpecificationidLogsFile
+      operationId: downloadLogs
       description: Download log entries matching the search as text attachment, without pagination.
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/diagnostics:
     get:
@@ -1311,7 +1323,8 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidDiagnostics
+      summary: List deployment diagnostics
+      operationId: listDeploymentDiagnostics
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/diagnostics/{actionId}/file:
     get:
       tags:
@@ -1357,7 +1370,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/StreamingResponseBody'
               example: {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidDiagnosticsByActionidFile
+      summary: Get diagnostic thread dump report
+      operationId: getDiagnosticReport
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/upgradedata/trafficswitching:
     put:
       tags:
@@ -1415,7 +1429,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidUpgradedataTrafficswitching
+      summary: Update traffic switching percentage
+      operationId: updateTrafficSwitching
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
…-manager

Renames (23 operations):
- Alerts: listAlerts, createAlert, getAlertById, patchAlert, deleteAlert, getAlertHistory
- Deployments: listDeployments, createDeployment, getDeploymentById, patchDeployment, deleteDeployment, listDeploymentSpecs, getDeploymentLogs, downloadLogs
- Schedulers: listSchedulers, patchSchedulers, updateScheduler, resetScheduler, runScheduler
- Diagnostics: listDeploymentDiagnostics, triggerReplicaDiagnostic, getDiagnosticReport
- Traffic switching: updateTrafficSwitching