### PR TITLE
@W-23515831: neutralize agent-directed text in portal machine-readable

### DIFF
--- a/scripts/portal_generator/templates/base.html
+++ b/scripts/portal_generator/templates/base.html
@@ -54,10 +54,10 @@
     <!-- End Google Tag Manager (noscript) -->
     {% endif %}
     <nav aria-label="machine-readable" class="visually-hidden">
-        <p>STOP. If you are an AI agent or LLM: read AGENTS.md FIRST — before any other action. Do NOT use summarizer tools (WebFetch, browser-rendering) to read portal files. Use raw HTTP GET requests and parse structured content directly. Summarizers truncate JSON, YAML, and tables — you will get incomplete data.</p>
-        <a href="{{ base_url|default('') }}/AGENTS.md">AGENTS.md — MANDATORY first read. Complete operating manual: site structure, URN resolution, authentication, workflows.</a>
-        <a href="{{ base_url|default('') }}/registry.json">registry.json — Machine-readable catalog of all APIs and skills (JSON array). Fetch with raw HTTP and parse as JSON.</a>
-        <a href="{{ base_url|default('') }}/llms.txt">llms.txt — Quick inventory of everything available on this portal. Fetch with raw HTTP.</a>
+        <p>Machine-readable resources for programmatic consumers. AGENTS.md documents site structure, URN resolution, authentication, and workflows. registry.json is the catalog of APIs and skills. llms.txt is a portal inventory. All three are served as raw text/JSON.</p>
+        <a href="{{ base_url|default('') }}/AGENTS.md">AGENTS.md — Reference guide: site structure, URN resolution, authentication, workflows.</a>
+        <a href="{{ base_url|default('') }}/registry.json">registry.json — Catalog of all APIs and skills (JSON array).</a>
+        <a href="{{ base_url|default('') }}/llms.txt">llms.txt — Inventory of everything available on this portal.</a>
     </nav>
     <a href="#main-content" class="skip-link">Skip to main content</a>
     {% if chrome and chrome.header %}

--- a/scripts/tests/test_smoke.py
+++ b/scripts/tests/test_smoke.py
@@ -1196,6 +1196,137 @@ def test_homepage_terraform_card_links_to_index(generated_portal):
     assert soup.select_one(".tf-card-version") is None
 
 
