### PR TITLE
Migrate release workflow tag based

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - master
-      - 'release/**'
       - 'poc/**'
   pull_request:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 # Disable concurrent builds
 concurrency:
@@ -22,8 +22,25 @@ concurrency:
 # https://github.com/marketplace/actions/slack-send
 
 jobs:
+  validate-tag:
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Check tag matches semver
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "Tag '$TAG' is not a valid semver tag (expected vX.Y.Z or vX.Y.Z-suffix)" >&2
+            exit 1
+          fi
+          echo "Tag '$TAG' is valid semver"
+
   test-portal-generator:
     name: Test Portal Generator
+    needs: validate-tag
+    if: always() && (needs.validate-tag.result == 'success' || needs.validate-tag.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:
@@ -235,8 +252,8 @@ jobs:
     name: Deploy to Production
     needs: validate-specs
     runs-on: ubuntu-latest
-    # Only run on release branches (release/*)
-    if: startsWith(github.ref, 'refs/heads/release/')
+    # Only run against a release tag (vX.Y.Z), dispatched manually via workflow_dispatch
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: production
       url: https://dev-portal.mulesoft.com
@@ -284,11 +301,11 @@ jobs:
 
   notify-on-failure:
     name: Notify on Failure
-    needs: [test-portal-generator, generate-portal, validate-specs, deploy-to-test, deploy-to-production]
+    needs: [validate-tag, test-portal-generator, generate-portal, validate-specs, deploy-to-test, deploy-to-production]
     runs-on: ubuntu-latest
     if: |
       failure() &&
-      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/'))
+      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
 
     steps:
       - name: Send Slack notification


### PR DESCRIPTION
Migrate release deploy trigger from release/** branch push to manual tag-based dispatch

  Replaces the branch-based production release trigger (push to release/**) with a manual, tag-based one. Production deploys are no longer triggered automatically by any push — instead, an operator runs the workflow manually from the Actions UI ("Run workflow") against
  a semver tag (e.g. v1.2.3), which a new validate-tag job verifies before the pipeline proceeds.

  Changes:
  - Removed 'release/**' from the push trigger; added workflow_dispatch
  - Added validate-tag job — validates the dispatched ref is strict semver (vX.Y.Z[-suffix]) before test-portal-generator runs
  - deploy-to-production now gates on refs/tags/ instead of refs/heads/release/
  - notify-on-failure updated to cover tag-based runs and the new validate-tag job (so an invalid-tag dispatch still notifies Slack)