### PR TITLE
@W-23307229 Fix OAS 3.0 linter warnings in api-designer-experience

### DIFF
--- a/apis/api-designer-experience/api.yaml
+++ b/apis/api-designer-experience/api.yaml
@@ -1956,8 +1956,11 @@ paths:
         schema:
           type: string
       requestBody:
-        $ref: '#/components/requestBodies/Generated'
         description: The acquireLock data to create.
+        content:
+          application/json:
+            schema: {}
+        x-amf-mediaType: application/json
       responses:
         '200':
           description: Successful operation.
@@ -2004,8 +2007,11 @@ paths:
         schema:
           type: string
       requestBody:
-        $ref: '#/components/requestBodies/Generated'
         description: The releaseLock data to create.
+        content:
+          application/json:
+            schema: {}
+        x-amf-mediaType: application/json
       responses:
         '200':
           description: Successful operation.
@@ -2044,8 +2050,11 @@ paths:
         schema:
           type: string
       requestBody:
-        $ref: '#/components/requestBodies/Generated'
         description: The keepAlive data to create.
+        content:
+          application/json:
+            schema: {}
+        x-amf-mediaType: application/json
       responses:
         '200':
           description: Successful operation.
@@ -2084,8 +2093,11 @@ paths:
         schema:
           type: string
       requestBody:
-        $ref: '#/components/requestBodies/Generated'
         description: The exchange data to create.
+        content:
+          application/json:
+            schema: {}
+        x-amf-mediaType: application/json
       responses:
         '200':
           description: Successful operation.
@@ -3206,13 +3218,6 @@ components:
       $ref: ../../fragments/anypoint_fragment.yaml#/components/securitySchemes/bearerAuth
     clientAuth:
       $ref: ../../fragments/anypoint_fragment.yaml#/components/securitySchemes/clientAuth
-  requestBodies:
-    Generated:
-      content:
-        application/json:
-          schema: {}
-      x-amf-mediaType: application/json
-      description: Request payload for Generated operations.
   schemas:
     ProjectCreate:
       example:
@@ -3528,13 +3533,12 @@ components:
         fileExample.txt: Content of fileExample file in text/plain
         file.json: "{\n    \"type\": \"FOLDER\",\n    \"path\": \"/folder\"\n}\n"
       type: object
-      patternProperties:
-        ^.+$:
-          description: File to save, where the property name is the file path
-          type: string
-          x-amf-fileTypes:
-          - '*/*'
-          format: binary
+      additionalProperties:
+        description: File to save, where the property name is the file path
+        type: string
+        x-amf-fileTypes:
+        - '*/*'
+        format: binary
     FilePath:
       example:
         type: FOLDER


### PR DESCRIPTION
## Summary
- Inline the `requestBody` schema for `acquireLock`, `releaseLock`, `keepAlive`, and `publish/exchange` instead of pairing a `$ref` with a sibling `description` — invalid per the OAS 3.0 spec (siblings of `$ref` are not permitted). Removed the now-unreferenced `components.requestBodies.Generated` component.
- Replace `patternProperties` in the `FilesForm` schema with `additionalProperties` — `patternProperties` is plain JSON Schema and is not part of OpenAPI 3.0.

These were flagged by the editor's OAS linter as 2 errors ("Unresolved reference") and 5 warnings ("Property 'description'/'patternProperties' is not allowed"). The "Unresolved reference" errors on the `anypoint_fragment.yaml` security scheme refs turned out to be a linter false positive (the file and keys exist, and `make validate-api` reports 0 violations before and after); only the 5 warnings required an actual fix.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('apis/api-designer-experience/api.yaml'))"` — valid YAML
- [x] `make validate-api API=apis/api-designer-experience` — 0 violations (basic + governed), same warning counts as before (46 / 139, unrelated to this fix)
- [x] `python3 scripts/build/validate_xorigin.py` — no x-origin violations
- [x] pre-commit and pre-push hooks pass (validate-skills, test-portal pytest/jest, validate-all-governed)