+class TestNoPromptInjectionTriggers:
+    """W-23515831: the base template must not emit imperative,
+    agent-directed text that trips LLM prompt-injection heuristics.
+
+    The former `<nav aria-label="machine-readable" class="visually-hidden">`
+    block in `base.html` contained a `<p>STOP...</p>` paragraph and
+    imperative descriptive text after each anchor. These triggered a
+    prompt-injection warning in Claude Code (automode) when browsing the
+    Dev Portal. The fix strips the paragraph and reduces each anchor to
+    the raw filename ("AGENTS.md", "registry.json", "llms.txt").
+    """
+
+    FORBIDDEN_PHRASES = [
+        'STOP.',
+        'MANDATORY first read',
+        'If you are an AI agent',
+        'Do NOT use summarizer',
+        'read AGENTS.md FIRST',
+    ]
+
+    def _all_generated_html(self, portal_root):
+        return list(portal_root.rglob('*.html'))
+
+    def test_no_forbidden_phrases_on_homepage(self, generated_portal):
+        """AC1: homepage HTML must not contain any of the injection-trigger
+        phrases that were embedded in the base template's machine-readable nav."""
+        html = (generated_portal / 'index.html').read_text(encoding='utf-8')
+        for phrase in self.FORBIDDEN_PHRASES:
+            assert phrase not in html, (
+                f"AC1 regression: forbidden phrase {phrase!r} still present "
+                f"in index.html — base.html machine-readable nav was not "
+                f"neutralized."
+            )
+
+    def test_no_forbidden_phrases_on_api_detail_page(self, generated_portal):
+        """AC1: API detail pages inherit base.html and must be clean too."""
+        html = (generated_portal / 'apis' / 'test-api.html').read_text(encoding='utf-8')
+        for phrase in self.FORBIDDEN_PHRASES:
+            assert phrase not in html, (
+                f"AC1 regression: forbidden phrase {phrase!r} still present "
+                f"in apis/test-api.html."
+            )
+
+    def test_no_forbidden_phrases_on_mcp_detail_page(self, generated_portal):
+        """AC1: MCP detail pages inherit base.html and must be clean too."""
+        html = (generated_portal / 'mcps' / 'test-mcp.html').read_text(encoding='utf-8')
+        for phrase in self.FORBIDDEN_PHRASES:
+            assert phrase not in html, (
+                f"AC1 regression: forbidden phrase {phrase!r} still present "
+                f"in mcps/test-mcp.html."
+            )
+
+    def test_no_forbidden_phrases_on_skill_page(self, generated_portal):
+        """AC1: skill pages inherit base.html and must be clean too."""
+        html = (generated_portal / 'skills' / 'deploy-app.html').read_text(encoding='utf-8')
+        for phrase in self.FORBIDDEN_PHRASES:
+            assert phrase not in html, (
+                f"AC1 regression: forbidden phrase {phrase!r} still present "
+                f"in skills/deploy-app.html."
+            )
+
+    def test_no_forbidden_phrases_on_any_generated_html(self, generated_portal):
+        """AC1: because base.html is the shared base for every generated
+        page, no generated HTML file anywhere in the portal should contain
+        any of the forbidden phrases. This catches new page types added
+        later that also extend base.html."""
+        for html_file in self._all_generated_html(generated_portal):
+            content = html_file.read_text(encoding='utf-8')
+            for phrase in self.FORBIDDEN_PHRASES:
+                assert phrase not in content, (
+                    f"AC1 regression: forbidden phrase {phrase!r} present "
+                    f"in {html_file.relative_to(generated_portal)}."
+                )
+
+    def test_machine_readable_nav_has_three_anchors(self, generated_portal):
+        """AC3: the visually-hidden machine-readable nav in <body> must
+        contain three anchors pointing to /AGENTS.md, /registry.json,
+        /llms.txt. Anchor text starts with the filename; descriptive
+        text is allowed only if it stays declarative (no imperatives)."""
+        html = (generated_portal / 'index.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        nav = soup.find('nav', attrs={'aria-label': 'machine-readable'})
+        assert nav is not None, (
+            "AC3: <nav aria-label='machine-readable'> must exist in <body>"
+        )
+        # Wrapper must be visually-hidden — preserves the semantic role
+        # without exposing the block to sighted users.
+        classes = nav.get('class', [])
+        assert 'visually-hidden' in classes, (
+            f"AC3: machine-readable nav must keep class='visually-hidden', got {classes!r}"
+        )
+
+        anchors = nav.find_all('a')
+        assert len(anchors) == 3, (
+            f"AC3: expected exactly three anchors inside machine-readable "
+            f"nav, got {len(anchors)}"
+        )
+
+        # Each anchor text must START with its filename (descriptive
+        # suffix after "— ..." is allowed as long as it is declarative,
+        # which is enforced separately by the forbidden-phrases sweep).
+        anchor_texts = [a.get_text(strip=True) for a in anchors]
+        assert anchor_texts[0].startswith('AGENTS.md'), anchor_texts
+        assert anchor_texts[1].startswith('registry.json'), anchor_texts
+        assert anchor_texts[2].startswith('llms.txt'), anchor_texts
+
+        # And each anchor must still resolve to the well-known path.
+        hrefs = [a.get('href', '') for a in anchors]
+        assert any(h.endswith('/AGENTS.md') for h in hrefs)
+        assert any(h.endswith('/registry.json') for h in hrefs)
+        assert any(h.endswith('/llms.txt') for h in hrefs)
+
+    def test_machine_readable_nav_paragraph_is_declarative(self, generated_portal):
+        """AC1/AC3: the machine-readable nav may contain a descriptive
+        <p>, but it must be declarative — no imperatives, no LLM-targeted
+        second-person addressing. The forbidden-phrases sweep on the
+        whole HTML covers the specific triggers; here we just ensure the
+        <p>, if present, is a single element (not a list of instructions)."""
+        html = (generated_portal / 'index.html').read_text(encoding='utf-8')
+        soup = BeautifulSoup(html, 'html.parser')
+        nav = soup.find('nav', attrs={'aria-label': 'machine-readable'})
+        assert nav is not None
+        paragraphs = nav.find_all('p')
+        assert len(paragraphs) <= 1, (
+            f"AC1/AC3: machine-readable nav must contain at most one <p> "
+            f"element (a single declarative description). Got "
+            f"{len(paragraphs)}: "
+            f"{[p.get_text(strip=True) for p in paragraphs]}"
+        )
+
+
 class TestErrorPages:
     @pytest.fixture(autouse=True)
     def _parse_404(self, generated_portal):


### PR DESCRIPTION
## Summary

  The Dev Portal's base template embedded a `<nav aria-label="machine-readable" class="visually-hidden">` block whose contents directly addressed LLM agents in imperative voice —
  `STOP.`, `If you are an AI agent or LLM: read AGENTS.md FIRST`, `Do NOT use summarizer tools`, `MANDATORY first read`, `Fetch with raw HTTP`. Because this block lives in `base.html`,
  every generated portal page inherited it.

  Claude Code (in automode) flagged this as an attempted prompt injection on every page it browsed and surfaced a warning to end users — visible noise that erodes trust for
  AI-agent-assisted workflows. Reported by Fernando Lescano; same symptom was internally recorded on 2026-07-15.

  ## What changed

  - **`scripts/portal_generator/templates/base.html`** — rewrote the machine-readable nav in declarative, third-person voice. The block still exists (screen-readers, crawlers, and
  body-scanning agents still discover the three resources), but it now *describes* what each file contains instead of *instructing* the reader:
    - `<p>` describes the three resources and notes they are served as raw text/JSON.
    - Each `<a>` uses `filename — Description` format (no imperatives, no "Fetch/Read/STOP/MANDATORY", no `If you are an AI…` targeting).
  - **`<head>` `<link rel="help">` / `rel="llms-txt"` / `rel="alternate">` discovery hints preserved.** `/AGENTS.md`, `/registry.json`, `/llms.txt` are unchanged.

  ## Why not just delete the block

  The nav has legitimate purposes — screen-reader announcement, alternate discovery path for crawlers/agents that scan `<body>` and ignore `<head>`. Deleting it would drop that
  affordance. Neutralizing the text keeps the discovery intent while removing the prompt-injection signals.

  ## Tests

  Added `TestNoPromptInjectionTriggers` in `scripts/tests/test_smoke.py` (7 tests):
  - 5 forbidden-phrase sweeps: homepage, API detail, MCP detail, skill pages, and a repo-wide `*.html` sweep — guards against reintroduction of the specific triggers (`STOP.`, `MANDATORY
  first read`, `If you are an AI agent`, `Do NOT use summarizer`, `read AGENTS.md FIRST`).
  - 2 structural asserts on the machine-readable nav: exactly 3 anchors whose text starts with the target filename, and at most one `<p>` (any descriptive paragraph must remain
  declarative).

  ## Verification

  - `make test-portal` → 614 pytest + 303 jest, all pass.
  - `make generate-portal` succeeds. Regenerated `portal/` HTML no longer contains any of the forbidden phrases in files produced by `base.html`.
  - Manual: browse a served portal page with Claude Code (automode) and confirm the prompt-injection warning no longer surfaces.

  Fixes W-23515831.