### PR TITLE
@W-23431001: api-manager operationId + summary cleanup

### DIFF
--- a/apis/api-manager/api.yaml
+++ b/apis/api-manager/api.yaml
@@ -59,7 +59,8 @@ paths:
             example: apimanager/examples/responses/application-import.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsApplications
+      summary: Import a client application
+      operationId: importApplication
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/environments/{environmentId}/apis:
@@ -155,7 +156,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: listOrganizationsEnvironmentsApis
+      summary: List APIs
+      operationId: listApis
     post:
       responses:
         '201':
@@ -221,7 +223,8 @@ paths:
               required: []
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApis
+      summary: Create an API
+      operationId: createApi
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -263,7 +266,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: getOrganizationsEnvironmentsApis
+      summary: Get an API
+      operationId: getApi
     put:
       responses:
         '201':
@@ -286,7 +290,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApis
+      summary: Replace an API
+      operationId: updateApi
     patch:
       responses:
         '200':
@@ -326,13 +331,15 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: patchOrganizationsEnvironmentsApis
+      summary: Update an API
+      operationId: patchApi
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApis
+      summary: Delete an API
+      operationId: deleteApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -348,13 +355,15 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Pins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: updateOrganizationsEnvironmentsApisPin
+      summary: Pin an API version
+      operationId: pinApi
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unpins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisPin
+      summary: Unpin an API version
+      operationId: unpinApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -380,7 +389,8 @@ paths:
               $ref: ./apimanager/schemas/upstreamPOST-oas.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisUpstreams
+      summary: Create an API upstream
+      operationId: createApiUpstream
     get:
       responses:
         '200':
@@ -393,7 +403,8 @@ paths:
                 Upstreams:
                   $ref: ./apimanager/examples/responses/upstreams.json
       description: "Get API version upstreams\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: listOrganizationsEnvironmentsApisUpstreams
+      summary: List API upstreams
+      operationId: listApiUpstreams
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -411,7 +422,8 @@ paths:
                 Upstream:
                   $ref: ./apimanager/examples/responses/upstream.json
       description: "Get an upstream\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: getOrganizationsEnvironmentsApisUpstreams
+      summary: Get an API upstream
+      operationId: getApiUpstream
     patch:
       responses:
         '200':
@@ -434,7 +446,8 @@ paths:
               $ref: ./apimanager/schemas/upstreamPATCH-oas.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisUpstreams
+      summary: Update an API upstream
+      operationId: updateApiUpstream
     delete:
       responses:
         default:
@@ -444,7 +457,8 @@ paths:
               example:
                 message: Success
       description: "Delete an upstream\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisUpstreams
+      summary: Delete an API upstream
+      operationId: deleteApiUpstream
     parameters:
     - $ref: '#/components/parameters/param_upstream_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -495,7 +509,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: listOrganizationsEnvironmentsApisPolicies
+      summary: List API policies
+      operationId: listApiPolicies
     post:
       responses:
         '201':
@@ -516,7 +531,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisPolicies
+      summary: Apply a new API policy
+      operationId: applyApiPolicy
     patch:
       responses:
         '200':
@@ -547,7 +563,8 @@ paths:
                 type: object
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisPoliciesBulk
+      summary: Reorder API policies
+      operationId: reorderApiPolicies
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -565,7 +582,8 @@ paths:
                 Policies:
                   $ref: ./apimanager/examples/responses/policies.json
       description: "Retrieves a specific policy for the API\n\nConnected Apps require the following scopes:\n  - View Policies\n"
-      operationId: getOrganizationsEnvironmentsApisPolicies
+      summary: Get an API policy
+      operationId: getApiPolicy
     patch:
       responses:
         '200':
@@ -585,13 +603,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsEnvironmentsApisPolicy
+      summary: Update an API policy
+      operationId: updateApiPolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unapplies a policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
-      operationId: deleteOrganizationsEnvironmentsApisPolicies
+      summary: Unapply an API policy
+      operationId: unapplyApiPolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -624,7 +644,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: createOrganizationsEnvironmentsApisPoliciesImplementationasset
+      summary: Update policy implementation asset
+      operationId: updateApiPolicyImplementationAsset
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -657,7 +678,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsEnvironmentsApisTiers
+      summary: List API tiers
+      operationId: listApiTiers
     post:
       responses:
         '201':
@@ -694,13 +716,15 @@ paths:
                 $ref: ./apimanager/examples/requests/tier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisTiers
+      summary: Create an SLA tier for the API
+      operationId: createApiTier
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count tiers of the API version
-      operationId: checkOrganizationsEnvironmentsApisTiers
+      summary: Count API tiers
+      operationId: checkApiTiers
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -742,13 +766,15 @@ paths:
                 $ref: ./apimanager/examples/requests/tier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisTiers
+      summary: Update an API tier
+      operationId: updateApiTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
-      operationId: deleteOrganizationsEnvironmentsApisTiers
+      summary: Delete an API tier
+      operationId: deleteApiTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -760,7 +786,8 @@ paths:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count group tiers of the API version
-      operationId: checkOrganizationsEnvironmentsApisGrouptiers
+      summary: Count API group tiers
+      operationId: checkApiGroupTiers
     get:
       responses:
         '200':
@@ -771,7 +798,8 @@ paths:
                 total: 0
                 data: []
       description: Returns a list of elements.
-      operationId: listOrganizationsEnvironmentsApisGrouptiers
+      summary: List API group tiers
+      operationId: listApiGroupTiers
     post:
       responses:
         '201':
@@ -792,7 +820,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisGrouptiers
+      summary: Create an API group tier
+      operationId: createApiGroupTier
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -810,7 +839,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a list of group contracts of the API version\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
-      operationId: listOrganizationsEnvironmentsApisGroupcontracts
+      summary: List API group contracts
+      operationId: listApiGroupContracts
     post:
       responses:
         '201':
@@ -831,7 +861,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisGroupcontracts
+      summary: Create an API group contract
+      operationId: createApiGroupContract
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -866,7 +897,8 @@ paths:
                 $ref: ./apimanager/examples/requests/contractThroughApi.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisContracts
+      summary: Create an API contract
+      operationId: createApiContract
     get:
       responses:
         '200':
@@ -912,7 +944,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsEnvironmentsApisContracts
+      summary: List API contracts
+      operationId: listApiContracts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -930,7 +963,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a specific contract for the API\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
-      operationId: getOrganizationsEnvironmentsApisContracts
+      summary: Get an API contract
+      operationId: getApiContract
     patch:
       responses:
         '200':
@@ -953,13 +987,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisContracts
+      summary: Update API contract conditions
+      operationId: updateApiContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes the contract\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
-      operationId: deleteOrganizationsEnvironmentsApisContracts
+      summary: Delete an API contract
+      operationId: deleteApiContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -978,7 +1014,8 @@ paths:
                 Contract:
                   $ref: ./apimanager/examples/responses/alerts.json
       description: "Retrieves a list of API alerts\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: listOrganizationsEnvironmentsApisAlerts
+      summary: List API alerts
+      operationId: listApiAlerts
     post:
       responses:
         '201':
@@ -1001,7 +1038,8 @@ paths:
                 $ref: ./apimanager/examples/requests/alert.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisAlerts
+      summary: Create an API alert
+      operationId: createApiAlert
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1038,7 +1076,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves an API alert\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: getOrganizationsEnvironmentsApisAlerts
+      summary: Get an API alert
+      operationId: getApiAlert
     patch:
       responses:
         '200':
@@ -1087,7 +1126,8 @@ paths:
                 $ref: ./apimanager/examples/requests/alert.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisAlerts
+      summary: Update an API alert
+      operationId: updateApiAlert
     delete:
       responses:
         '204':
@@ -1112,7 +1152,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Deletes the specified alert definition\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: deleteOrganizationsEnvironmentsApisAlerts
+      summary: Delete an API alert
+      operationId: deleteApiAlert
     parameters:
     - $ref: '#/components/parameters/param_alert_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1157,7 +1198,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: listOrganizationsEnvironmentsApisBundle
+      summary: Export the API bundle
+      operationId: exportApiBundle
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1173,13 +1215,15 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Adds a new API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: updateOrganizationsEnvironmentsApisTags
+      summary: Add a new API tag
+      operationId: addApiTag
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisTags
+      summary: Delete an API tag
+      operationId: deleteApiTag
     parameters:
     - name: tag
       in: path
@@ -1209,7 +1253,8 @@ paths:
         description: The version of the gateway that will use the autodiscovery properties to track this API, written in semver.
         schema:
           type: string
-      operationId: listOrganizationsEnvironmentsApisAutodiscoveryproperties
+      summary: Get API autodiscovery properties
+      operationId: getApiAutodiscoveryProperties
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1241,7 +1286,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: Retrieves TLS Contexts configuration for a given API endpoint
-      operationId: listOrganizationsEnvironmentsApisTlscontexts
+      summary: Get API TLS context configuration
+      operationId: getApiTlsContexts
     post:
       responses:
         '201':
@@ -1276,7 +1322,8 @@ paths:
                 $ref: ./apimanager/examples/tlsContextsRequest.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisTlscontexts
+      summary: Create API TLS context configuration
+      operationId: createApiTlsContexts
     put:
       responses:
         '200':
@@ -1296,13 +1343,15 @@ paths:
                 $ref: ./apimanager/examples/tlsContextsRequest.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisTlscontexts
+      summary: Update API TLS context configuration
+      operationId: updateApiTlsContexts
     delete:
       responses:
         '204':
           description: TLS Contexts successfully deleted
       description: Deletes TLS Contexts configuration
