### PR TITLE
@W-23431001: rename operationIds and add summaries in api-designer-ex…

### DIFF
--- a/apis/api-designer-experience/api.yaml
+++ b/apis/api-designer-experience/api.yaml
@@ -25,6 +25,7 @@ paths:
       responses:
         '200':
           description: Successful operation.
+      summary: Check service health
       operationId: getPing
   /status:
     get:
@@ -32,6 +33,7 @@ paths:
       responses:
         '200':
           description: Successful operation.
+      summary: Get service status
       operationId: getStatus
   /projects:
     post:
@@ -85,7 +87,8 @@ paths:
           description: Authorization failed
         '409':
           description: Project {type}-{name} already exists
-      operationId: createProjects
+      summary: Create project
+      operationId: createProject
     get:
       description: Gets all the projects that the user has access
       parameters:
@@ -124,7 +127,8 @@ paths:
                 type: string
         '401':
           description: Authorization failed
-      operationId: getProjects
+      summary: List projects the user can access
+      operationId: listProjects
   /projects/import:
     post:
       description: Creates a project from a zip file containing files
@@ -179,7 +183,8 @@ paths:
           description: Authorization failed
         '409':
           description: Project {type}-{name} already exists
-      operationId: createProjectsImport
+      summary: Import project from zip file
+      operationId: importProject
   /projects/{projectId}:
     get:
       description: Get project data
@@ -224,7 +229,8 @@ paths:
                 createdDate: 0
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectid
+      summary: Get project by ID
+      operationId: getProjectById
     patch:
       description: 'Patches project metadata.
 
@@ -279,7 +285,8 @@ paths:
                 createdDate: 0
         '401':
           description: Authorization failed
-      operationId: patchProjectsByProjectid
+      summary: Patch project metadata
+      operationId: patchProject
     delete:
       description: Deletes the given project
       parameters:
@@ -309,7 +316,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '401':
           description: Authorization failed
-      operationId: deleteProjectsByProjectid
+      summary: Delete project
+      operationId: deleteProject
   /projects/{projectId}/branches:
     post:
       description: Creates new branch
@@ -381,7 +389,8 @@ paths:
                 commitId: 734713bc0
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranches
+      summary: Create branch
+      operationId: createBranch
     get:
       description: List branches
       parameters:
@@ -421,7 +430,8 @@ paths:
                 type: string
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidBranches
+      summary: List branches
+      operationId: listBranches
   /projects/{projectId}/branches/{branch}:
     delete:
       description: Deletes a branch
@@ -458,7 +468,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '401':
           description: Authorization failed
-      operationId: deleteProjectsByProjectidBranchesByBranch
+      summary: Delete branch
+      operationId: deleteBranch
   /projects/{projectId}/branches/{branch}/open:
     post:
       description: List project files. If user's workingDir does not exists, it creates one.
@@ -511,7 +522,8 @@ paths:
                 type: FILE
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchOpen
+      summary: Open branch and list project files
+      operationId: openBranch
   /projects/{projectId}/branches/{branch}/clean:
     post:
       description: cleans uncommited files from users workingDir
@@ -548,7 +560,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchClean
+      summary: Clean uncommitted files from working dir
+      operationId: cleanBranch
   /projects/{projectId}/branches/{branch}/status:
     get:
       description: list WorkingDir status
@@ -585,7 +598,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidBranchesByBranchStatus
+      summary: Get branch working directory status
+      operationId: getBranchStatus
   /projects/{projectId}/branches/{branch}/save:
     post:
       description: save listed files (save and save All)
@@ -637,7 +651,8 @@ paths:
           description: Authorization failed
         '409':
           description: Could not save changes
-      operationId: createProjectsByProjectidBranchesByBranchSave
+      summary: Save branch files
+      operationId: saveBranchFiles
   /projects/{projectId}/branches/{branch}/save/v2:
     post:
       description: 'Save listed files (save and save All).
@@ -700,7 +715,8 @@ paths:
           description: Authorization failed
         '409':
           description: Could not save changes
-      operationId: createProjectsByProjectidBranchesByBranchSaveV2
+      summary: Save branch files (v2 multipart)
+      operationId: saveBranchFilesV2
   /projects/{projectId}/branches/{branch}/files:
     get:
       description: Gets a list of the structure of the file system (open project)
@@ -743,7 +759,8 @@ paths:
               example: *id001
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidBranchesByBranchFiles
+      summary: List branch files
+      operationId: listBranchFiles
   /projects/{projectId}/branches/{branch}/files/v2/{filePath}:
     get:
       description: Returns the given file (getFile) with content-type according to file's content
@@ -790,7 +807,8 @@ paths:
               schema: {}
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidBranchesByBranchFilesV2ByFilepath
+      summary: Get branch file content (v2)
+      operationId: getBranchFileV2
   /projects/{projectId}/branches/{branch}/files/{filePath}:
     description: Operations over a specific file path
     get:
@@ -838,7 +856,8 @@ paths:
               schema: {}
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidBranchesByBranchFilesByFilepath
+      summary: Get branch file as JSON
+      operationId: getBranchFile
     delete:
       description: Deletes the given file or folder and commit changes (deleteFile)
       parameters:
@@ -880,7 +899,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '401':
           description: Authorization failed
-      operationId: deleteProjectsByProjectidBranchesByBranchFilesByFilepath
+      summary: Delete branch file or folder
+      operationId: deleteBranchFile
   /projects/{projectId}/branches/{branch}/files/{filePath}/move:
     post:
       description: renames the file or folder (move or rename)
