### PR TITLE
@W-23431001: cloudhub-20 operationId + summary cleanup

### DIFF
--- a/apis/cloudhub-20/api.yaml
+++ b/apis/cloudhub-20/api.yaml
@@ -119,7 +119,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespaces
+      summary: List Private Spaces
+      operationId: listPrivateSpaces
     post:
       description: create a Private Space
       parameters:
@@ -229,7 +230,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespaces
+      summary: Create a Private Space
+      operationId: createPrivateSpace
   /organizations/{organizationId}/privatespaces/supportedVpnConfigs:
     get:
       description: get supported vpn configs
@@ -238,7 +240,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesSupportedvpnconfigs
+      summary: List supported VPN configurations
+      operationId: listSupportedVpnConfigs
   /organizations/{organizationId}/privatespaces/monthlypatchwindow:
     get:
       description: get the latest upcoming monthly patch window schedule
@@ -259,7 +262,8 @@ paths:
                 sandboxEndDate: &id006 2024-03-22 23:59:59.999000+00:00
                 productionStartDate: &id007 2024-03-23 00:00:00+00:00
                 productionEndDate: &id008 2024-03-24 23:59:59.999000+00:00
-      operationId: getOrganizationsByOrganizationidPrivatespacesMonthlypatchwindow
+      summary: Get monthly patch window schedule
+      operationId: getMonthlyPatchWindow
   /organizations/{organizationId}/privatespaces/{privateSpaceId}:
     description: Get an entity representing a privatespace
     delete:
@@ -270,7 +274,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Delete a Private Space
+      operationId: deletePrivateSpace
     get:
       description: get the Private Space
       parameters:
@@ -330,7 +335,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Get a Private Space
+      operationId: getPrivateSpace
     patch:
       description: Update existing Private Space
       parameters:
@@ -391,7 +397,8 @@ paths:
                         filters: []
                       protocol: https-redirect
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Update a Private Space
+      operationId: updatePrivateSpace
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/associations:
     post:
       description: create associations for Private space with business groups and environments
@@ -423,7 +430,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/Association'
               example: *id001
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociations
+      summary: Create Private Space associations
+      operationId: createAssociations
     get:
       description: get all associations of a private space.
       parameters:
@@ -447,7 +455,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/Association'
               example: *id002
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociations
+      summary: List Private Space associations
+      operationId: listAssociations
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/associations/{associationId}:
     get:
       description: get a specific associations of a private space.
@@ -472,7 +481,8 @@ paths:
                 id: d282e462-07af-4146-b7d8-8bd7e6b18d83
                 environmentId: 2ea3eff9-569a-4495-b7b6-1e28c6440aeb
                 organizationId: 1ffdaa42-4702-4747-aeb9-aecab0f5ac1b
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociationsByAssociationid
+      summary: Get a Private Space association
+      operationId: getAssociation
     delete:
       description: delete an association
       parameters:
@@ -487,7 +497,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociationsByAssociationid
+      summary: Delete a Private Space association
+      operationId: deleteAssociation
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/ports:
     get:
       description: Get the next set of available ports.
@@ -522,7 +533,8 @@ paths:
                 - 0
         '409':
           description: All the available ports for the space are in use.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidPorts
+      summary: Get available ports
+      operationId: getAvailablePorts
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/iamroles:
     get:
       description: get the IAM roles associated with the space.
@@ -543,7 +555,8 @@ paths:
                 organizationId: string
                 spaceId: string
                 message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidIamroles
+      summary: Get IAM roles for the Private Space
+      operationId: getPrivateSpaceIamRoles
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/accounts:
     get:
       description: get the AWS account Id a string value.
@@ -553,7 +566,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAccounts
+      summary: Get AWS account ID for the Private Space
+      operationId: getPrivateSpaceAwsAccountId
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/upgrade:
     patch:
       description: Either upgrade now or (re)schedule an upgrade later
@@ -583,7 +597,8 @@ paths:
               example:
                 scheduledUpdateTime: &id003 2024-02-28 17:57:36+00:00
                 status: QUEUED
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgrade
+      summary: Schedule or trigger Private Space upgrade
+      operationId: schedulePrivateSpaceUpgrade
     delete:
       description: cancel a scheduled upgrade
       parameters:
@@ -592,7 +607,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgrade
+      summary: Cancel a scheduled Private Space upgrade
+      operationId: cancelPrivateSpaceUpgrade
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/upgradestatus:
     get:
       description: get the upgrade status of the space
@@ -610,7 +626,8 @@ paths:
               example:
                 scheduledUpdateTime: *id003
                 status: QUEUED
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgradestatus
+      summary: Get Private Space upgrade status
+      operationId: getPrivateSpaceUpgradeStatus
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/egress:
     post:
       description: create an egress rule group