-      operationId: deleteOrganizationsEnvironmentsApisTlscontexts
+      summary: Delete API TLS context configuration
+      operationId: deleteApiTlsContexts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1335,7 +1384,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupInstanceCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstances
+      summary: Create a group instance
+      operationId: createGroupInstance
     get:
       responses:
         '200':
@@ -1346,7 +1396,8 @@ paths:
                 total: 0
                 data: []
       description: "Gets a list of group istances by environmentId\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstances
+      summary: List group instances
+      operationId: listGroupInstances
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -1368,7 +1419,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Gets a group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstances
+      summary: Get a group instance
+      operationId: getGroupInstance
     patch:
       responses:
         '200':
@@ -1388,7 +1440,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsGroupinstances
+      summary: Update a group instance
+      operationId: updateGroupInstance
     delete:
       responses:
         '201':
@@ -1399,7 +1452,8 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Deletes a group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstances
+      summary: Delete a group instance
+      operationId: deleteGroupInstance
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1434,7 +1488,8 @@ paths:
                 $ref: ./apimanager/examples/requests/contractThroughApi.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Create a group instance contract
+      operationId: createGroupInstanceContract
     get:
       responses:
         '200':
@@ -1447,13 +1502,15 @@ paths:
                 GroupContract:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceContractsRetrieve.json
       description: "Retrieves the list of contracts of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesContracts
+      summary: List group instance contracts
+      operationId: listGroupInstanceContracts
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: "Retrieves the count of contracts of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: checkOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Count group instance contracts
+      operationId: checkGroupInstanceContracts
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1471,13 +1528,15 @@ paths:
                 GroupContract:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceContractsRetrieve.json
       description: "Retrieves a specific contract for the group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Get a group instance contract
+      operationId: getGroupInstanceContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a group instance contract that is not currently applied\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Delete a group instance contract
+      operationId: deleteGroupInstanceContract
     patch:
       responses:
         '200':
@@ -1487,7 +1546,8 @@ paths:
               example:
                 message: Resource updated successfully
       description: "Updates a group instance contract\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: updateOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Update a group instance contract
+      operationId: updateGroupInstanceContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id_string'
     - $ref: '#/components/parameters/param_group_instance_id'
@@ -1506,7 +1566,8 @@ paths:
                 GroupTier:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceTiersRetrieve.json
       description: "Retrieves the tiers of a Group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesTiers
+      summary: List group instance tiers
+      operationId: listGroupInstanceTiers
     post:
       responses:
         '201':
@@ -1536,7 +1597,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupInstanceTierCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Create a group instance tier
+      operationId: createGroupInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1561,13 +1623,15 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a group instance tier\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Get a group instance tier
+      operationId: getGroupInstanceTier
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Delete a group instance tier
+      operationId: deleteGroupInstanceTier
     put:
       responses:
         '200':
@@ -1611,7 +1675,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Replace a group instance tier
+      operationId: updateGroupInstanceTier
     patch:
       responses:
         '200':
@@ -1631,7 +1696,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Update a group instance tier
+      operationId: patchGroupInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_group_instance_id'
@@ -1648,7 +1714,8 @@ paths:
                 total: 0
                 data: []
       description: "Gets API instances of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesApiinstances
+      summary: List group instance APIs
+      operationId: listGroupInstanceApiInstances
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1672,7 +1739,8 @@ paths:
               examples:
                 ApiList:
                   $ref: ./apimanager/examples/responses/managedServices/apiList.json
-      operationId: listOrganizationsEnvironmentsManagedserviceapis
+      summary: List managed service APIs
+      operationId: listManagedServiceApis
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -1689,7 +1757,8 @@ paths:
                 Api:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiGet.json
       description: Retrieve a specific Managed Service API
-      operationId: getOrganizationsEnvironmentsManagedserviceapis
+      summary: Get a managed service API
+      operationId: getManagedServiceApi
     patch:
       responses:
         '200':
@@ -1712,7 +1781,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapis
+      summary: Update managed service API details
+      operationId: updateManagedServiceApi
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1740,7 +1810,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Create a managed service API policy
+      operationId: createManagedServiceApiPolicy
     get:
       description: 'Retrieves all policies applied to a specific Managed Service API.
 
@@ -1775,7 +1846,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
         description: The fullInfo query parameter.
-      operationId: listOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: List managed service API policies
+      operationId: listManagedServiceApiPolicies
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1799,7 +1871,8 @@ paths:
               examples:
                 Policy:
                   $ref: ./apimanager/examples/responses/managedServices/policy.json
-      operationId: getOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Get a managed service API policy
+      operationId: getManagedServiceApiPolicy
     patch:
       responses:
         '200':