@@ -936,7 +956,8 @@ paths:
           description: File not found
         '409':
           description: The file or folder already exists
-      operationId: createProjectsByProjectidBranchesByBranchFilesByFilepathMove
+      summary: Move or rename branch file
+      operationId: moveBranchFile
   /projects/{projectId}/branches/{branch}/acquireLock:
     post:
       description: Acquire lock for given project
@@ -984,7 +1005,8 @@ paths:
                 name: demo-username
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchAcquirelock
+      summary: Acquire branch lock
+      operationId: acquireBranchLock
   /projects/{projectId}/branches/{branch}/releaseLock:
     post:
       description: Release lock for given project
@@ -1024,7 +1046,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchReleaselock
+      summary: Release branch lock
+      operationId: releaseBranchLock
   /projects/{projectId}/branches/{branch}/publish/platform:
     post:
       description: Publish project to Api Platform
@@ -1064,7 +1087,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchPublishPlatform
+      summary: Publish branch to API Platform
+      operationId: publishBranchToPlatform
   /projects/{projectId}/branches/{branch}/publish/exchange:
     post:
       description: Publish project to Exchange. As a result, an Exchange asset is created.
@@ -1125,7 +1149,8 @@ paths:
                 metadata: {}
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchPublishExchange
+      summary: Publish branch to Exchange
+      operationId: publishBranchToExchange
   /projects/{projectId}/branches/{branch}/exchange/dependencies:
     put:
       description: Add new dependencies in exchange.json
@@ -1181,7 +1206,8 @@ paths:
               example: *id001
         '401':
           description: Authorization failed
-      operationId: updateProjectsByProjectidBranchesByBranchExchangeDependencies
+      summary: Add Exchange dependencies
+      operationId: addExchangeDependencies
     post:
       description: Updates exchange.json file, with given dependencies
       parameters:
@@ -1245,7 +1271,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidBranchesByBranchExchangeDependencies
+      summary: Update Exchange dependencies
+      operationId: updateExchangeDependencies
     delete:
       description: Removes dependencies in exchange.json
       parameters:
@@ -1294,7 +1321,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '401':
           description: Authorization failed
-      operationId: deleteProjectsByProjectidBranchesByBranchExchangeDependencies
+      summary: Remove Exchange dependencies
+      operationId: removeExchangeDependencies
   /projects/{projectId}/api/{name}:
     get:
       description: Get api data, from Api Platform, for given {name}
@@ -1309,7 +1337,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getProjectsByProjectidApiByName
+      summary: Get project API from platform
+      operationId: getProjectApi
   /projects/{projectId}/api/{name}/{version}:
     post:
       description: Publish project to Api Platform (Deprecated)
@@ -1330,7 +1359,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: createProjectsByProjectidApiByNameByVersion
+      summary: Publish project to API Platform (deprecated)
+      operationId: publishProjectApiVersion
   /projects/{projectId}/sync/github:
     description: Endpoint to manage project's Github sync
     post:
@@ -1347,7 +1377,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: createProjectsByProjectidSyncGithub
+      summary: Sync project with Github repository
+      operationId: syncProjectGithub
     delete:
       description: Remove sync with Github repository
       parameters:
@@ -1355,7 +1386,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteProjectsByProjectidSyncGithub
+      summary: Remove Github repository sync
+      operationId: removeGithubSync
   /projects/{projectId}/access/permissions:
     get:
       description: Gets permissions for a project
@@ -1396,7 +1428,8 @@ paths:
                 canRename: true
         '401':
           description: Authorization failed
-      operationId: getProjectsByProjectidAccessPermissions
+      summary: Get project permissions
+      operationId: getProjectPermissions
   /projects/{projectId}/access/permissions/share:
     post:
       description: Grants or Revokes permissions on a [user | role] matrix for a project.
@@ -1448,7 +1481,8 @@ paths:
                   result: string
         '401':
           description: Authorization failed
-      operationId: createProjectsByProjectidAccessPermissionsShare
+      summary: Share or revoke project permissions
+      operationId: shareProjectPermissions
   /exchange/graphql:
     post:
       description: Executes GQL queries against exchange GraphQL service
@@ -1474,7 +1508,8 @@ paths:
           description: Successful operation.
         '401':
           description: Authorization failed
-      operationId: createExchangeGraphql
+      summary: Execute Exchange GraphQL query
+      operationId: executeExchangeGraphql
 components:
   securitySchemes:
     bearerAuth:
@@ -2022,7 +2057,7 @@ components:
         pattern: ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$
       x-origin:
       - api: urn:api:api-designer-experience
-        operation: getProjects
+        operation: listProjects
         description: GET `/projects` in this API; use `[].id` values as `projectId`.
         values: $[*].id
         labels: $[*].name


### PR DESCRIPTION
…perience

Renames (33 operations):
- Projects: listProjects, createProject, importProject, getProjectById, patchProject, deleteProject, syncProjectGithub, removeGithubSync, getProjectPermissions, shareProjectPermissions, getProjectApi, publishProjectApiVersion
- Branches: listBranches, createBranch, deleteBranch, openBranch, acquireBranchLock, releaseBranchLock, cleanBranch, getBranchStatus
- Branch files: listBranchFiles, getBranchFile, getBranchFileV2, deleteBranchFile, moveBranchFile, saveBranchFiles, saveBranchFilesV2
- Exchange: publishBranchToExchange, publishBranchToPlatform, addExchangeDependencies, updateExchangeDependencies, removeExchangeDependencies, executeExchangeGraphql

Also patched 1 internal x-origin ref (projectId path parameter).