@@ -635,7 +652,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgress
+      summary: Create an egress rule group
+      operationId: createEgressRuleGroup
     get:
       description: get all egress rule groups of a private space.
       parameters:
@@ -662,7 +680,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/EgressRuleGroup'
               example: *id004
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgress
+      summary: List egress rule groups
+      operationId: listEgressRuleGroups
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/egress/{ruleGroupId}:
     delete:
       description: delete egress rule group
@@ -678,7 +697,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Delete an egress rule group
+      operationId: deleteEgressRuleGroup
     get:
       description: get a specific egress rule group
       parameters:
@@ -705,7 +725,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Get an egress rule group
+      operationId: getEgressRuleGroup
     patch:
       description: Update egress rule group.
       parameters:
@@ -735,7 +756,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Update an egress rule group
+      operationId: updateEgressRuleGroup
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/routes:
     get:
       description: get the list of CIDR's in the private space.
@@ -755,7 +777,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidRoutes
+      summary: List Private Space routes
+      operationId: listPrivateSpaceRoutes
     patch:
       description: Update the CIDRs that the Cloudhub VPC will send traffic to via the IGW.
       parameters:
@@ -781,7 +804,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidRoutes
+      summary: Update Private Space routes
+      operationId: updatePrivateSpaceRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections:
     description: The collection of connections
     get:
@@ -857,7 +881,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnections
+      summary: List Private Space connections
+      operationId: listConnections
     post:
       description: create a Private Space Connection
       parameters:
@@ -955,7 +980,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnections
+      summary: Create a Private Space connection
+      operationId: createConnection
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/{connectionId}:
     description: Get an entity representing a connection
     delete:
@@ -967,7 +993,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Delete a Private Space connection
+      operationId: deleteConnection
     get:
       description: get the Private Space Connection
       parameters:
@@ -1015,7 +1042,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Get a Private Space connection
+      operationId: getConnection
     patch:
       description: Update existing Private Space Connection
       parameters:
@@ -1075,7 +1103,8 @@ paths:
                       vpnTunnels: []
                       vpnTunnelsConfig: []
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Update a Private Space connection
+      operationId: updateConnection
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns:
     post:
       description: add a vpn to an existing connection.
@@ -1126,7 +1155,8 @@ paths:
               example: {}
         '409':
           description: Conflict. The request conflicts with the current state of the resource.
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpns
+      summary: Add a VPN to a connection
+      operationId: addConnectionVpn
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns/{vpnId}:
     delete:
       description: delete a vpn from a connection.
@@ -1142,7 +1172,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnid
+      summary: Delete a VPN from a connection
+      operationId: deleteConnectionVpn
     patch:
       description: delete a vpn from a connection.
       parameters:
@@ -1180,7 +1211,8 @@ paths:
                 vpnTunnels:
                 - id: string
                   type: string
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnid
+      summary: Update a VPN in a connection
+      operationId: updateConnectionVpn
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns/{vpnId}/connectionGuide:
     description: download connection guide for vpn.
     get:
@@ -1214,7 +1246,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnidConnectionguide
+      summary: Download VPN connection guide
+      operationId: getVpnConnectionGuide
       description: Retrieves a connectionGuide.
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways:
     description: The collection of transitgateways
@@ -1313,7 +1346,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+      summary: List Private Space Transit Gateway connections
+      operationId: listPrivateSpaceTgws
     post:
       description: create a private space TGW connection.
       parameters:
@@ -1405,7 +1439,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+      summary: Create a Private Space Transit Gateway connection
+      operationId: createPrivateSpaceTgw
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/{tgwId}:
     description: Get an entity representing a transitgateway
     delete:
@@ -1417,7 +1452,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Detach a Transit Gateway from a Private Space
+      operationId: deletePrivateSpaceTgw
     patch:
       description: patch the Private Space TGW Connection
       parameters:
@@ -1475,7 +1511,8 @@ paths:
                       - 10.0.0.0/21
                       - 10.0.0.0/22
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Update a Private Space Transit Gateway
+      operationId: updatePrivateSpaceTgw
     get:
       description: 'Get the transitgateway
 
@@ -1523,7 +1560,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Get a Private Space Transit Gateway
+      operationId: getPrivateSpaceTgw
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/{tgwId}/routes:
     patch:
       description: patch routes for a TGW connection.
@@ -1543,7 +1581,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwidRoutes
+      summary: Update Transit Gateway connection routes
+      operationId: updateTgwConnectionRoutes
     get:
       description: get TGW routes configured to tgw connection.
       parameters:
@@ -1553,7 +1592,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwidRoutes
+      summary: List Transit Gateway connection routes
+      operationId: listTgwConnectionRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/routes:
     get:
       description: get TGW routes configured to private space.