@@ -1822,13 +1895,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Update a managed service API policy
+      operationId: updateManagedServiceApiPolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Unapplies a policy.
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Unapply a managed service API policy
+      operationId: unapplyManagedServiceApiPolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -1847,7 +1922,8 @@ paths:
                 Tiers:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiTiersRetrieve.json
       description: Retrieves the tiers of a Managed Service API
-      operationId: listOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: List managed service API tiers
+      operationId: listManagedServiceApiTiers
     post:
       responses:
         '201':
@@ -1870,7 +1946,8 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiTier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Create a managed service API tier
+      operationId: createManagedServiceApiTier
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1898,13 +1975,15 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiTier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Edit a managed service API tier
+      operationId: updateManagedServiceApiTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Delete a tier of a Managed Service API
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Delete a managed service API tier
+      operationId: deleteManagedServiceApiTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id_managed_service'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -1923,7 +2002,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiContractsRetrieve.json
       description: Retrieves the contracts of a Managed Service API
-      operationId: listOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: List managed service API contracts
+      operationId: listManagedServiceApiContracts
     post:
       responses:
         '201':
@@ -1946,7 +2026,8 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiContract.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Create a managed service API contract
+      operationId: createManagedServiceApiContract
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1964,7 +2045,8 @@ paths:
                 Contract:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiContractRetrieve.json
       description: Retrieves a contract of a Managed Service API
-      operationId: getOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Get a managed service API contract
+      operationId: getManagedServiceApiContract
     patch:
       responses:
         '201':
@@ -1987,13 +2069,15 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiContractPatch.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Edit a managed service API contract
+      operationId: updateManagedServiceApiContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Delete a contract of a Managed Service API
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Delete a managed service API contract
+      operationId: deleteManagedServiceApiContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id_string'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -2016,7 +2100,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsCustompolicytemplates
+      summary: List custom policy templates
+      operationId: listCustomPolicyTemplates
     post:
       responses:
         '201':
@@ -2057,7 +2142,8 @@ paths:
               required: []
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsCustompolicytemplates
+      summary: Create a custom policy template
+      operationId: createCustomPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/custom-policy-templates/{customPolicyTemplateId}:
@@ -2071,7 +2157,8 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 name: Example Resource
       description: Returns an instance of a single element.
-      operationId: getOrganizationsCustompolicytemplates
+      summary: Get a custom policy template
+      operationId: getCustomPolicyTemplate
     put:
       responses:
         '201':
@@ -2092,7 +2179,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsCustompolicytemplates
+      summary: Replace a custom policy template
+      operationId: updateCustomPolicyTemplate
     patch:
       responses:
         '200':
@@ -2112,13 +2200,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsCustompolicytemplates
+      summary: Update a custom policy template
+      operationId: patchCustomPolicyTemplate
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsCustompolicytemplates
+      summary: Delete a custom policy template
+      operationId: deleteCustomPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2133,7 +2223,8 @@ paths:
                 total: 0
                 data: []
       description: The XML configuration for the custom policy template.
-      operationId: listOrganizationsCustompolicytemplatesConfiguration
+      summary: Get custom policy template configuration
+      operationId: getCustomPolicyTemplateConfiguration
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2148,7 +2239,8 @@ paths:
                 total: 0
                 data: []
       description: The YAML definition for the custom policy template.
-      operationId: listOrganizationsCustompolicytemplatesDefinition
+      summary: Get custom policy template definition
+      operationId: getCustomPolicyTemplateDefinition
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2197,7 +2289,8 @@ paths:
           pattern: ^v\d+(.\d+)?(.\d+)?$
           type: string
         description: The version query parameter.
-      operationId: listOrganizationsPolicytemplates
+      summary: List policy templates
+      operationId: listPolicyTemplates
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/policy-templates/{policyTemplateId}:
@@ -2249,7 +2342,8 @@ paths:
           pattern: ^v\d+(.\d+)?(.\d+)?$
           type: string
         description: The version query parameter.
-      operationId: getOrganizationsPolicytemplates
+      summary: Get a policy template
+      operationId: getPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2267,7 +2361,8 @@ paths:
         description: A semver string that will be checked for an exact match of Runtime Version
         schema:
           type: string
-      operationId: checkOrganizationsAutomatedpolicies
+      summary: Count automated policies
+      operationId: checkAutomatedPolicies
     get:
       responses:
         '200':
@@ -2295,7 +2390,8 @@ paths:
         description: A semver string that will be checked for an exact match of Runtime Version
         schema:
           type: string
-      operationId: listOrganizationsAutomatedpolicies
+      summary: List automated policies
+      operationId: listAutomatedPolicies
     post:
       responses:
         '201':
@@ -2330,7 +2426,8 @@ paths:
                 $ref: ./apimanager/examples/requests/automatedPolicy.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsAutomatedpolicies
+      summary: Create an automated policy
+      operationId: createAutomatedPolicy
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/automated-policies/{automatedPolicyId}:
@@ -2346,7 +2443,8 @@ paths:
                 AutomatedPolicies:
                   $ref: ./apimanager/examples/responses/automatedPolicies/automatedPoliciesRetrieve.json
       description: "Retrieves an Automated Policy.\n\nConnected Apps require the following scopes:\n  - View Policies\n"
-      operationId: getOrganizationsAutomatedpolicies
+      summary: Get an automated policy
+      operationId: getAutomatedPolicy
     patch:
       responses:
         '200':
@@ -2373,7 +2471,8 @@ paths:
                 $ref: ./apimanager/examples/requests/automatedPolicy.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsAutomatedpolicies
+      summary: Update an automated policy
+      operationId: patchAutomatedPolicy
     delete:
       responses:
         '204':
@@ -2386,7 +2485,8 @@ paths:
                 error: Bad Request
                 message: Invalid request parameters
       description: "Deletes an Automated Policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
-      operationId: deleteOrganizationsAutomatedpolicies
+      summary: Delete an automated policy
+      operationId: deleteAutomatedPolicy
     put:
       responses:
         '201':
@@ -2407,7 +2507,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsAutomatedpolicies
+      summary: Replace an automated policy
+      operationId: updateAutomatedPolicy
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2462,7 +2563,8 @@ paths:
         schema:
           default: 100
           type: integer
-      operationId: listOrganizationsAutomatedpoliciesApis
+      summary: List APIs affected by policy
+      operationId: listAutomatedPolicyApis
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2481,7 +2583,8 @@ paths:
       description: Delete Automated Policy coverage over the apiVersion specified due to incompatible implementation for the proxy version.
       parameters:
       - $ref: '#/components/parameters/XOrigin_environmentId_Query'
-      operationId: deleteOrganizationsAutomatedpoliciesIncompatibleapis
+      summary: Remove incompatible API from policy
+      operationId: deleteAutomatedPolicyIncompatibleApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_automated_policy_id'
@@ -2513,7 +2616,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: createOrganizationsAutomatedpoliciesImplementationassets
+      summary: Update policy implementation assets
+      operationId: setAutomatedPolicyImplementationAssets
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2544,7 +2648,8 @@ paths:
         description: Search groups by name
         schema:
           type: string
-      operationId: listOrganizationsGroups
+      summary: List groups
+      operationId: listGroups
     post:
       responses:
         '201':
@@ -2574,7 +2679,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroups
+      summary: Create a group
+      operationId: createGroup
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/groups/{groupId}:
@@ -2597,7 +2703,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a Group\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsGroups
+      summary: Get a group
+      operationId: getGroup
     patch:
       responses:
         '200':
@@ -2624,7 +2731,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupUpdate.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsGroups
+      summary: Update a group
+      operationId: patchGroup
     put:
       responses:
         '201':
@@ -2645,13 +2753,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsGroups
+      summary: Replace a group
+      operationId: updateGroup
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsGroups
+      summary: Delete a group
+      operationId: deleteGroup
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2683,7 +2793,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroupsAssets
+      summary: Create a group asset
+      operationId: createGroupAsset
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2717,7 +2828,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupVersionCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroupsVersions
+      summary: Create a group version
+      operationId: createGroupVersion
     get:
       responses:
         '200':
@@ -2730,7 +2842,8 @@ paths:
                 Group:
                   $ref: ./apimanager/examples/responses/apiGroups/groupVersionsRetrieve.json
       description: "Retrieves all versions of a Group\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsGroupsVersions
+      summary: List group versions
+      operationId: listGroupVersions
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2754,7 +2867,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a Group Version\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsGroupsVersions
+      summary: Get a group version
+      operationId: getGroupVersion
     patch:
       responses:
         '200':
@@ -2788,7 +2902,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupVersionUpdate.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsGroupsVersions
+      summary: Update a group version
+      operationId: patchGroupVersion
     put:
       responses:
         '201':
@@ -2809,13 +2924,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsGroupsVersions
+      summary: Replace a group version
+      operationId: updateGroupVersion
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsGroupsVersions
+      summary: Delete a group version
+      operationId: deleteGroupVersion
     parameters:
     - $ref: '#/components/parameters/param_group_version_id'
     - $ref: '#/components/parameters/param_api_group_id'
@@ -2840,7 +2957,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves the instances contained in a Group Version\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsGroupsVersionsInstances
+      summary: List group version instances
+      operationId: listGroupVersionInstances
     parameters:
     - $ref: '#/components/parameters/param_group_version_id'
     - $ref: '#/components/parameters/param_api_group_id'
@@ -2943,7 +3061,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsApisUpstreams
+        operation: listApiUpstreams
         values: $.id
         labels: $.name
     param_policy_id:
@@ -2965,7 +3083,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsApisAlerts
+        operation: listApiAlerts
         values: $.id
         labels: $.name
     param_group_instance_id:
@@ -2979,7 +3097,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsGroupinstances
+        operation: listGroupInstances
         values: $.id
         labels: $.name
     param_managed_service_api_id:
@@ -2993,7 +3111,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsManagedserviceapis
+        operation: listManagedServiceApis
         values: $.id
         labels: $.name
     param_custom_policy_template_id:
@@ -3007,7 +3125,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsPolicytemplates
+        operation: listPolicyTemplates
         values: $.id
         labels: $.name
     param_automated_policy_id:
@@ -3021,7 +3139,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsAutomatedpolicies
+        operation: listAutomatedPolicies
         values: $.id
         labels: $.name
     param_api_group_id:
@@ -3037,7 +3155,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsGroupsVersions
+        operation: listGroupVersions
         values: $.id
         labels: $.name
     XOrigin_environmentId_Query:

--- a/apis/api-manager/api.yaml
+++ b/apis/api-manager/api.yaml
@@ -157,7 +157,7 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
       summary: List APIs
-      operationId: listApis
+      operationId: listApiInstances
     post:
       responses:
         '201':
@@ -224,7 +224,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API
-      operationId: createApi
+      operationId: createApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -267,7 +267,7 @@ paths:
           - type: boolean
             default: false
       summary: Get an API
-      operationId: getApi
+      operationId: getApiInstance
     put:
       responses:
         '201':
@@ -290,8 +290,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      summary: Replace an API
-      operationId: updateApi
+      summary: Update an API
+      operationId: updateApiInstance
     patch:
       responses:
         '200':
@@ -332,14 +332,14 @@ paths:
           - type: boolean
             default: false
       summary: Update an API
-      operationId: patchApi
+      operationId: patchApiInstance
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API
-      operationId: deleteApi
+      operationId: deleteApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -356,14 +356,14 @@ paths:
                 message: Resource created successfully
       description: "Pins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Pin an API version
-      operationId: pinApi
+      operationId: pinApiInstance
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unpins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Unpin an API version
-      operationId: unpinApi
+      operationId: unpinApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -390,7 +390,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API upstream
-      operationId: createApiUpstream
+      operationId: createApiInstanceUpstream
     get:
       responses:
         '200':
@@ -404,7 +404,7 @@ paths:
                   $ref: ./apimanager/examples/responses/upstreams.json
       description: "Get API version upstreams\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: List API upstreams
-      operationId: listApiUpstreams
+      operationId: listApiInstanceUpstreams
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -423,7 +423,7 @@ paths:
                   $ref: ./apimanager/examples/responses/upstream.json
       description: "Get an upstream\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Get an API upstream
-      operationId: getApiUpstream
+      operationId: getApiInstanceUpstream
     patch:
       responses:
         '200':
@@ -447,7 +447,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API upstream
-      operationId: updateApiUpstream
+      operationId: updateApiInstanceUpstream
     delete:
       responses:
         default:
@@ -458,7 +458,7 @@ paths:
                 message: Success
       description: "Delete an upstream\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API upstream
-      operationId: deleteApiUpstream
+      operationId: deleteApiInstanceUpstream
     parameters:
     - $ref: '#/components/parameters/param_upstream_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -510,7 +510,7 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
       summary: List API policies
-      operationId: listApiPolicies
+      operationId: listApiInstancePolicies
     post:
       responses:
         '201':
@@ -532,7 +532,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Apply a new API policy
-      operationId: applyApiPolicy
+      operationId: applyApiInstancePolicy
     patch:
       responses:
         '200':
@@ -564,7 +564,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Reorder API policies
-      operationId: reorderApiPolicies
+      operationId: reorderApiInstancePolicies
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -583,7 +583,7 @@ paths:
                   $ref: ./apimanager/examples/responses/policies.json
       description: "Retrieves a specific policy for the API\n\nConnected Apps require the following scopes:\n  - View Policies\n"
       summary: Get an API policy
-      operationId: getApiPolicy
+      operationId: getApiInstancePolicy
     patch:
       responses:
         '200':
@@ -604,14 +604,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API policy
-      operationId: updateApiPolicy
+      operationId: updateApiInstancePolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unapplies a policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
       summary: Unapply an API policy
-      operationId: unapplyApiPolicy
+      operationId: unapplyApiInstancePolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -645,7 +645,7 @@ paths:
           - type: boolean
             default: false
       summary: Update policy implementation asset
-      operationId: updateApiPolicyImplementationAsset
+      operationId: updateApiInstancePolicyImplementationAsset
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -679,7 +679,7 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
       summary: List API tiers
-      operationId: listApiTiers
+      operationId: listApiInstanceTiers
     post:
       responses:
         '201':
@@ -717,14 +717,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an SLA tier for the API
-      operationId: createApiTier
+      operationId: createApiInstanceTier
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count tiers of the API version
       summary: Count API tiers
-      operationId: checkApiTiers
+      operationId: checkApiInstanceTiers
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -767,14 +767,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API tier
-      operationId: updateApiTier
+      operationId: updateApiInstanceTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
       summary: Delete an API tier
-      operationId: deleteApiTier
+      operationId: deleteApiInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -787,7 +787,7 @@ paths:
           description: Success. Returns the requested resource.
       description: Retrieves a count group tiers of the API version
       summary: Count API group tiers
-      operationId: checkApiGroupTiers
+      operationId: checkApiInstanceGroupTiers
     get:
       responses:
         '200':
@@ -799,7 +799,7 @@ paths:
                 data: []
       description: Returns a list of elements.
       summary: List API group tiers
-      operationId: listApiGroupTiers
+      operationId: listApiInstanceGroupTiers
     post:
       responses:
         '201':
@@ -821,7 +821,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API group tier
-      operationId: createApiGroupTier
+      operationId: createApiInstanceGroupTier
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -840,7 +840,7 @@ paths:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a list of group contracts of the API version\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
       summary: List API group contracts
-      operationId: listApiGroupContracts
+      operationId: listApiInstanceGroupContracts
     post:
       responses:
         '201':
@@ -862,7 +862,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API group contract
-      operationId: createApiGroupContract
+      operationId: createApiInstanceGroupContract
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -898,7 +898,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API contract
-      operationId: createApiContract
+      operationId: createApiInstanceContract
     get:
       responses:
         '200':
@@ -945,7 +945,7 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
       summary: List API contracts
-      operationId: listApiContracts
+      operationId: listApiInstanceContracts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -964,7 +964,7 @@ paths:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a specific contract for the API\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
       summary: Get an API contract
-      operationId: getApiContract
+      operationId: getApiInstanceContract
     patch:
       responses:
         '200':
@@ -988,14 +988,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update API contract conditions
-      operationId: updateApiContract
+      operationId: updateApiInstanceContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes the contract\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
       summary: Delete an API contract
-      operationId: deleteApiContract
+      operationId: deleteApiInstanceContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1015,7 +1015,7 @@ paths:
                   $ref: ./apimanager/examples/responses/alerts.json
       description: "Retrieves a list of API alerts\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: List API alerts
-      operationId: listApiAlerts
+      operationId: listApiInstanceAlerts
     post:
       responses:
         '201':
@@ -1039,7 +1039,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API alert
-      operationId: createApiAlert
+      operationId: createApiInstanceAlert
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1077,7 +1077,7 @@ paths:
                 message: Resource not found
       description: "Retrieves an API alert\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: Get an API alert
-      operationId: getApiAlert
+      operationId: getApiInstanceAlert
     patch:
       responses:
         '200':
@@ -1127,7 +1127,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API alert
-      operationId: updateApiAlert
+      operationId: updateApiInstanceAlert
     delete:
       responses:
         '204':
@@ -1153,7 +1153,7 @@ paths:
                 message: Resource not found
       description: "Deletes the specified alert definition\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: Delete an API alert
-      operationId: deleteApiAlert
+      operationId: deleteApiInstanceAlert
     parameters:
     - $ref: '#/components/parameters/param_alert_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1199,7 +1199,7 @@ paths:
           - type: boolean
             default: false
       summary: Export the API bundle
-      operationId: exportApiBundle
+      operationId: exportApiInstanceBundle
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1216,14 +1216,14 @@ paths:
                 message: Resource created successfully
       description: "Adds a new API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Add a new API tag
-      operationId: addApiTag
+      operationId: addApiInstanceTag
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API tag
-      operationId: deleteApiTag
+      operationId: deleteApiInstanceTag
     parameters:
     - name: tag
       in: path
@@ -1254,7 +1254,7 @@ paths:
         schema:
           type: string
       summary: Get API autodiscovery properties
-      operationId: getApiAutodiscoveryProperties
+      operationId: getApiInstanceAutodiscoveryProperties
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1287,7 +1287,7 @@ paths:
                 message: Resource not found
       description: Retrieves TLS Contexts configuration for a given API endpoint
       summary: Get API TLS context configuration
-      operationId: getApiTlsContexts
+      operationId: getApiInstanceTlsContexts
     post:
       responses:
         '201':
@@ -1323,7 +1323,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create API TLS context configuration
-      operationId: createApiTlsContexts
+      operationId: createApiInstanceTlsContexts
     put:
       responses:
         '200':
@@ -1344,14 +1344,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update API TLS context configuration
-      operationId: updateApiTlsContexts
+      operationId: updateApiInstanceTlsContexts
     delete:
       responses:
         '204':
           description: TLS Contexts successfully deleted
       description: Deletes TLS Contexts configuration
       summary: Delete API TLS context configuration