@@ -1563,7 +1603,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysRoutes
+      summary: List Transit Gateway routes for Private Space
+      operationId: listPrivateSpaceTgwRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/tlsContexts:
     description: The collection of tlsContexts
     get:
@@ -1793,7 +1834,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontexts
+      summary: List TLS contexts
+      operationId: listTlsContexts
     post:
       description: create a TLS context
       parameters:
@@ -2004,7 +2046,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontexts
+      summary: Create a TLS context
+      operationId: createTlsContext
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/tlsContexts/{contextId}:
     description: Get an entity representing a tlsContext
     delete:
@@ -2021,7 +2064,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Delete a TLS context
+      operationId: deleteTlsContext
     get:
       description: get the TLS context
       parameters:
@@ -2112,7 +2156,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Get a TLS context
+      operationId: getTlsContext
     patch:
       description: Update an existing TLS context
       parameters:
@@ -2215,7 +2260,8 @@ paths:
                       tlsAes128GcmSha256: true
                     type: custom
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Update a TLS context
+      operationId: updateTlsContext
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/logs:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -2241,7 +2287,8 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidLogsIngress
+      summary: Download ingress logs
+      operationId: downloadIngressLogs
   /organizations/{organizationId}:
     parameters:
     - $ref: '#/components/parameters/XOrigin_networkOrganizationId_Path'
@@ -2353,7 +2400,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidTransitgateways
+      summary: List Transit Gateway connections for the org
+      operationId: listOrgTransitGateways
   /organizations/{organizationId}/transitgateways/{tgwId}:
     delete:
       description: Remove the Transit gateway from your Anypoint Platform organization
@@ -2363,7 +2411,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidTransitgatewaysByTgwid
+      summary: Remove a Transit Gateway from the organization
+      operationId: deleteOrgTransitGateway
   /organizations/{organizationId}/transitgateways/{tgwId}/routes:
     get:
       description: get TGW routes configured for a gateway
@@ -2373,7 +2422,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidTransitgatewaysByTgwidRoutes
+      summary: Get Transit Gateway routes
+      operationId: listOrgTgwRoutes
   /organizations/{organizationId}/targets:
     description: The collection of targets
     get:
@@ -2537,7 +2587,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidTargets
+      summary: List deployment targets
+      operationId: listTargets
   /organizations/{organizationId}/targets/{id}:
     get:
       description: get the target
@@ -2573,7 +2624,8 @@ paths:
                 environments:
                 - string
                 isAvailableForDeployments: true
-      operationId: getOrganizationsByOrganizationidTargetsById
+      summary: Get a deployment target
+      operationId: getTarget
   /organizations/{organizationId}/migration:
     parameters:
     - $ref: '#/components/parameters/XOrigin_vpnOrganizationId_Path'
@@ -2701,7 +2753,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidMigrationVpcsByVpcidPrivatespaces
+      summary: Migrate a Cloudhub VPC to a Private Space
+      operationId: migrateVpcToPrivateSpace
   /organizations/{organizationId}/migration/vpcs:
     get:
       description: get Cloudhub VPCs upgrade eligibility information
@@ -2712,7 +2765,8 @@ paths:
           description: Successful operation.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getOrganizationsByOrganizationidMigrationVpcs
+      summary: List Cloudhub VPCs eligible for upgrade
+      operationId: listMigratableVpcs
   /organizations/{organizationId}/migration/vpcs/{vpcId}:
     get:
       description: get Cloudhub VPC upgrade eligibility information
@@ -2734,7 +2788,8 @@ paths:
           description: Successful operation.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getOrganizationsByOrganizationidMigrationVpcsByVpcid
+      summary: Get VPC upgrade eligibility
+      operationId: getVpcMigrationInfo
 components:
   securitySchemes:
     bearerAuth:
@@ -4661,7 +4716,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidPrivatespaces
+        operation: listPrivateSpaces
         description: GET `/organizations/{organizationId}/privatespaces` in this API; use `id` values as `privateSpaceId`.
         values: $.id
         labels: $.name
@@ -4676,7 +4731,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+        operation: listPrivateSpaceTgws
         description: GET `/organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways` in this API; use `id` values as `tgwId`.
         values: $.id
         labels: $.name
@@ -4691,7 +4746,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidTransitgateways
+        operation: listOrgTransitGateways
         description: GET `/organizations/{organizationId}/transitgateways` in this API; use `id` values as `tgwId`.
         values: $.id
         labels: $.name


### PR DESCRIPTION
Applied cleanup for apis/cloudhub-20:
- 55 operationId renames (verbose By-prefixed forms -> resource-focused names)
- Summary lines added / normalized (imperative mood, no trailing period)
- 3 internal x-origin cross-refs patched to renamed operations

No external cross-references to other APIs, skills, or MCPs.