-      operationId: deleteApiTlsContexts
+      operationId: deleteApiInstanceTlsContexts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -3061,7 +3061,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listApiUpstreams
+        operation: listApiInstanceUpstreams
         values: $.id
         labels: $.name
     param_policy_id:
@@ -3083,7 +3083,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listApiAlerts
+        operation: listApiInstanceAlerts
         values: $.id
         labels: $.name
     param_group_instance_id:

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -87,7 +87,7 @@ Retrieve all API instances in the selected environment. Each entry represents a 
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -180,7 +180,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -87,7 +87,7 @@ Retrieve all API instances in the selected environment. Each entry represents a 
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -114,7 +114,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `version`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID from Step 1
@@ -165,7 +165,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults. For example, Omni Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults. For example, Omni Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
 
 ## Step 5: Apply Policy to API Instance
 
@@ -180,7 +180,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -237,15 +237,15 @@ After completing all steps, verify the policy is properly applied:
 
 ## Next Steps
 
-1. **Verify the policy** — List applied policies with `listOrganizationsEnvironmentsApisPolicies` to confirm it's active and correctly configured.
+1. **Verify the policy** — List applied policies with `listApiPolicies` to confirm it's active and correctly configured.
 
 2. **Test the enforcement** — Send requests to the API and verify the policy behaves as expected (e.g., unauthorized requests are rejected, rate limits are enforced).
 
-3. **Adjust configuration** — Use `patchOrganizationsEnvironmentsApisPolicy` to update configuration without removing the policy.
+3. **Adjust configuration** — Use `updateApiPolicy` to update configuration without removing the policy.
 
-4. **Apply additional policies** — Repeat this workflow to layer multiple policies (e.g., add rate limiting on top of OAuth2). Use `updateOrganizationsEnvironmentsApisPoliciesBulk` to control execution order.
+4. **Apply additional policies** — Repeat this workflow to layer multiple policies (e.g., add rate limiting on top of OAuth2). Use `reorderApiPolicies` to control execution order.
 
-5. **Consider automated policies** — If you want this policy applied to all APIs in the organization automatically, explore `createOrganizationsAutomatedpolicies`.
+5. **Consider automated policies** — If you want this policy applied to all APIs in the organization automatically, explore `createAutomatedPolicy`.
 
 ## Troubleshooting
 
@@ -270,7 +270,7 @@ After completing all steps, verify the policy is properly applied:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint
@@ -302,7 +302,7 @@ After completing all steps, verify the policy is properly applied:
 **Solutions:**
 - Pass both `apiInstanceId` and `environmentId` to filter for compatible templates
 - Remove filters to see all templates, then check compatibility manually
-- For custom policies, verify the template is published via `listOrganizationsCustompolicytemplates`
+- For custom policies, verify the template is published via `listCustomPolicyTemplates`
 
 ## Related Jobs
 

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your agent Exchange asset. Th
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists agent instances in the selected environment by filtering with `family=agen
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -490,7 +490,7 @@ Apply the selected policy to your agent instance with the appropriate configurat
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your agent Exchange asset. Th
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists agent instances in the selected environment by filtering with `family=agen
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -423,7 +423,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -475,7 +475,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 9: Apply Policy to Instance
 
@@ -490,7 +490,7 @@ Apply the selected policy to your agent instance with the appropriate configurat
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -622,7 +622,7 @@ Your agent is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -223,7 +223,7 @@ Creates a managed API instance in API Manager from your Exchange asset. This cre
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -350,7 +350,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -402,7 +402,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 7: Apply Policy to API Instance
 
@@ -417,7 +417,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -552,7 +552,7 @@ Your API is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -223,7 +223,7 @@ Creates a managed API instance in API Manager from your Exchange asset. This cre
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -417,7 +417,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your MCP server Exchange asse
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists MCP server instances in the selected environment by filtering with `family
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -490,7 +490,7 @@ Apply the selected policy to your MCP server instance with the appropriate confi
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your MCP server Exchange asse
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists MCP server instances in the selected environment by filtering with `family
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -423,7 +423,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -475,7 +475,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 9: Apply Policy to API Instance
 
@@ -490,7 +490,7 @@ Apply the selected policy to your MCP server instance with the appropriate confi
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -622,7 +622,7 @@ Your MCP server is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint


### PR DESCRIPTION
Applied cleanup for apis/api-manager:
- 118 operationId renames (verbose By-prefixed forms -> resource-focused names)
- Summary lines added / normalized (imperative mood, no trailing period)
- 7 internal x-origin cross-refs patched to renamed operations
- 4 skill files patched (SKILL.md operationId refs + prose backtick mentions):
  - skills/secure-api
  - skills/secure-agent
  - skills/secure-mcp-server
  - skills/apply-policy-to-api-instance