### PR TITLE
Operation ids and summary

### DIFF
--- a/apis/access-management/api.yaml
+++ b/apis/access-management/api.yaml
@@ -111,6 +111,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Authorize a resource
       operationId: listAuthorize
     post:
       description: Authorize for many resources
@@ -183,6 +184,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Authorize multiple resources
       operationId: createAuthorize
   /authorize/client:
     get:
@@ -280,6 +282,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Authorize a client for a resource
       operationId: listAuthorizeClient
       description: Authorizes a client application for access to a specific resource
         using client credentials.
@@ -342,6 +345,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List contexts allowed for an action
       operationId: createAuthorizeContext
   /clients:
     description: 'Access to clients
@@ -668,6 +672,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List clients
       operationId: listClients
     post:
       description: Create a new client
@@ -752,6 +757,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a client
       operationId: createClients
   /clients/{clientId}:
     description: 'Access to a client
@@ -842,6 +848,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a client
       operationId: getClients
     patch:
       description: 'Patches a single client
@@ -885,6 +892,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a client
       operationId: updateClients
     delete:
       description: 'Deletes a single client
@@ -922,6 +930,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a client
       operationId: deleteClients
   /clients/{clientId}/roles:
     description: Access to a client's roles
@@ -994,6 +1003,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List roles assigned to a client
       operationId: listClientsRoles
     post:
       description: Assign a list of roles to a client
@@ -1027,6 +1037,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign roles to a client
       operationId: createClientsRoles
     delete:
       description: Unassign a list of roles from a client
@@ -1060,6 +1071,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign roles from a client
       operationId: deleteClientsRoles
   /clients/{clientId}/roles/{roleId}:
     get:
@@ -1132,6 +1144,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a role assigned to a client
       operationId: getClientsRoles
     post:
       description: Assign a role to a client
@@ -1166,6 +1179,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a role to a client
       operationId: createClientRole
     delete:
       description: Unassign a role from a client
@@ -1198,6 +1212,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign a role from a client
       operationId: deleteClientRole
   /clients/search:
     post:
@@ -1345,6 +1360,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Search clients
       operationId: createClientsSearch
   /connectedApplications:
     description: Access to connected applications
@@ -1561,6 +1577,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List connected applications
       operationId: listConnectedApplications
     post:
       description: Create a new connected application
@@ -1667,6 +1684,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a connected application
       operationId: createConnectedApplications
   /connectedApplications/{clientId}:
     description: Access to individual connected application
@@ -1784,6 +1802,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a connected application
       operationId: getConnectedApplications
     patch:
       description: Patches a single connected application
@@ -1900,6 +1919,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a connected application
       operationId: updateConnectedApplications
     delete:
       description: Deletes a single connected application
@@ -1929,6 +1949,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a connected application
       operationId: deleteConnectedApplications
   /connectedApplications/{clientId}/scopes:
     description: 'Routes for operationg upon context-aware scopes assigned directly
@@ -2031,6 +2052,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List connected app scopes
       operationId: listConnectedApplicationsScopes
     put:
       description: Replaces the entire list of context-aware scopes assigned to the
@@ -2063,6 +2085,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Replace connected app scopes
       operationId: updateConnectedApplicationsScopes
     patch:
       description: 'Assigns additional context-aware scopes to the connected application.
@@ -2100,6 +2123,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Add scopes to connected app
       operationId: updateConnectedApplicationScopes
     delete:
       description: 'Unassigns context-aware scopes from the connected application.
@@ -2135,6 +2159,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove scopes from connected app
       operationId: deleteConnectedApplicationsScopes
   /connectedApplications/{clientId}/revoke:
     delete:
@@ -2166,6 +2191,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Revoke connected app tokens
       operationId: deleteConnectedApplicationsRevoke
   /deletedResources:
     description: find deleted resources
@@ -2301,6 +2327,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List deleted organizations
       operationId: listDeletedResources
   /deletedResources/environments:
     get:
@@ -2423,6 +2450,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List deleted environments
       operationId: listDeletedResourcesEnvironments
   /environments:
     description: Environments resource
@@ -2497,6 +2525,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an environment
       operationId: getEnvironments
     put:
       description: Update an environment, implemented as a patch. Note that only the
@@ -2589,6 +2618,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an environment
       operationId: updateEnvironments
   /featureFlags/{featureFlagName}:
     parameters:
@@ -2637,6 +2667,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Check feature flag for organizations
       operationId: createFeatureFlagsCheck
   /featureFlags/{featureFlagName}/enabled:
     get:
@@ -2671,6 +2702,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List enabled feature flags
       operationId: listFeatureFlagsEnabled
   /invites:
     description: Invite people to join the organization
@@ -2809,6 +2841,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List invites
       operationId: listInvites
     post:
       description: Invite a person to join the organization
@@ -2845,6 +2878,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Invite a user to the organization
       operationId: createInvites
     delete:
       description: Invite a person to join your organization
@@ -2877,6 +2911,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete invites
       operationId: deleteInvites
   /invites/{inviteId}:
     description: Invite resource
@@ -2922,6 +2957,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an invite
       operationId: getInvites
   /invites/accept:
     get:
@@ -2948,6 +2984,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Redirect to accept invite
       operationId: listInvitesAccept
   /invites/resend:
     description: Resend invites
@@ -2987,6 +3024,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Resend invites
       operationId: createInvitesResend
   /login:
     description: login to the Anypoint Platform
@@ -3079,6 +3117,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Log in to Anypoint Platform
       operationId: createLogin
   /logout:
     description: logout of the Anypoint Platform
@@ -3111,6 +3150,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Log out of Anypoint Platform
       operationId: listLogout
   /me:
     description: all about the caller
@@ -4629,6 +4669,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get caller information
       operationId: listMe
   /notifications:
     description: Make Anypoint Platform activity known to subscribers; think webhooks.
@@ -4736,6 +4777,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a notification
       operationId: createNotifications
   /oauth2:
     description: oauth 2 routes
@@ -4802,6 +4844,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Start OAuth2 authorization
       operationId: listOauth2Authorize
   /oauth2/authorize/{domain}:
     description: OAuth2 authorization route for federated or non-federated users
@@ -4873,6 +4916,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Start OAuth2 authorization for domain
       operationId: listOauth2AuthorizeByDomain
   /oauth2/authorize/{domain}/providers:
     parameters:
@@ -4942,6 +4986,7 @@ paths:
           description: Bad request; an invalid redirect_uri, response_type or client_id
       security:
       - {}
+      summary: Authorize via identity provider
       operationId: getOauth2AuthorizeProviders
   /oauth2/decision: {}
   /oauth2/decision/{domain}:
@@ -4962,6 +5007,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Record OAuth2 consent decision
       operationId: createOauth2Decision
   /oauth2/introspect:
     description: Look up caller information from an access token
@@ -5049,6 +5095,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Introspect an OAuth2 token
       operationId: createOauth2Introspect
   /oauth2/token:
     description: OAuth2 token resource
@@ -5115,6 +5162,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create or retrieve OAuth2 token
       operationId: createOauth2Token
   /organizationname/{organizationName}:
     get:
@@ -5152,6 +5200,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Check organization name availability
       operationId: getOrganizationname
   /organizations:
     description: Organizations Resource
@@ -6517,6 +6566,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization
       operationId: getOrganizations
     put:
       description: Updates the referenced organization
@@ -8287,6 +8337,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an organization
       operationId: updateOrganizations
     delete:
       description: Deletes the referenced organization
@@ -8318,6 +8369,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an organization
       operationId: deleteOrganizations
   /organizations/{organizationId}/clientProviders:
     get:
@@ -8433,6 +8485,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List client management providers
       operationId: listClientProviders
     post:
       description: Adds a new client management provider for the organization. This
@@ -8473,6 +8526,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a client management provider
       operationId: createClientProviders
   /organizations/{organizationId}/clientProviders/{clientProviderId}:
     get:
@@ -8522,6 +8576,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a client management provider
       operationId: getClientProviders
     put:
       description: Replaces the associated client management provider config
@@ -8562,6 +8617,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Replace a client management provider
       operationId: updateClientProviders
     patch:
       description: Updates the associated client management provider config
@@ -8615,6 +8671,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Patch a client management provider
       operationId: updateOrganizationClientProvider
     delete:
       description: Deletes the associated client management provider
@@ -8651,6 +8708,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a client management provider
       operationId: deleteClientProviders
   /organizations/{organizationId}/clientProviders/{clientProviderId}/grantTypes:
     get:
@@ -8688,6 +8746,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List provider grant types
       operationId: listClientProvidersGrantTypes
   /organizations/{organizationId}/clientProviders/{clientProviderId}/clients:
     get:
@@ -8843,6 +8902,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List provider clients
       operationId: listClientProvidersClients
     post:
       description: Adds a new client using the Client Management Provider
@@ -8883,6 +8943,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a provider client
       operationId: createClientProvidersClients
   /organizations/{organizationId}/clientProviders/{clientProviderId}/clients/{clientId}:
     get:
@@ -8975,6 +9036,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a provider client
       operationId: getClientProvidersClients
     patch:
       description: Updates the associated client
@@ -9032,6 +9094,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a provider client
       operationId: updateClientProvidersClients
     delete:
       description: Deletes the associated client
@@ -9079,6 +9142,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a provider client
       operationId: deleteClientProvidersClients
   /organizations/{organizationId}/clients:
     description: Access to clients
@@ -9403,6 +9467,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization clients
       operationId: listOrganizationClients
     post:
       description: Create a new client
@@ -9489,6 +9554,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an organization client
       operationId: createOrganizationClient
   /organizations/{organizationId}/clients/{clientId}:
     description: Access to a client
@@ -9576,6 +9642,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization client
       operationId: getOrganizationClient
     patch:
       description: Patches a single client
@@ -9618,6 +9685,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an organization client
       operationId: updateOrganizationClient
     delete:
       description: Deletes a single client
@@ -9654,6 +9722,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an organization client
       operationId: deleteOrganizationClient
   /organizations/{organizationId}/clients/{clientId}/roles:
     description: Access to a client's roles
@@ -9690,6 +9759,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign roles to an org client
       operationId: createOrganizationClientRole
     delete:
       description: Unassign a list of roles from a client
@@ -9724,6 +9794,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign roles from an org client
       operationId: deleteOrganizationClientRoles
   /organizations/{organizationId}/clients/{clientId}/roles/{roleId}:
     post:
@@ -9765,6 +9836,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a role to an org client
       operationId: createOrganizationClientRoleById
     delete:
       description: 'Unassign a role from a client
@@ -9805,6 +9877,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign a role from an org client
       operationId: deleteOrganizationClientRole
   /organizations/{organizationId}/clients/search:
     post:
@@ -9941,6 +10014,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Search organization clients
       operationId: createOrganizationClientsSearch
   /organizations/{organizationId}/clients/validate:
     post:
@@ -10033,6 +10107,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Validate organization clients
       operationId: createClientsValidate
   /organizations/{organizationId}/connectedApplications:
     description: Access to connected applications
@@ -10250,6 +10325,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List org connected applications
       operationId: listOrganizationConnectedApplications
     post:
       description: Create a new connected application
@@ -10358,6 +10434,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an org connected application
       operationId: createOrganizationConnectedApplication
   /organizations/{organizationId}/connectedApplications/{clientId}:
     description: Access to individual connected application
@@ -10476,6 +10553,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an org connected application
       operationId: getOrganizationConnectedApplication
     patch:
       description: Patches a single connected application
@@ -10594,6 +10672,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an org connected application
       operationId: updateOrganizationConnectedApplication
     delete:
       description: Deletes a single connected application
@@ -10624,6 +10703,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an org connected application
       operationId: deleteOrganizationConnectedApplication
   /organizations/{organizationId}/connectedApplications/{clientId}/scopes:
     description: 'Routes for operationg upon context-aware scopes assigned directly
@@ -10727,7 +10807,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: listOrganizationConnectedApplicationScopes
+      summary: List org connected app scopes
+      operationId: listOrgConnectedAppScopes
     put:
       description: Replaces the entire list of context-aware scopes assigned to the
         connected application
@@ -10760,7 +10841,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: updateOrganizationConnectedApplicationScopes
+      summary: Replace org connected app scopes
+      operationId: replaceOrgConnectedAppScopes
     patch:
       description: 'Assigns additional context-aware scopes to the connected application.
 
@@ -10798,7 +10880,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: replaceOrganizationConnectedApplicationScopes
+      summary: Add scopes to org connected app
+      operationId: addOrgConnectedAppScopes
     delete:
       description: 'Unassigns context-aware scopes from the connected application.
 
@@ -10834,7 +10917,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: deleteOrganizationConnectedApplicationScopes
+      summary: Remove scopes from org connected app
+      operationId: removeOrgConnectedAppScopes
   /organizations/{organizationId}/connectedApplications/{clientId}/revoke:
     delete:
       description: Revoke all access tokens and refresh tokens issued to the connected
@@ -10866,6 +10950,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Revoke org connected app tokens
       operationId: revokeOrganizationConnectedApplication
   /organizations/{organizationId}/connectedApplications/authorizations:
     description: Permissions granted to connected applications by users within the
@@ -10951,6 +11036,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List connected app authorizations
       operationId: listConnectedApplicationsAuthorizations
     delete:
       description: Revoke all authorizations that grant rights to accessing resources
@@ -10990,7 +11076,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: deleteConnectedApplicationsAuthorizations
+      summary: Revoke all connected app authorizations
+      operationId: revokeOrgConnectedAppAuths
   /organizations/{organizationId}/connectedApplications/authorizations/{authorizationId}:
     get:
       description: Returns a single authorization
@@ -11031,6 +11118,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a connected app authorization
       operationId: getConnectedApplicationsAuthorizations
     delete:
       description: Revokes an authorization. Only available on the root organization.
@@ -11069,7 +11157,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: deleteOrganizationConnectedApplicationAuthorization
+      summary: Revoke a connected app authorization
+      operationId: revokeOrgConnectedAppAuth
   /organizations/{organizationId}/connectedApplications/settings:
     get:
       description: Returns the organization's Connected Application settings. For
@@ -11107,6 +11196,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get connected app settings
       operationId: listConnectedApplicationsSettings
     patch:
       description: Updates the organization's connected application settings
@@ -11153,6 +11243,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update connected app settings
       operationId: updateConnectedApplicationsSettings
   /organizations/{organizationId}/connectedApplications/allowlist:
     get:
@@ -11235,6 +11326,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List connected app allowlist
       operationId: listConnectedApplicationsAllowlist
     put:
       description: Replaces the organization's Connected Application allowlist with
@@ -11272,6 +11364,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Replace connected app allowlist
       operationId: updateConnectedApplicationsAllowlist
     patch:
       description: Inserts the entries into the organization's Connected Application
@@ -11309,7 +11402,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: updateOrganizationConnectedApplicationsAllowlist
+      summary: Add entries to connected app allowlist
+      operationId: addOrgConnectedAppAllowlist
     delete:
       description: Deletes the entries from the organization's Connected Application
         allowlist
@@ -11346,6 +11440,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove entries from allowlist
       operationId: deleteConnectedApplicationsAllowlist
   /organizations/{organizationId}/connectedApplications/whitelist:
     get:
@@ -11428,6 +11523,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List connected app whitelist
       operationId: listConnectedApplicationsWhitelist
     put:
       description: Replaces the organization's Connected Application allowlist with
@@ -11465,6 +11561,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Replace connected app whitelist
       operationId: updateConnectedApplicationsWhitelist
     patch:
       description: Inserts the entries into the organization's Connected Application
@@ -11502,7 +11599,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: updateOrganizationConnectedApplicationsWhitelist
+      summary: Add entries to connected app whitelist
+      operationId: addOrgConnectedAppWhitelist
     delete:
       description: Deletes the entries from the organization's Connected Application
         allowlist
@@ -11539,6 +11637,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove entries from whitelist
       operationId: deleteConnectedApplicationsWhitelist
   /organizations/{organizationId}/entitlements:
     description: Entitlements for a given organization
@@ -11570,6 +11669,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization entitlements
       operationId: listEntitlements
   /organizations/{organizationId}/entitlements/{entitlementName}:
     description: Entitlement by name
@@ -11609,6 +11709,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an entitlement
       operationId: getEntitlements
     put:
       description: 'Update an entitlement.
@@ -11674,6 +11775,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an entitlement
       operationId: updateEntitlements
   /organizations/{organizationId}/environments:
     description: Environments from an organization
@@ -11808,6 +11910,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List environments
       operationId: listEnvironments
     post:
       description: Creates an environment
@@ -11908,6 +12011,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an environment
       operationId: createEnvironments
   /organizations/{organizationId}/environments/{environmentId}:
     description: Environment by id
@@ -11981,6 +12085,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization environment
       operationId: getOrganizationEnvironment
     put:
       description: Update an environment, implemented as a patch. Note that only the
@@ -12069,6 +12174,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an organization environment
       operationId: updateOrganizationEnvironment
     delete:
       description: Delete an environment
@@ -12101,6 +12207,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an environment
       operationId: deleteEnvironments
   /organizations/{organizationId}/environments/{environmentId}/clientManagementProviders:
     get:
@@ -12152,7 +12259,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: listEnvironmentsClientManagementProviders
+      summary: List env client management providers
+      operationId: listEnvClientProviders
     put:
       description: Upsert client providers for the environment
       parameters:
@@ -12209,7 +12317,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: updateEnvironmentsClientManagementProviders
+      summary: Upsert env client management providers
+      operationId: upsertEnvClientProviders
   /organizations/{organizationId}/featureFlags:
     get:
       description: get all feature flags of an given organization
@@ -12258,6 +12367,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization feature flags
       operationId: listFeatureFlags
   /organizations/{organizationId}/featureFlags/{featureFlagName}:
     get:
@@ -12292,6 +12402,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization feature flag
       operationId: getFeatureFlags
     post:
       description: API to upsert a feature flag.
@@ -12336,6 +12447,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Upsert an organization feature flag
       operationId: createFeatureFlags
   /organizations/{organizationId}/hierarchy:
     description: get related organizations in hierarchical structure
@@ -12807,6 +12919,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get organization business group hierarchy
       operationId: listHierarchy
   /organizations/{organizationId}/identityProviders:
     get:
@@ -12936,6 +13049,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List identity providers
       operationId: listIdentityProviders
     post:
       description: Add a new identity management provider to the root organization.
@@ -12981,6 +13095,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an identity provider
       operationId: createIdentityProviders
   /organizations/{organizationId}/identityProviders/saml-sp-metadata:
     get:
@@ -13086,6 +13201,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Download SAML SP metadata
       operationId: listIdentityProvidersSamlSpMetadata
   /organizations/{organizationId}/identityProviders/ldap-test:
     post:
@@ -13134,6 +13250,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Test LDAP identity provider config
       operationId: createIdentityProvidersLdapTest
   /organizations/{organizationId}/identityProviders/{identityProviderId}:
     get:
@@ -13179,6 +13296,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an identity provider
       operationId: getIdentityProviders
     patch:
       description: Updates the associated identity management provider config
@@ -13220,6 +13338,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an identity provider
       operationId: updateIdentityProviders
     delete:
       description: Deletes the associated identity management provider
@@ -13252,6 +13371,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an identity provider
       operationId: deleteIdentityProviders
   /organizations/{organizationId}/identityProviders/{identityProviderId}/saml-sp-keys:
     get:
@@ -13299,6 +13419,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List SAML SP keys
       operationId: listIdentityProvidersSamlSpKeys
     post:
       description: Add or generate a new SAML SP key pair
@@ -13360,6 +13481,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Add or generate a SAML SP key
       operationId: createIdentityProvidersSamlSpKeys
   /organizations/{organizationId}/identityProviders/{identityProviderId}/saml-sp-keys/{samlSpKeyId}:
     get:
@@ -13455,6 +13577,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a SAML SP key
       operationId: getIdentityProvidersSamlSpKeys
     delete:
       description: Delete the SAML SP key
@@ -13496,6 +13619,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a SAML SP key
       operationId: deleteIdentityProvidersSamlSpKeys
   /organizations/{organizationId}/identityProviders/{identityProviderId}/saml-sp-keys/{samlSpKeyId}/setPrimary:
     post:
@@ -13544,7 +13668,8 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
-      operationId: createIdentityProvidersSamlSpKeysSetPrimary
+      summary: Set primary SAML SP key
+      operationId: setPrimarySamlSpKey
   /organizations/{organizationId}/identityProviderSettings:
     get:
       description: Get the identity provider settings for the org
@@ -13563,6 +13688,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get identity provider settings
       operationId: listIdentityProviderSettings
     patch:
       description: Update the identity provider settings for the org
@@ -13585,6 +13711,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update identity provider settings
       operationId: updateIdentityProviderSettings
   /organizations/{organizationId}/invites:
     description: Invite people to join the organization
@@ -13679,6 +13806,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization invites
       operationId: listOrganizationInvites
     post:
       description: Invite a person to join the organization
@@ -13717,6 +13845,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Invite a user to the organization
       operationId: createOrganizationInvite
     delete:
       description: Invite a person to join your organization
@@ -13751,6 +13880,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete organization invites
       operationId: deleteOrganizationInvites
   /organizations/{organizationId}/invites/{inviteId}:
     description: Invite resource
@@ -13797,6 +13927,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization invite
       operationId: getOrganizationInvite
   /organizations/{organizationId}/invites/resend:
     description: Resend invites
@@ -13838,6 +13969,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Resend organization invites
       operationId: resendOrganizationInvite
   /organizations/{organizationId}/members:
     description: Organization membership
@@ -14010,6 +14142,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization members
       operationId: listMembers
     put:
       description: Add a group of users to the organization by their IDs
@@ -14045,6 +14178,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Add users to organization
       operationId: updateMembers
     delete:
       description: Remove a group of users from the organization by their IDs
@@ -14080,6 +14214,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove users from organization
       operationId: deleteMembers
   /organizations/{organizationId}/members/{userId}:
     put:
@@ -14117,6 +14252,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Add a user to organization
       operationId: updateOrganizationMember
     delete:
       description: Remove the user from the organization
@@ -14153,6 +14289,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove a user from organization
       operationId: deleteOrganizationMember
   /organizations/{organizationId}/owner:
     description: Resource for owner of an organization
@@ -14269,6 +14406,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get organization owner
       operationId: listOwner
   /organizations/{organizationId}/owner/{userId}:
     description: Endpoint to switch organization owner to the one specified by userId
@@ -14398,6 +14536,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Change organization owner
       operationId: updateOwner
   /organizations/{organizationId}/provider:
     parameters:
@@ -14539,6 +14678,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get organization identity provider
       operationId: listProviderUsers
     put:
       description: Updates the identity provider for the organization
@@ -14575,6 +14715,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update organization identity provider
       operationId: updateProviderUsers
     delete:
       description: Revert to using the default identity provider
@@ -14604,6 +14745,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Reset organization identity provider
       operationId: deleteProviderUsers
   /organizations/{organizationId}/provider/users/ldap/test:
     post:
@@ -14641,6 +14783,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Test LDAP provider configuration
       operationId: createLdapTest
   /organizations/{organizationId}/provider/users/saml-sp-metadata:
     get:
@@ -14737,6 +14880,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Download organization SAML SP metadata
       operationId: listProviderUsersSamlSpMetadata
   /organizations/{organizationId}/proxyusers/{userId}:
     description: Creates a proxy user in an organization
@@ -14843,6 +14987,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an organization proxy user
       operationId: createProxyusers
   /organizations/{organizationId}/rolegroups:
     description: Role groups that belong to this organization
@@ -14933,6 +15078,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List role groups
       operationId: listRolegroups
     post:
       description: Creates a role group for this org
@@ -15056,6 +15202,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a role group
       operationId: createRolegroups
     delete:
       description: Deletes role groups that belong to this organization
@@ -15087,6 +15234,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete role groups
       operationId: deleteRolegroups
   /organizations/{organizationId}/rolegroups/{roleGroupId}:
     get:
@@ -15178,6 +15326,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a role group
       operationId: getRolegroups
     put:
       description: Updates a role group
@@ -15268,6 +15417,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a role group
       operationId: updateRolegroups
     delete:
       description: Deletes a role group
@@ -15298,6 +15448,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a role group
       operationId: deleteOrganizationRolegroup
   /organizations/{organizationId}/rolegroups/{roleGroupId}/roles:
     description: Roles assigned to this role group
@@ -15431,6 +15582,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List roles in a role group
       operationId: listRolegroupsRoles
     post:
       description: Assigns roles to this role group
@@ -15463,6 +15615,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign roles to a role group
       operationId: createRolegroupsRoles
     delete:
       description: Removes roles from this role group
@@ -15495,6 +15648,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign roles from a role group
       operationId: deleteRolegroupsRoles
   /organizations/{organizationId}/rolegroups/{roleGroupId}/users:
     description: Users assigned to this role group
@@ -15598,6 +15752,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List users in a role group
       operationId: listRolegroupsUsers
     post:
       description: Assigns a group of users to this role group
@@ -15630,6 +15785,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign users to a role group
       operationId: createRolegroupsUsers
     delete:
       description: Unassigns a group of users from this role group
@@ -15664,6 +15820,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign users from a role group
       operationId: deleteRolegroupsUsers
   /organizations/{organizationId}/rolegroups/{roleGroupId}/users/{userId}:
     post:
@@ -15696,6 +15853,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a user to a role group
       operationId: addUserToOrganizationRolegroup
     delete:
       description: Removes this user from the role group
@@ -15727,6 +15885,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove a user from a role group
       operationId: removeUserFromOrganizationRolegroup
   /organizations/{organizationId}/roles:
     description: Roles by organization
@@ -15778,6 +15937,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete role assignments
       operationId: deleteRoles
   /organizations/{organizationId}/smtp:
     description: SMTP information for the organization
@@ -15859,6 +16019,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get organization SMTP settings
       operationId: listSmtp
     put:
       description: Updates the SMTP details
@@ -15940,6 +16101,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update organization SMTP settings
       operationId: updateSmtp
   /organizations/{organizationId}/teams:
     description: Teams are groups of users and/or other teams
@@ -16087,6 +16249,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List teams
       operationId: listTeams
     post:
       description: Creates a new team.
@@ -16131,6 +16294,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a team
       operationId: createTeams
   /organizations/{organizationId}/teams/{teamId}:
     get:
@@ -16167,6 +16331,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a team
       operationId: getTeams
     patch:
       description: Update or move the team
@@ -16219,6 +16384,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a team
       operationId: updateTeams
     delete:
       description: Delete the team, including all child teams.
@@ -16249,6 +16415,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a team
       operationId: deleteTeams
   /organizations/{organizationId}/teams/{teamId}/parent:
     put:
@@ -16298,6 +16465,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Move a team under a new parent
       operationId: updateTeamsParent
   /organizations/{organizationId}/teams/{teamId}/groupmappings:
     description: 'group access mappings configure how memberships in external groups
@@ -16410,6 +16578,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List team group mappings
       operationId: listTeamsGroupmappings
     put:
       description: |
@@ -16445,6 +16614,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Replace team group mappings
       operationId: updateTeamsGroupmappings
     patch:
       description: |
@@ -16480,6 +16650,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk add team group mappings
       operationId: updateOrganizationTeamGroupmappings
     delete:
       description: |
@@ -16515,6 +16686,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk remove team group mappings
       operationId: deleteTeamsGroupmappings
   /organizations/{organizationId}/teams/{teamId}/roles:
     description: roles assigned to the team. All members of the team receive these
@@ -16610,6 +16782,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List team role assignments
       operationId: listTeamsRoles
     post:
       description: bulk assign roles to the team
@@ -16644,6 +16817,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk assign roles to a team
       operationId: createTeamsRoles
     delete:
       description: bulk unassign roles from the team
@@ -16678,6 +16852,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk unassign roles from a team
       operationId: deleteTeamsRoles
   /organizations/{organizationId}/teams/{teamId}/members:
     description: members of teams can be users or other teams
@@ -16823,6 +16998,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List team members
       operationId: listTeamsMembers
     patch:
       description: bulk add users and/or modify users' membership_type to the team.
@@ -16864,6 +17040,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk add team members
       operationId: updateTeamsMembers
     delete:
       description: bulk remove user members from the team
@@ -16904,6 +17081,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk remove team members
       operationId: deleteTeamsMembers
   /organizations/{organizationId}/teams/{teamId}/members/{userId}:
     put:
@@ -16946,6 +17124,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Add a user to a team
       operationId: updateOrganizationTeamMember
     delete:
       description: remove the user from the team.
@@ -16980,6 +17159,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove a user from a team
       operationId: removeOrganizationTeamMember
   /organizations/{organizationId}/tenantRelationships:
     get:
@@ -17113,6 +17293,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List tenant relationships
       operationId: listTenantRelationships
     post:
       description: Establish manual tenant relationships
@@ -17154,6 +17335,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a tenant relationship
       operationId: createTenantRelationships
   /organizations/{organizationId}/tenantRelationships/{relationshipId}:
     get:
@@ -17185,6 +17367,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a tenant relationship
       operationId: getTenantRelationships
     patch:
       description: Patch update a particular Tenant Relationship by ID
@@ -17222,6 +17405,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a tenant relationship
       operationId: updateTenantRelationships
     delete:
       description: Delete a particular Tenant Relationship by ID
@@ -17247,6 +17431,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a tenant relationship
       operationId: deleteTenantRelationships
   /organizations/{organizationId}/tenantRelationships/{relationshipId}/repair:
     patch:
@@ -17294,6 +17479,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Repair a tenant relationship
       operationId: updateTenantRelationshipsRepair
   /organizations/{organizationId}/myTenantRelationship:
     parameters:
@@ -17365,6 +17551,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update tenant relationship status
       operationId: updateMyTenantRelationshipStatus
   /organizations/{organizationId}/myTenantRelationship/assignments:
     get:
@@ -17449,6 +17636,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List tenant relationship assignments
       operationId: listMyTenantRelationshipAssignments
   /organizations/{organizationId}/users:
     description: Users that belong to the organization
@@ -18693,6 +18881,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List organization users
       operationId: listUsers
     post:
       description: Create a single user under the organization
@@ -18768,6 +18957,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create an organization user
       operationId: createUsers
     put:
       description: Update a group of users
@@ -18804,6 +18994,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update organization users
       operationId: updateUsers
     delete:
       description: Deletes a group of users
@@ -18837,6 +19028,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete organization users
       operationId: deleteUsers
   /organizations/{organizationId}/users/{userId}:
     description: A single user that belongs to the organization
@@ -20046,6 +20238,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get an organization user
       operationId: getUsers
     put:
       description: Updates a single user. Modifying email may require reauthentication.
@@ -21280,6 +21473,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update an organization user
       operationId: updateOrganizationUser
     delete:
       description: Deletes a user
@@ -21312,6 +21506,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete an organization user
       operationId: deleteOrganizationUser
   /organizations/{organizationId}/users/{userId}/manage_verifiers:
     get:
@@ -21331,6 +21526,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get user verifier management redirect
       operationId: listUsersManageVerifiers
   /organizations/{organizationId}/users/{userId}/properties:
     description: A user's properties.
@@ -21385,6 +21581,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update user directory properties
       operationId: updateUsersProperties
       description: Updates an existing users properties in the platform user directory.
   /organizations/{organizationId}/users/{userId}/rolegroups:
@@ -21468,6 +21665,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List user role groups
       operationId: listUsersRolegroups
   /organizations/{organizationId}/users/{userId}/rolegroups/{roleGroupId}:
     description: A single role group assigned to the user
@@ -21501,6 +21699,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a role group to a user
       operationId: createUsersRolegroups
     delete:
       description: Unassigns the role group from the user
@@ -21532,6 +21731,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign a role group from a user
       operationId: deleteUsersRolegroups
   /organizations/{organizationId}/users/{userId}/roles:
     description: Roles/permissions assigned to the user
@@ -21665,6 +21865,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List user roles
       operationId: listUsersRoles
     post:
       description: Bulk assign roles to the user
@@ -21718,6 +21919,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Bulk assign roles to a user
       operationId: createUsersRoles
   /organizations/{organizationId}/users/{userId}/roles/{roleId}:
     post:
@@ -21752,6 +21954,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a role to a user
       operationId: addRoleToOrganizationUser
     delete:
       description: Unassign a role from the user
@@ -21785,6 +21988,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign a role from a user
       operationId: deleteUsersRoles
   /organizations/{organizationId}/users/{userId}/teams:
     get:
@@ -21925,6 +22129,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List user teams
       operationId: listUsersTeams
   /organizations/{organizationId}/users/{userId}/verifiers:
     delete:
@@ -21940,6 +22145,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Revoke user MFA verifiers
       operationId: deleteUsersVerifiers
   /organizations/{organizationId}/users/{userId}/identityProviderProfiles:
     get:
@@ -22030,6 +22236,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List user identity provider profiles
       operationId: listUsersIdentityProviderProfiles
     delete:
       description: Removes an identity provider profile from a user
@@ -22082,6 +22289,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Remove a user identity provider profile
       operationId: deleteUsersIdentityProviderProfiles
   /profile:
     get:
@@ -23721,6 +23929,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get user profile for access token
       operationId: listProfile
   /recover:
     description: recover user's account
@@ -23775,6 +23984,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Send password reset email
       operationId: createRecoverPassword
   /recover/password/{recoverCode}:
     description: reset password
@@ -23821,6 +24031,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Check password reset code
       operationId: listRecoverPassword
     post:
       description: Sets a new password for the user associated with the password reset
@@ -23889,6 +24100,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Reset password with reset code
       operationId: createRecoverPasswordByCode
   /recover/username:
     post:
@@ -23933,6 +24145,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Send username recovery email
       operationId: createRecoverUsername
   /roles:
     description: Roles resource
@@ -24101,6 +24314,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List roles
       operationId: listRoles
   /roles/{roleId}:
     description: A single role
@@ -24132,6 +24346,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a role
       operationId: getRoles
   /roles/{roleId}/users:
     description: Users by role
@@ -24179,6 +24394,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List users assigned to a role
       operationId: listRolesUsers
   /roles/{roleId}/permissions:
     description: Permissions by a single role
@@ -24224,6 +24440,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List permissions assigned to a role
       operationId: listRolesPermissions
   /roles/rolegroups: {}
   /roles/rolegroups/search:
@@ -24365,6 +24582,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Search role groups by role
       operationId: createRolesRolegroupsSearch
   /roles/teams:
     description: Teams by role
@@ -24562,6 +24780,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Search teams by role assignments
       operationId: createRolesTeamsSearch
   /roles/users:
     description: Users by role
@@ -24735,6 +24954,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List users across role assignments
       operationId: listAllRolesUsers
   /roles/users/search:
     description: Search users by role assignments
@@ -25015,6 +25235,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Search users by role assignments
       operationId: createRolesUsersSearch
   /session:
     description: The session associated with the caller
@@ -25085,6 +25306,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get session timeout metadata
       operationId: listSession
     post:
       description: Extend the session timeout time
@@ -25112,6 +25334,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Extend the session timeout
       operationId: createSession
   /signup:
     description: Signup for the Anypoint Platform
@@ -25202,6 +25425,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Get invite signup metadata
       operationId: listSignup
     post:
       description: "Creates a new user and organization, or accepts an invite to join\
@@ -26449,6 +26673,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Create user via signup or invite
       operationId: createSignup
   /signup/existingUser:
     description: Information about signing up (accepting an invite) with an existing
@@ -27511,6 +27736,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Accept invite as existing user
       operationId: createSignupExistingUser
   /status:
     description: Application healthcheck, used by the load balancer to detect the
@@ -27620,6 +27846,7 @@ paths:
                 - status
       security:
       - {}
+      summary: Get application health status
       operationId: listStatus
   /subscriptions:
     description: Subscriptions
@@ -27684,6 +27911,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List supported subscriptions
       operationId: listSubscriptions
   /support:
     description: Support portal
@@ -27717,6 +27945,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Redirect to support portal
       operationId: listSupport
   /username/{username}:
     get:
@@ -27754,6 +27983,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Check username availability
       operationId: getUsername
   /users:
     description: Users Resource
@@ -28988,6 +29218,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List all users
       operationId: listAllUsers
     post:
       description: Creates new users
@@ -29015,6 +29246,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create a user
       operationId: createUser
     put:
       description: Update a group of users
@@ -29046,6 +29278,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update multiple users
       operationId: updateAllUsers
     delete:
       description: Delete a group of users
@@ -29075,6 +29308,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete multiple users
       operationId: deleteAllUsers
   /users/{userId}:
     description: A single user
@@ -30283,6 +30517,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a user by ID
       operationId: getUserById
     put:
       description: Updates a single user. Modifying email may require reauthentication.
@@ -30341,6 +30576,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update a user by ID
       operationId: updateUserById
     delete:
       description: Deletes a user
@@ -30370,6 +30606,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a user by ID
       operationId: deleteUserById
   /users/{userId}/banpassword:
     description: Ban a user's current password
@@ -30403,6 +30640,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Ban a user password
       operationId: createUsersBanpassword
   /users/{userId}/properties:
     description: Properties of a user
@@ -30457,6 +30695,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update user properties
       operationId: updateUserProperties
   /users/{userId}/roles:
     description: Roles assigned to the user
@@ -30582,6 +30821,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List roles assigned to a user
       operationId: listAllUserRoles
   /users/{userId}/roles/{roleId}:
     description: A role assigned to the user
@@ -30614,6 +30854,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Assign a role to a user
       operationId: addRoleToUser
     delete:
       description: Unassign a role from the user
@@ -30644,6 +30885,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Unassign a role from a user
       operationId: removeRoleFromUser
   /users/me:
     get:
@@ -31849,6 +32091,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get user for access token
       operationId: listUsersMe
   /version:
     description: Application version
@@ -31915,6 +32158,7 @@ paths:
                 type: number
       security:
       - {}
+      summary: Get application version info
       operationId: listVersion
   /v2: {}
   /v2/oauth2: {}
@@ -31992,6 +32236,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Start v2 OAuth2 authorization
       operationId: listV2Oauth2Authorize
     post:
       description: Starts an OAuth2 authorization flow; allows the logged-in user
@@ -32029,6 +32274,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Post v2 OAuth2 authorization
       operationId: createV2Oauth2Authorize
   /v2/oauth2/authorize/{domain}:
     description: OAuth2 authorization route for federated or non-federated users
@@ -32112,6 +32358,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Start v2 OAuth2 flow by domain
       operationId: listV2Oauth2AuthorizeByDomain
     post:
       description: Starts an OAuth2 authorization flow; allows the logged-in user
@@ -32157,6 +32404,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Post v2 OAuth2 flow by domain
       operationId: createV2Oauth2AuthorizeByDomain
   /v2/oauth2/decision:
     post:
@@ -32167,6 +32415,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Record v2 OAuth2 consent decision
       operationId: createV2Oauth2Decision
   /v2/oauth2/token:
     post:
@@ -32178,6 +32427,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Create v2 OAuth2 token
       operationId: createV2Oauth2Token
   /v2/oauth2/keys:
     get:
@@ -32213,6 +32463,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get v2 OAuth2 public JWK set
       operationId: listV2Oauth2Keys
   /v2/oauth2/.well-known/openid-configuration:
     get:
@@ -32247,6 +32498,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get OpenID Connect configuration
       operationId: getOpenidConfiguration
   /v2/oauth2/userinfo:
     get:
@@ -32280,6 +32532,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get v2 OpenID Connect userinfo
       operationId: listV2Oauth2Userinfo
     post:
       description: OpenID Connect Userinfo endpoint.
@@ -32312,6 +32565,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Post v2 OpenID Connect userinfo
       operationId: createV2Oauth2Userinfo
   /v2/oauth2/introspect:
     post:
@@ -32341,6 +32595,7 @@ paths:
           description: ''
       security:
       - basic: []
+      summary: Introspect v2 OAuth2 token
       operationId: createV2Oauth2Introspect
   /v2/oauth2/revoke:
     post:
@@ -32389,6 +32644,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Revoke v2 OAuth2 token
       operationId: createV2Oauth2Revoke
   /v2/organizations:
     description: Organizations
@@ -32433,6 +32689,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get v2 organization
       operationId: getV2Organization
       description: Retrieves details of v2.
     delete:
@@ -32468,6 +32725,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete v2 organization
       operationId: deleteV2Organization
       description: Deletes an existing v2.
   /v2/organizations/{organizationId}/einstein:
@@ -32516,6 +32774,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get org Einstein status
       operationId: listV2EinsteinStatus
     put:
       description: Set the org-wide Einstein status
@@ -32552,6 +32811,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Set org Einstein status
       operationId: updateV2EinsteinStatus
   /v2/organizations/{organizationId}/einstein/termsAndConditions:
     get:
@@ -32596,6 +32856,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get Einstein terms and conditions status
       operationId: listV2EinsteinTermsAndConditions
     put:
       description: Toggle the agreement status for einstein terms and conditions
@@ -32632,6 +32893,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Set Einstein terms and conditions status
       operationId: updateV2EinsteinTermsAndConditions
   /v2/organizations/{organizationId}/entitlements:
     get:
@@ -32817,6 +33079,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List v2 entitlements
       operationId: listV2Entitlements
       description: Retrieves a list of v2 entitlements.
     put:
@@ -33030,6 +33293,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Update v2 entitlements
       operationId: updateV2Entitlements
   /v2/organizations/{organizationId}/entitlements/{entitlementName}:
     get:
@@ -33075,6 +33339,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Get a v2 entitlement
       operationId: getV2Entitlements
   /v2/organizations/{organizationId}/environments:
     parameters:
@@ -33121,6 +33386,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: Delete a v2 environment
       operationId: deleteV2Environments
   /v2/roles: {}
   /v2/roles/users:
@@ -33295,6 +33561,7 @@ paths:
       security:
       - bearerAuth: []
       - clientAuth: []
+      summary: List v2 users by role
       operationId: listV2RolesUsers
 components:
   requestBodies:

--- a/apis/amc-application-manager/api.yaml
+++ b/apis/amc-application-manager/api.yaml
@@ -97,7 +97,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlowname
+      summary: Update scheduler configuration
+      operationId: updateScheduler
     delete:
       tags:
       - Schedulers
@@ -152,7 +153,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlowname
+      summary: Reset scheduler to default
+      operationId: resetScheduler
   /organizations/{organizationId}/environments/{environmentId}/deployments:
     get:
       tags:
@@ -193,7 +195,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeployments
+      summary: List deployments
+      operationId: listDeployments
     post:
       tags:
       - Deployments
@@ -252,7 +255,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeployments
+      summary: Deploy a new application
+      operationId: createDeployment
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/schedulers/{flowName}/run:
     post:
       tags:
@@ -307,12 +311,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulersByFlownameRun
+      summary: Run scheduler immediately
+      operationId: runScheduler
   /organizations/{organizationId}/environments/{environmentId}/alerts:
     get:
       tags:
       - Alerts
-      summary: Retrieves Cloudhub 2.0 alerts
+      summary: List CloudHub 2.0 alerts
       parameters:
       - name: Authorization
         in: header
@@ -353,12 +358,12 @@ paths:
                 data:
                 - id: string
                   type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlerts
+      operationId: listAlerts
       description: Retrieves Cloudhub 2.0 alerts
     post:
       tags:
       - Alerts
-      summary: Creates a Cloudhub 2.0 alert
+      summary: Create CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -430,7 +435,7 @@ paths:
                 createdAt: 0
                 isSystem: true
                 productName: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlerts
+      operationId: createAlert
       description: Creates a Cloudhub 2.0 alert
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}:
     get:
@@ -514,7 +519,8 @@ paths:
                 - id: string
                   type: string
                 lastSuccessfulVersion: 0ef171b6-aad1-459b-8720-10c405b05ed1
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Get deployment by ID
+      operationId: getDeploymentById
     delete:
       tags:
       - Deployments
@@ -554,7 +560,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Delete deployment
+      operationId: deleteDeployment
     patch:
       tags:
       - Deployments
@@ -686,7 +693,8 @@ paths:
                 - id: string
                   type: string
                 lastSuccessfulVersion: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentid
+      summary: Update deployment
+      operationId: patchDeployment
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/schedulers:
     get:
       tags:
@@ -736,7 +744,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulers
+      summary: List deployment schedulers
+      operationId: listSchedulers
     patch:
       tags:
       - Schedulers
@@ -794,12 +803,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSchedulers
+      summary: Enable or disable schedulers
+      operationId: patchSchedulers
   /organizations/{organizationId}/environments/{environmentId}/alerts/{alertId}:
     get:
       tags:
       - Alerts
-      summary: Retrieves a single Cloudhub 2.0 alert
+      summary: Get CloudHub 2.0 alert by ID
       parameters:
       - name: Authorization
         in: header
@@ -878,12 +888,12 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: getAlertById
       description: Retrieves a single Cloudhub 2.0 alert
     delete:
       tags:
       - Alerts
-      summary: Deletes a Cloudhub 2.0 alert
+      summary: Delete CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -932,12 +942,12 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: deleteAlert
       description: Deletes a Cloudhub 2.0 alert
     patch:
       tags:
       - Alerts
-      summary: Updates a Cloudhub 2.0 alert
+      summary: Update CloudHub 2.0 alert
       parameters:
       - name: Authorization
         in: header
@@ -1038,7 +1048,7 @@ paths:
                 createdAt: 0
                 isSystem: true
                 productName: string
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertid
+      operationId: patchAlert
       description: Updates a Cloudhub 2.0 alert
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs:
     get:
@@ -1083,12 +1093,13 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecs
+      summary: List deployment version specs
+      operationId: listDeploymentSpecs
   /organizations/{organizationId}/environments/{environmentId}/alerts/{alertId}/history:
     get:
       tags:
       - Alerts
-      summary: Retrieves a Cloudhub 2.0 alert history record
+      summary: Get CloudHub 2.0 alert history
       parameters:
       - name: Authorization
         in: header
@@ -1147,7 +1158,7 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidAlertsByAlertidHistory
+      operationId: getAlertHistory
       description: Retrieves a Cloudhub 2.0 alert history record
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/replicas/{replicaId}/diagnostics:
     post:
@@ -1182,12 +1193,13 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidReplicasByReplicaidDiagnostics
+      summary: Trigger replica thread dump diagnostic
+      operationId: triggerReplicaDiagnostic
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs/{specificationId}/logs:
     get:
       tags:
       - Logs
-      summary: Fetch logs from the Log Aggregator V2 API.
+      summary: Fetch deployment logs
       parameters:
       - $ref: '#/components/parameters/XOrigin_anotherContextOrganizationId_Path'
       - $ref: '#/components/parameters/XOrigin_anotherContextEnvironmentId_Path'
@@ -1227,13 +1239,13 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecsBySpecificationidLogs
+      operationId: getDeploymentLogs
       description: Fetch logs from the Log Aggregator V2 API.
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/specs/{specificationId}/logs/file:
     get:
       tags:
       - Logs
-      summary: Download log entries matching the search as text attachment, without pagination.
+      summary: Download log entries as text
       parameters:
       - $ref: '#/components/parameters/XOrigin_anotherContextOrganizationId_Path'
       - $ref: '#/components/parameters/XOrigin_anotherContextEnvironmentId_Path'
@@ -1273,7 +1285,7 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidSpecsBySpecificationidLogsFile
+      operationId: downloadLogs
       description: Download log entries matching the search as text attachment, without pagination.
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/diagnostics:
     get:
@@ -1311,7 +1323,8 @@ paths:
                   id: string
                   type: string
                 detail: string
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidDiagnostics
+      summary: List deployment diagnostics
+      operationId: listDeploymentDiagnostics
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/diagnostics/{actionId}/file:
     get:
       tags:
@@ -1357,7 +1370,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/StreamingResponseBody'
               example: {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidDiagnosticsByActionidFile
+      summary: Get diagnostic thread dump report
+      operationId: getDiagnosticReport
   /organizations/{organizationId}/environments/{environmentId}/deployments/{deploymentId}/upgradedata/trafficswitching:
     put:
       tags:
@@ -1415,7 +1429,8 @@ paths:
               style: simple
               schema:
                 type: string
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDeploymentsByDeploymentidUpgradedataTrafficswitching
+      summary: Update traffic switching percentage
+      operationId: updateTrafficSwitching
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/anypoint-monitoring-archive/api.yaml
+++ b/apis/anypoint-monitoring-archive/api.yaml
@@ -49,6 +49,7 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
+      summary: List organizations with archived data
       operationId: getOrganizations
   /organizations/{organization}/environments:
     get:
@@ -88,7 +89,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironments
+      summary: List archived environments for organization
+      operationId: listOrgEnvironments
   /organizations/{organization}/environments/{environment}:
     get:
       description: 'Returns a list of entity type identifiers for the entity types that have archived data.  If this path contains no
@@ -127,7 +129,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironment
+      summary: List archived entity types in environment
+      operationId: listEntityTypes
   /organizations/{organization}/environments/{environment}/{entityType}:
     get:
       description: 'Returns a list of entity identifiers for the entities that have archived data.  If this path contains no
@@ -177,7 +180,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytype
+      summary: List archived entities by entity type
+      operationId: listEntitiesByType
   /organizations/{organization}/environments/{environment}/{entityType}/{entityID}:
     get:
       description: 'Returns a list of file type identifiers for the file types that have archived data.  If this path contains no
@@ -228,7 +232,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityid
+      summary: List archived file types for entity
+      operationId: listEntityFileTypes
   /organizations/{organization}/environments/{environment}/{entityType}/{entityID}/{fileType}:
     get:
       description: 'Returns a list of year identifiers for the years that have archived data.  If this path contains no
@@ -291,7 +296,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityidByFiletype
+      summary: List archive years for entity file type
+      operationId: listArchiveYears
   /organizations/{organization}/environments/{environment}/{entityType}/{entityID}/{fileType}/{year}:
     get:
       description: 'Returns a list of month identifiers for the months that have archived data.  If this path contains no
@@ -363,7 +369,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityidByFiletypeByYear
+      summary: List archive months for year
+      operationId: listArchiveMonths
   /organizations/{organization}/environments/{environment}/{entityType}/{entityID}/{fileType}/{year}/{month}:
     get:
       description: 'Returns a list of day identifiers for the days that have archived data.  If this path contains no
@@ -444,7 +451,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityidByFiletypeByYearByMonth
+      summary: List archive days for month
+      operationId: listArchiveDays
   /organizations/{organization}/environments/{environment}/{entityType}/{entityID}/{fileType}/{year}/{month}/{dayOfMonth}:
     get:
       description: 'Returns a list of data files under this node with each file containing archived metric data.
@@ -531,7 +539,8 @@ paths:
           description: The client is sending more than the allowed number of requests per unit time
         '504':
           description: The API service is temporarily unreachable.  Please try again later.  Contact support if problem persists.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityidByFiletypeByYearByMonthByDayofmonth
+      summary: List archive data files for day
+      operationId: listArchiveDataFiles
   ? /organizations/{organization}/environments/{environment}/{entityType}/{entityID}/{fileType}/{year}/{month}/{dayOfMonth}/{fileName}
   : get:
       description: Retrieve the contents of the given data file.  A data file contains either metric data.
@@ -604,7 +613,8 @@ paths:
               example: string
         '404':
           description: The given file is not found.
-      operationId: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytypeByEntityidByFiletypeByYearByMonthByDayofmonthByFilename
+      summary: Get archive data file contents
+      operationId: getArchiveDataFile
 components:
   securitySchemes:
     bearerAuth:
@@ -724,7 +734,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:anypoint-monitoring-archive
-        operation: getOrganizationsByOrganizationEnvironmentsByEnvironmentByEntitytype
+        operation: listEntitiesByType
         description: GET `/organizations/{organization}/environments/{environment}/{entityType}` in this API; use `resources[].id` values as `entityID`.
         values: $.resources[*].id
         labels: $.resources[*].name

--- a/apis/anypoint-mq-broker/api.yaml
+++ b/apis/anypoint-mq-broker/api.yaml
@@ -188,7 +188,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessages
+      summary: Receive messages from destination
+      operationId: receiveMessages
     put:
       description: 'Publishes a batch of messages to the destination. Batch size must be at least 1 and at most 10.
 
@@ -270,7 +271,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessages
+      summary: Send message batch
+      operationId: sendMessageBatch
     delete:
       description: 'Acknowledge a batch of messages. If you are using connected app, "Destination subscriber for given environment" scope is needed.
 
@@ -330,7 +332,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessages
+      summary: Acknowledge message batch
+      operationId: acknowledgeMessageBatch
   /organizations/{organizationId}/environments/{environmentId}/destinations/{destinationId}/messages/locks:
     patch:
       description: 'Modifies the lock TTL of a batch of messages. If you are using connected app, "Destination publisher for given environment" scope is needed.
@@ -393,7 +396,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesLocks
+      summary: Update message lock TTL batch
+      operationId: updateMessageLockTtlBatch
     delete:
       description: 'Performs a batch negative acknowledge of messages. These are available again for this or other consumers.
 
@@ -451,7 +455,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesLocks
+      summary: Nack message batch
+      operationId: nackMessageBatch
   /organizations/{organizationId}/environments/{environmentId}/destinations/{destinationId}/messages/{messageId}:
     put:
       description: 'Sends the message to the specified destination.
@@ -552,7 +557,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesByMessageid
+      summary: Send message
+      operationId: sendMessage
     delete:
       description: 'Performs an acknowledge of the message, effectively deleting it from the destination.
 
@@ -627,7 +633,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesByMessageid
+      summary: Acknowledge message
+      operationId: acknowledgeMessage
   /organizations/{organizationId}/environments/{environmentId}/destinations/{destinationId}/messages/{messageId}/locks:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -736,7 +743,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesByMessageidLocksByLockid
+      summary: Update message lock TTL
+      operationId: updateMessageLockTtl
     delete:
       description: 'Performs a negative acknowledge of the message. The message is available again for this or other consumers.
 
@@ -810,7 +818,8 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidDestinationsByDestinationidMessagesByMessageidLocksByLockid
+      summary: Nack message
+      operationId: nackMessage
   /authorize:
     post:
       description: 'Obtains an access token using client credentials of the OAuth grant type.
@@ -849,6 +858,7 @@ paths:
       - bearerAuth: []
       - clientAuth: []
       - {}
+      summary: Authorize with client credentials
       operationId: createAuthorize
 components:
   requestBodies:

--- a/apis/anypoint-mq-stats/api.yaml
+++ b/apis/anypoint-mq-stats/api.yaml
@@ -148,7 +148,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationid
+      summary: Get organization usage metrics
+      operationId: getOrganizationUsageMetrics
   /organizations/{organizationId}/environments:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -271,7 +272,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentid
+      summary: Get environment usage metrics
+      operationId: getEnvironmentUsageMetrics
   /organizations/{organizationId}/environments/{environmentId}/regions:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -346,7 +348,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidQueues
+      summary: List realtime queue stats
+      operationId: listQueueRealtimeStats
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/queues/{queueId}:
     description: Entity representing a queue
     get:
@@ -493,7 +496,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidQueuesByQueueid
+      summary: Get historic queue stats
+      operationId: getQueueHistoricStats
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/exchanges:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -604,7 +608,8 @@ paths:
             '
       security:
       - {}
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidExchangesByExchangeid
+      summary: Get historic exchange stats
+      operationId: getExchangeHistoricStats
 components:
   securitySchemes:
     oauth_2_0:

--- a/apis/anypoint-security-policies/api.yaml
+++ b/apis/anypoint-security-policies/api.yaml
@@ -37,7 +37,8 @@ paths:
       responses:
         '204':
           description: Successful. Returns zero length body.
-      operationId: deleteByOrganizationid
+      summary: Delete organization Security Fabric data
+      operationId: purgeOrganizationData
   /{organizationId}/environments/{envId}:
     delete:
       description: Deletes all the data belonging to an environments from Security Fabric Edge
@@ -47,7 +48,8 @@ paths:
       responses:
         '204':
           description: Successful. Returns zero length body.
-      operationId: deleteByOrganizationidEnvironmentsByEnvid
+      summary: Delete environment Security Fabric data
+      operationId: purgeEnvironmentData
   /{organizationId}/environments/{envId}/agents/{agentId}/domains:
     get:
       description: Get all CN (common name) and SANs (Subject Alternate Name) list
@@ -101,7 +103,8 @@ paths:
                   message: Edge Config for the given Runtime Fabric id does not exist
                   details: {}
               example: *id002
-      operationId: getByOrganizationidEnvironmentsByEnvidAgentsByAgentidDomains
+      summary: List agent CN and SAN domains
+      operationId: listAgentDomains
   /{organizationId}/environments/{envId}/tlsContexts:
     get:
       description: Get TLS contexts configured for the enviorment
@@ -335,7 +338,8 @@ paths:
                 type: array
                 items: {}
               example: *id003
-      operationId: getByOrganizationidEnvironmentsByEnvidTlscontexts
+      summary: List environment TLS contexts
+      operationId: listTlsContexts
   /{organizationId}/agents/{agentId}/virtualServers:
     description: The collection of virtualServers
     get:
@@ -556,7 +560,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getByOrganizationidAgentsByAgentidVirtualservers
+      summary: List agent virtual servers
+      operationId: listAgentVirtualServers
   /{organizationId}/agents/{agentId}/edge:
     description: The collection of edge
     get:
@@ -622,7 +627,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getByOrganizationidAgentsByAgentidEdge
+      summary: Get agent edge configuration
+      operationId: getAgentEdgeConfig
     post:
       description: create Edge configuration for the given runtime fabric
       parameters:
@@ -723,7 +729,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createByOrganizationidAgentsByAgentidEdge
+      summary: Create agent edge configuration
+      operationId: createAgentEdgeConfig
   /{organizationId}/agents/{agentId}/edge/{edgeConfigId}:
     description: Get an entity representing a edge
     put:
@@ -823,7 +830,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateByOrganizationidAgentsByAgentidEdgeByEdgeconfigid
+      summary: Update agent edge configuration
+      operationId: updateAgentEdgeConfig
     patch:
       description: Except TLS config, update other configuration if PEM/JKS is selected d
       parameters:
@@ -921,7 +929,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: patchByOrganizationidAgentsByAgentidEdgeByEdgeconfigid
+      summary: Patch agent edge configuration
+      operationId: patchAgentEdgeConfig
     delete:
       description: Delete Edge configuration for the given edge configuration id
       parameters:
@@ -975,7 +984,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteByOrganizationidAgentsByAgentidEdgeByEdgeconfigid
+      summary: Delete agent edge configuration
+      operationId: deleteAgentEdgeConfig
   /{organizationId}/agents/{agentId}/edge/{edgeConfigId}/deployments:
     get:
       description: Get the edge deployement status
@@ -1020,7 +1030,8 @@ paths:
                   message: Error while trying to get deployment data from deployer
                   errors: []
               example: *id006
-      operationId: getByOrganizationidAgentsByAgentidEdgeByEdgeconfigidDeployments
+      summary: Get edge deployment status
+      operationId: getEdgeDeploymentStatus
   /{organizationId}/policies:
     description: The collection of policies
     post:
@@ -1116,7 +1127,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createByOrganizationidPolicies
+      summary: Create security policy
+      operationId: createSecurityPolicy
     get:
       description: Get all the policies
       parameters:
@@ -1359,7 +1371,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getByOrganizationidPolicies
+      summary: List security policies
+      operationId: listSecurityPolicies
   /{organizationId}/policies/{policyId}:
     description: Get an entity representing a policy
     get:
@@ -1440,7 +1453,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getByOrganizationidPoliciesByPolicyid
+      summary: Get security policy by ID
+      operationId: getSecurityPolicyById
     put:
       description: Update policy by id
       parameters:
@@ -1535,7 +1549,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateByOrganizationidPoliciesByPolicyid
+      summary: Update security policy
+      operationId: updateSecurityPolicy
     delete:
       description: Delete policy by id
       parameters:
@@ -1573,7 +1588,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteByOrganizationidPoliciesByPolicyid
+      summary: Delete security policy
+      operationId: deleteSecurityPolicy
 components:
   securitySchemes:
     bearerAuth:
@@ -3187,7 +3203,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:anypoint-security-policies
-        operation: getByOrganizationidAgentsByAgentidEdge
+        operation: getAgentEdgeConfig
         description: GET `/{organizationId}/agents/{agentId}/edge` in this API; use `id` values as `edgeConfigId`.
         values: $.id
         labels: $.name

--- a/apis/api-manager/api.yaml
+++ b/apis/api-manager/api.yaml
@@ -2904,7 +2904,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:exchange-experience
-        operation: getAssetsSearch
+        operation: searchAssets
         name: getAssetsAssetId
         values: $[*].assetId
         labels: $[*].name
@@ -2916,7 +2916,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:exchange-experience
-        operation: getAssetsSearch
+        operation: searchAssets
         name: getAssetsGroupId
         values: $[*].groupId
         labels: $[*].name
@@ -2929,7 +2929,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:exchange-experience
-        operation: getAssetsSearch
+        operation: searchAssets
         description: Align with Exchange asset version for the same assetId + groupId; exact response shape depends on search results.
         values: $[*].version
         labels: $[*].name

--- a/apis/api-manager/api.yaml
+++ b/apis/api-manager/api.yaml
@@ -59,7 +59,8 @@ paths:
             example: apimanager/examples/responses/application-import.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsApplications
+      summary: Import a client application
+      operationId: importApplication
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/environments/{environmentId}/apis:
@@ -155,7 +156,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: listOrganizationsEnvironmentsApis
+      summary: List APIs
+      operationId: listApis
     post:
       responses:
         '201':
@@ -221,7 +223,8 @@ paths:
               required: []
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApis
+      summary: Create an API
+      operationId: createApi
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -263,7 +266,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: getOrganizationsEnvironmentsApis
+      summary: Get an API
+      operationId: getApi
     put:
       responses:
         '201':
@@ -286,7 +290,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApis
+      summary: Replace an API
+      operationId: updateApi
     patch:
       responses:
         '200':
@@ -326,13 +331,15 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: patchOrganizationsEnvironmentsApis
+      summary: Update an API
+      operationId: patchApi
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApis
+      summary: Delete an API
+      operationId: deleteApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -348,13 +355,15 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Pins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: updateOrganizationsEnvironmentsApisPin
+      summary: Pin an API version
+      operationId: pinApi
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unpins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisPin
+      summary: Unpin an API version
+      operationId: unpinApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -380,7 +389,8 @@ paths:
               $ref: ./apimanager/schemas/upstreamPOST-oas.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisUpstreams
+      summary: Create an API upstream
+      operationId: createApiUpstream
     get:
       responses:
         '200':
@@ -393,7 +403,8 @@ paths:
                 Upstreams:
                   $ref: ./apimanager/examples/responses/upstreams.json
       description: "Get API version upstreams\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: listOrganizationsEnvironmentsApisUpstreams
+      summary: List API upstreams
+      operationId: listApiUpstreams
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -411,7 +422,8 @@ paths:
                 Upstream:
                   $ref: ./apimanager/examples/responses/upstream.json
       description: "Get an upstream\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
-      operationId: getOrganizationsEnvironmentsApisUpstreams
+      summary: Get an API upstream
+      operationId: getApiUpstream
     patch:
       responses:
         '200':
@@ -434,7 +446,8 @@ paths:
               $ref: ./apimanager/schemas/upstreamPATCH-oas.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisUpstreams
+      summary: Update an API upstream
+      operationId: updateApiUpstream
     delete:
       responses:
         default:
@@ -444,7 +457,8 @@ paths:
               example:
                 message: Success
       description: "Delete an upstream\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisUpstreams
+      summary: Delete an API upstream
+      operationId: deleteApiUpstream
     parameters:
     - $ref: '#/components/parameters/param_upstream_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -495,7 +509,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: listOrganizationsEnvironmentsApisPolicies
+      summary: List API policies
+      operationId: listApiPolicies
     post:
       responses:
         '201':
@@ -516,7 +531,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisPolicies
+      summary: Apply a new API policy
+      operationId: applyApiPolicy
     patch:
       responses:
         '200':
@@ -547,7 +563,8 @@ paths:
                 type: object
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisPoliciesBulk
+      summary: Reorder API policies
+      operationId: reorderApiPolicies
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -565,7 +582,8 @@ paths:
                 Policies:
                   $ref: ./apimanager/examples/responses/policies.json
       description: "Retrieves a specific policy for the API\n\nConnected Apps require the following scopes:\n  - View Policies\n"
-      operationId: getOrganizationsEnvironmentsApisPolicies
+      summary: Get an API policy
+      operationId: getApiPolicy
     patch:
       responses:
         '200':
@@ -585,13 +603,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsEnvironmentsApisPolicy
+      summary: Update an API policy
+      operationId: updateApiPolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unapplies a policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
-      operationId: deleteOrganizationsEnvironmentsApisPolicies
+      summary: Unapply an API policy
+      operationId: unapplyApiPolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -624,7 +644,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: createOrganizationsEnvironmentsApisPoliciesImplementationasset
+      summary: Update policy implementation asset
+      operationId: updateApiPolicyImplementationAsset
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -657,7 +678,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsEnvironmentsApisTiers
+      summary: List API tiers
+      operationId: listApiTiers
     post:
       responses:
         '201':
@@ -694,13 +716,15 @@ paths:
                 $ref: ./apimanager/examples/requests/tier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisTiers
+      summary: Create an SLA tier for the API
+      operationId: createApiTier
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count tiers of the API version
-      operationId: checkOrganizationsEnvironmentsApisTiers
+      summary: Count API tiers
+      operationId: checkApiTiers
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -742,13 +766,15 @@ paths:
                 $ref: ./apimanager/examples/requests/tier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisTiers
+      summary: Update an API tier
+      operationId: updateApiTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
-      operationId: deleteOrganizationsEnvironmentsApisTiers
+      summary: Delete an API tier
+      operationId: deleteApiTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -760,7 +786,8 @@ paths:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count group tiers of the API version
-      operationId: checkOrganizationsEnvironmentsApisGrouptiers
+      summary: Count API group tiers
+      operationId: checkApiGroupTiers
     get:
       responses:
         '200':
@@ -771,7 +798,8 @@ paths:
                 total: 0
                 data: []
       description: Returns a list of elements.
-      operationId: listOrganizationsEnvironmentsApisGrouptiers
+      summary: List API group tiers
+      operationId: listApiGroupTiers
     post:
       responses:
         '201':
@@ -792,7 +820,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisGrouptiers
+      summary: Create an API group tier
+      operationId: createApiGroupTier
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -810,7 +839,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a list of group contracts of the API version\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
-      operationId: listOrganizationsEnvironmentsApisGroupcontracts
+      summary: List API group contracts
+      operationId: listApiGroupContracts
     post:
       responses:
         '201':
@@ -831,7 +861,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisGroupcontracts
+      summary: Create an API group contract
+      operationId: createApiGroupContract
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -866,7 +897,8 @@ paths:
                 $ref: ./apimanager/examples/requests/contractThroughApi.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisContracts
+      summary: Create an API contract
+      operationId: createApiContract
     get:
       responses:
         '200':
@@ -912,7 +944,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsEnvironmentsApisContracts
+      summary: List API contracts
+      operationId: listApiContracts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -930,7 +963,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a specific contract for the API\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
-      operationId: getOrganizationsEnvironmentsApisContracts
+      summary: Get an API contract
+      operationId: getApiContract
     patch:
       responses:
         '200':
@@ -953,13 +987,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisContracts
+      summary: Update API contract conditions
+      operationId: updateApiContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes the contract\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
-      operationId: deleteOrganizationsEnvironmentsApisContracts
+      summary: Delete an API contract
+      operationId: deleteApiContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -978,7 +1014,8 @@ paths:
                 Contract:
                   $ref: ./apimanager/examples/responses/alerts.json
       description: "Retrieves a list of API alerts\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: listOrganizationsEnvironmentsApisAlerts
+      summary: List API alerts
+      operationId: listApiAlerts
     post:
       responses:
         '201':
@@ -1001,7 +1038,8 @@ paths:
                 $ref: ./apimanager/examples/requests/alert.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisAlerts
+      summary: Create an API alert
+      operationId: createApiAlert
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1038,7 +1076,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves an API alert\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: getOrganizationsEnvironmentsApisAlerts
+      summary: Get an API alert
+      operationId: getApiAlert
     patch:
       responses:
         '200':
@@ -1087,7 +1126,8 @@ paths:
                 $ref: ./apimanager/examples/requests/alert.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisAlerts
+      summary: Update an API alert
+      operationId: updateApiAlert
     delete:
       responses:
         '204':
@@ -1112,7 +1152,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Deletes the specified alert definition\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
-      operationId: deleteOrganizationsEnvironmentsApisAlerts
+      summary: Delete an API alert
+      operationId: deleteApiAlert
     parameters:
     - $ref: '#/components/parameters/param_alert_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1157,7 +1198,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
             default: false
-      operationId: listOrganizationsEnvironmentsApisBundle
+      summary: Export the API bundle
+      operationId: exportApiBundle
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1173,13 +1215,15 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Adds a new API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: updateOrganizationsEnvironmentsApisTags
+      summary: Add a new API tag
+      operationId: addApiTag
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
-      operationId: deleteOrganizationsEnvironmentsApisTags
+      summary: Delete an API tag
+      operationId: deleteApiTag
     parameters:
     - name: tag
       in: path
@@ -1209,7 +1253,8 @@ paths:
         description: The version of the gateway that will use the autodiscovery properties to track this API, written in semver.
         schema:
           type: string
-      operationId: listOrganizationsEnvironmentsApisAutodiscoveryproperties
+      summary: Get API autodiscovery properties
+      operationId: getApiAutodiscoveryProperties
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1241,7 +1286,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: Retrieves TLS Contexts configuration for a given API endpoint
-      operationId: listOrganizationsEnvironmentsApisTlscontexts
+      summary: Get API TLS context configuration
+      operationId: getApiTlsContexts
     post:
       responses:
         '201':
@@ -1276,7 +1322,8 @@ paths:
                 $ref: ./apimanager/examples/tlsContextsRequest.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsApisTlscontexts
+      summary: Create API TLS context configuration
+      operationId: createApiTlsContexts
     put:
       responses:
         '200':
@@ -1296,13 +1343,15 @@ paths:
                 $ref: ./apimanager/examples/tlsContextsRequest.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsApisTlscontexts
+      summary: Update API TLS context configuration
+      operationId: updateApiTlsContexts
     delete:
       responses:
         '204':
           description: TLS Contexts successfully deleted
       description: Deletes TLS Contexts configuration
-      operationId: deleteOrganizationsEnvironmentsApisTlscontexts
+      summary: Delete API TLS context configuration
+      operationId: deleteApiTlsContexts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1335,7 +1384,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupInstanceCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstances
+      summary: Create a group instance
+      operationId: createGroupInstance
     get:
       responses:
         '200':
@@ -1346,7 +1396,8 @@ paths:
                 total: 0
                 data: []
       description: "Gets a list of group istances by environmentId\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstances
+      summary: List group instances
+      operationId: listGroupInstances
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -1368,7 +1419,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Gets a group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstances
+      summary: Get a group instance
+      operationId: getGroupInstance
     patch:
       responses:
         '200':
@@ -1388,7 +1440,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsGroupinstances
+      summary: Update a group instance
+      operationId: updateGroupInstance
     delete:
       responses:
         '201':
@@ -1399,7 +1452,8 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 message: Resource created successfully
       description: "Deletes a group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstances
+      summary: Delete a group instance
+      operationId: deleteGroupInstance
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1434,7 +1488,8 @@ paths:
                 $ref: ./apimanager/examples/requests/contractThroughApi.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Create a group instance contract
+      operationId: createGroupInstanceContract
     get:
       responses:
         '200':
@@ -1447,13 +1502,15 @@ paths:
                 GroupContract:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceContractsRetrieve.json
       description: "Retrieves the list of contracts of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesContracts
+      summary: List group instance contracts
+      operationId: listGroupInstanceContracts
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: "Retrieves the count of contracts of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: checkOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Count group instance contracts
+      operationId: checkGroupInstanceContracts
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1471,13 +1528,15 @@ paths:
                 GroupContract:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceContractsRetrieve.json
       description: "Retrieves a specific contract for the group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Get a group instance contract
+      operationId: getGroupInstanceContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a group instance contract that is not currently applied\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Delete a group instance contract
+      operationId: deleteGroupInstanceContract
     patch:
       responses:
         '200':
@@ -1487,7 +1546,8 @@ paths:
               example:
                 message: Resource updated successfully
       description: "Updates a group instance contract\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: updateOrganizationsEnvironmentsGroupinstancesContracts
+      summary: Update a group instance contract
+      operationId: updateGroupInstanceContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id_string'
     - $ref: '#/components/parameters/param_group_instance_id'
@@ -1506,7 +1566,8 @@ paths:
                 GroupTier:
                   $ref: ./apimanager/examples/responses/apiGroups/groupInstanceTiersRetrieve.json
       description: "Retrieves the tiers of a Group instance\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesTiers
+      summary: List group instance tiers
+      operationId: listGroupInstanceTiers
     post:
       responses:
         '201':
@@ -1536,7 +1597,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupInstanceTierCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Create a group instance tier
+      operationId: createGroupInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1561,13 +1623,15 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a group instance tier\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Get a group instance tier
+      operationId: getGroupInstanceTier
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: deleteOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Delete a group instance tier
+      operationId: deleteGroupInstanceTier
     put:
       responses:
         '200':
@@ -1611,7 +1675,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Replace a group instance tier
+      operationId: updateGroupInstanceTier
     patch:
       responses:
         '200':
@@ -1631,7 +1696,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsEnvironmentsGroupinstancesTiers
+      summary: Update a group instance tier
+      operationId: patchGroupInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_group_instance_id'
@@ -1648,7 +1714,8 @@ paths:
                 total: 0
                 data: []
       description: "Gets API instances of a group instances\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsEnvironmentsGroupinstancesApiinstances
+      summary: List group instance APIs
+      operationId: listGroupInstanceApiInstances
     parameters:
     - $ref: '#/components/parameters/param_group_instance_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1672,7 +1739,8 @@ paths:
               examples:
                 ApiList:
                   $ref: ./apimanager/examples/responses/managedServices/apiList.json
-      operationId: listOrganizationsEnvironmentsManagedserviceapis
+      summary: List managed service APIs
+      operationId: listManagedServiceApis
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -1689,7 +1757,8 @@ paths:
                 Api:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiGet.json
       description: Retrieve a specific Managed Service API
-      operationId: getOrganizationsEnvironmentsManagedserviceapis
+      summary: Get a managed service API
+      operationId: getManagedServiceApi
     patch:
       responses:
         '200':
@@ -1712,7 +1781,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapis
+      summary: Update managed service API details
+      operationId: updateManagedServiceApi
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1740,7 +1810,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Create a managed service API policy
+      operationId: createManagedServiceApiPolicy
     get:
       description: 'Retrieves all policies applied to a specific Managed Service API.
 
@@ -1775,7 +1846,8 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
         description: The fullInfo query parameter.
-      operationId: listOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: List managed service API policies
+      operationId: listManagedServiceApiPolicies
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1799,7 +1871,8 @@ paths:
               examples:
                 Policy:
                   $ref: ./apimanager/examples/responses/managedServices/policy.json
-      operationId: getOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Get a managed service API policy
+      operationId: getManagedServiceApiPolicy
     patch:
       responses:
         '200':
@@ -1822,13 +1895,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Update a managed service API policy
+      operationId: updateManagedServiceApiPolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Unapplies a policy.
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisPolicies
+      summary: Unapply a managed service API policy
+      operationId: unapplyManagedServiceApiPolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -1847,7 +1922,8 @@ paths:
                 Tiers:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiTiersRetrieve.json
       description: Retrieves the tiers of a Managed Service API
-      operationId: listOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: List managed service API tiers
+      operationId: listManagedServiceApiTiers
     post:
       responses:
         '201':
@@ -1870,7 +1946,8 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiTier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Create a managed service API tier
+      operationId: createManagedServiceApiTier
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1898,13 +1975,15 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiTier.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Edit a managed service API tier
+      operationId: updateManagedServiceApiTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Delete a tier of a Managed Service API
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisTiers
+      summary: Delete a managed service API tier
+      operationId: deleteManagedServiceApiTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id_managed_service'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -1923,7 +2002,8 @@ paths:
                 Contracts:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiContractsRetrieve.json
       description: Retrieves the contracts of a Managed Service API
-      operationId: listOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: List managed service API contracts
+      operationId: listManagedServiceApiContracts
     post:
       responses:
         '201':
@@ -1946,7 +2026,8 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiContract.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Create a managed service API contract
+      operationId: createManagedServiceApiContract
     parameters:
     - $ref: '#/components/parameters/param_managed_service_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1964,7 +2045,8 @@ paths:
                 Contract:
                   $ref: ./apimanager/examples/responses/managedServices/managedServiceApiContractRetrieve.json
       description: Retrieves a contract of a Managed Service API
-      operationId: getOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Get a managed service API contract
+      operationId: getManagedServiceApiContract
     patch:
       responses:
         '201':
@@ -1987,13 +2069,15 @@ paths:
                 $ref: ./apimanager/examples/requests/managedServices/managedServiceApiContractPatch.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Edit a managed service API contract
+      operationId: updateManagedServiceApiContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: Delete a contract of a Managed Service API
-      operationId: deleteOrganizationsEnvironmentsManagedserviceapisContracts
+      summary: Delete a managed service API contract
+      operationId: deleteManagedServiceApiContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id_string'
     - $ref: '#/components/parameters/param_managed_service_api_id'
@@ -2016,7 +2100,8 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_sort'
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
-      operationId: listOrganizationsCustompolicytemplates
+      summary: List custom policy templates
+      operationId: listCustomPolicyTemplates
     post:
       responses:
         '201':
@@ -2057,7 +2142,8 @@ paths:
               required: []
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsCustompolicytemplates
+      summary: Create a custom policy template
+      operationId: createCustomPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/custom-policy-templates/{customPolicyTemplateId}:
@@ -2071,7 +2157,8 @@ paths:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 name: Example Resource
       description: Returns an instance of a single element.
-      operationId: getOrganizationsCustompolicytemplates
+      summary: Get a custom policy template
+      operationId: getCustomPolicyTemplate
     put:
       responses:
         '201':
@@ -2092,7 +2179,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsCustompolicytemplates
+      summary: Replace a custom policy template
+      operationId: updateCustomPolicyTemplate
     patch:
       responses:
         '200':
@@ -2112,13 +2200,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsCustompolicytemplates
+      summary: Update a custom policy template
+      operationId: patchCustomPolicyTemplate
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsCustompolicytemplates
+      summary: Delete a custom policy template
+      operationId: deleteCustomPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2133,7 +2223,8 @@ paths:
                 total: 0
                 data: []
       description: The XML configuration for the custom policy template.
-      operationId: listOrganizationsCustompolicytemplatesConfiguration
+      summary: Get custom policy template configuration
+      operationId: getCustomPolicyTemplateConfiguration
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2148,7 +2239,8 @@ paths:
                 total: 0
                 data: []
       description: The YAML definition for the custom policy template.
-      operationId: listOrganizationsCustompolicytemplatesDefinition
+      summary: Get custom policy template definition
+      operationId: getCustomPolicyTemplateDefinition
     parameters:
     - $ref: '#/components/parameters/param_custom_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2197,7 +2289,8 @@ paths:
           pattern: ^v\d+(.\d+)?(.\d+)?$
           type: string
         description: The version query parameter.
-      operationId: listOrganizationsPolicytemplates
+      summary: List policy templates
+      operationId: listPolicyTemplates
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/policy-templates/{policyTemplateId}:
@@ -2249,7 +2342,8 @@ paths:
           pattern: ^v\d+(.\d+)?(.\d+)?$
           type: string
         description: The version query parameter.
-      operationId: getOrganizationsPolicytemplates
+      summary: Get a policy template
+      operationId: getPolicyTemplate
     parameters:
     - $ref: '#/components/parameters/param_policy_template_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2267,7 +2361,8 @@ paths:
         description: A semver string that will be checked for an exact match of Runtime Version
         schema:
           type: string
-      operationId: checkOrganizationsAutomatedpolicies
+      summary: Count automated policies
+      operationId: checkAutomatedPolicies
     get:
       responses:
         '200':
@@ -2295,7 +2390,8 @@ paths:
         description: A semver string that will be checked for an exact match of Runtime Version
         schema:
           type: string
-      operationId: listOrganizationsAutomatedpolicies
+      summary: List automated policies
+      operationId: listAutomatedPolicies
     post:
       responses:
         '201':
@@ -2330,7 +2426,8 @@ paths:
                 $ref: ./apimanager/examples/requests/automatedPolicy.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsAutomatedpolicies
+      summary: Create an automated policy
+      operationId: createAutomatedPolicy
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/automated-policies/{automatedPolicyId}:
@@ -2346,7 +2443,8 @@ paths:
                 AutomatedPolicies:
                   $ref: ./apimanager/examples/responses/automatedPolicies/automatedPoliciesRetrieve.json
       description: "Retrieves an Automated Policy.\n\nConnected Apps require the following scopes:\n  - View Policies\n"
-      operationId: getOrganizationsAutomatedpolicies
+      summary: Get an automated policy
+      operationId: getAutomatedPolicy
     patch:
       responses:
         '200':
@@ -2373,7 +2471,8 @@ paths:
                 $ref: ./apimanager/examples/requests/automatedPolicy.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsAutomatedpolicies
+      summary: Update an automated policy
+      operationId: patchAutomatedPolicy
     delete:
       responses:
         '204':
@@ -2386,7 +2485,8 @@ paths:
                 error: Bad Request
                 message: Invalid request parameters
       description: "Deletes an Automated Policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
-      operationId: deleteOrganizationsAutomatedpolicies
+      summary: Delete an automated policy
+      operationId: deleteAutomatedPolicy
     put:
       responses:
         '201':
@@ -2407,7 +2507,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsAutomatedpolicies
+      summary: Replace an automated policy
+      operationId: updateAutomatedPolicy
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2462,7 +2563,8 @@ paths:
         schema:
           default: 100
           type: integer
-      operationId: listOrganizationsAutomatedpoliciesApis
+      summary: List APIs affected by policy
+      operationId: listAutomatedPolicyApis
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2481,7 +2583,8 @@ paths:
       description: Delete Automated Policy coverage over the apiVersion specified due to incompatible implementation for the proxy version.
       parameters:
       - $ref: '#/components/parameters/XOrigin_environmentId_Query'
-      operationId: deleteOrganizationsAutomatedpoliciesIncompatibleapis
+      summary: Remove incompatible API from policy
+      operationId: deleteAutomatedPolicyIncompatibleApi
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_automated_policy_id'
@@ -2513,7 +2616,8 @@ paths:
           allOf:
           - x-force-coercion-to: boolean
           - type: boolean
-      operationId: createOrganizationsAutomatedpoliciesImplementationassets
+      summary: Update policy implementation assets
+      operationId: setAutomatedPolicyImplementationAssets
     parameters:
     - $ref: '#/components/parameters/param_automated_policy_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2544,7 +2648,8 @@ paths:
         description: Search groups by name
         schema:
           type: string
-      operationId: listOrganizationsGroups
+      summary: List groups
+      operationId: listGroups
     post:
       responses:
         '201':
@@ -2574,7 +2679,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroups
+      summary: Create a group
+      operationId: createGroup
     parameters:
     - $ref: '#/components/parameters/param_organization_id'
   /organizations/{organizationId}/groups/{groupId}:
@@ -2597,7 +2703,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a Group\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsGroups
+      summary: Get a group
+      operationId: getGroup
     patch:
       responses:
         '200':
@@ -2624,7 +2731,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupUpdate.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsGroups
+      summary: Update a group
+      operationId: patchGroup
     put:
       responses:
         '201':
@@ -2645,13 +2753,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsGroups
+      summary: Replace a group
+      operationId: updateGroup
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsGroups
+      summary: Delete a group
+      operationId: deleteGroup
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2683,7 +2793,8 @@ paths:
               description: Example description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroupsAssets
+      summary: Create a group asset
+      operationId: createGroupAsset
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2717,7 +2828,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupVersionCreation.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: createOrganizationsGroupsVersions
+      summary: Create a group version
+      operationId: createGroupVersion
     get:
       responses:
         '200':
@@ -2730,7 +2842,8 @@ paths:
                 Group:
                   $ref: ./apimanager/examples/responses/apiGroups/groupVersionsRetrieve.json
       description: "Retrieves all versions of a Group\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsGroupsVersions
+      summary: List group versions
+      operationId: listGroupVersions
     parameters:
     - $ref: '#/components/parameters/param_api_group_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -2754,7 +2867,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves a Group Version\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: getOrganizationsGroupsVersions
+      summary: Get a group version
+      operationId: getGroupVersion
     patch:
       responses:
         '200':
@@ -2788,7 +2902,8 @@ paths:
                 $ref: ./apimanager/examples/requests/apiGroups/groupVersionUpdate.json
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: patchOrganizationsGroupsVersions
+      summary: Update a group version
+      operationId: patchGroupVersion
     put:
       responses:
         '201':
@@ -2809,13 +2924,15 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      operationId: updateOrganizationsGroupsVersions
+      summary: Replace a group version
+      operationId: updateGroupVersion
     delete:
       responses:
         '204':
           description: The element has been deleted successfully.
       description: Deletes the instance of the element specified.
-      operationId: deleteOrganizationsGroupsVersions
+      summary: Delete a group version
+      operationId: deleteGroupVersion
     parameters:
     - $ref: '#/components/parameters/param_group_version_id'
     - $ref: '#/components/parameters/param_api_group_id'
@@ -2840,7 +2957,8 @@ paths:
                 error: Not Found
                 message: Resource not found
       description: "Retrieves the instances contained in a Group Version\n\nConnected Apps require the following scopes:\n  - API Group Administrator\n"
-      operationId: listOrganizationsGroupsVersionsInstances
+      summary: List group version instances
+      operationId: listGroupVersionInstances
     parameters:
     - $ref: '#/components/parameters/param_group_version_id'
     - $ref: '#/components/parameters/param_api_group_id'
@@ -2943,7 +3061,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsApisUpstreams
+        operation: listApiUpstreams
         values: $.id
         labels: $.name
     param_policy_id:
@@ -2965,7 +3083,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsApisAlerts
+        operation: listApiAlerts
         values: $.id
         labels: $.name
     param_group_instance_id:
@@ -2979,7 +3097,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsGroupinstances
+        operation: listGroupInstances
         values: $.id
         labels: $.name
     param_managed_service_api_id:
@@ -2993,7 +3111,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsEnvironmentsManagedserviceapis
+        operation: listManagedServiceApis
         values: $.id
         labels: $.name
     param_custom_policy_template_id:
@@ -3007,7 +3125,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsPolicytemplates
+        operation: listPolicyTemplates
         values: $.id
         labels: $.name
     param_automated_policy_id:
@@ -3021,7 +3139,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsAutomatedpolicies
+        operation: listAutomatedPolicies
         values: $.id
         labels: $.name
     param_api_group_id:
@@ -3037,7 +3155,7 @@ components:
         type: integer
       x-origin:
       - api: urn:api:api-manager
-        operation: listOrganizationsGroupsVersions
+        operation: listGroupVersions
         values: $.id
         labels: $.name
     XOrigin_environmentId_Query:

--- a/apis/api-manager/api.yaml
+++ b/apis/api-manager/api.yaml
@@ -157,7 +157,7 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
       summary: List APIs
-      operationId: listApis
+      operationId: listApiInstances
     post:
       responses:
         '201':
@@ -224,7 +224,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API
-      operationId: createApi
+      operationId: createApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_id'
     - $ref: '#/components/parameters/param_organization_id'
@@ -267,7 +267,7 @@ paths:
           - type: boolean
             default: false
       summary: Get an API
-      operationId: getApi
+      operationId: getApiInstance
     put:
       responses:
         '201':
@@ -290,8 +290,8 @@ paths:
               description: Updated description
         required: true
         description: Request body containing the data needed for this operation.
-      summary: Replace an API
-      operationId: updateApi
+      summary: Update an API
+      operationId: updateApiInstance
     patch:
       responses:
         '200':
@@ -332,14 +332,14 @@ paths:
           - type: boolean
             default: false
       summary: Update an API
-      operationId: patchApi
+      operationId: patchApiInstance
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API
-      operationId: deleteApi
+      operationId: deleteApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -356,14 +356,14 @@ paths:
                 message: Resource created successfully
       description: "Pins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Pin an API version
-      operationId: pinApi
+      operationId: pinApiInstance
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unpins an environment API version\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Unpin an API version
-      operationId: unpinApi
+      operationId: unpinApiInstance
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -390,7 +390,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API upstream
-      operationId: createApiUpstream
+      operationId: createApiInstanceUpstream
     get:
       responses:
         '200':
@@ -404,7 +404,7 @@ paths:
                   $ref: ./apimanager/examples/responses/upstreams.json
       description: "Get API version upstreams\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: List API upstreams
-      operationId: listApiUpstreams
+      operationId: listApiInstanceUpstreams
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -423,7 +423,7 @@ paths:
                   $ref: ./apimanager/examples/responses/upstream.json
       description: "Get an upstream\n\nConnected Apps require the following scopes:\n  - View APIs Configuration\n"
       summary: Get an API upstream
-      operationId: getApiUpstream
+      operationId: getApiInstanceUpstream
     patch:
       responses:
         '200':
@@ -447,7 +447,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API upstream
-      operationId: updateApiUpstream
+      operationId: updateApiInstanceUpstream
     delete:
       responses:
         default:
@@ -458,7 +458,7 @@ paths:
                 message: Success
       description: "Delete an upstream\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API upstream
-      operationId: deleteApiUpstream
+      operationId: deleteApiInstanceUpstream
     parameters:
     - $ref: '#/components/parameters/param_upstream_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -510,7 +510,7 @@ paths:
           - x-force-coercion-to: boolean
           - type: boolean
       summary: List API policies
-      operationId: listApiPolicies
+      operationId: listApiInstancePolicies
     post:
       responses:
         '201':
@@ -532,7 +532,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Apply a new API policy
-      operationId: applyApiPolicy
+      operationId: applyApiInstancePolicy
     patch:
       responses:
         '200':
@@ -564,7 +564,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Reorder API policies
-      operationId: reorderApiPolicies
+      operationId: reorderApiInstancePolicies
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -583,7 +583,7 @@ paths:
                   $ref: ./apimanager/examples/responses/policies.json
       description: "Retrieves a specific policy for the API\n\nConnected Apps require the following scopes:\n  - View Policies\n"
       summary: Get an API policy
-      operationId: getApiPolicy
+      operationId: getApiInstancePolicy
     patch:
       responses:
         '200':
@@ -604,14 +604,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API policy
-      operationId: updateApiPolicy
+      operationId: updateApiInstancePolicy
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Unapplies a policy\n\nConnected Apps require the following scopes:\n  - Manage Policies\n"
       summary: Unapply an API policy
-      operationId: unapplyApiPolicy
+      operationId: unapplyApiInstancePolicy
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -645,7 +645,7 @@ paths:
           - type: boolean
             default: false
       summary: Update policy implementation asset
-      operationId: updateApiPolicyImplementationAsset
+      operationId: updateApiInstancePolicyImplementationAsset
     parameters:
     - $ref: '#/components/parameters/param_policy_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -679,7 +679,7 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
       summary: List API tiers
-      operationId: listApiTiers
+      operationId: listApiInstanceTiers
     post:
       responses:
         '201':
@@ -717,14 +717,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an SLA tier for the API
-      operationId: createApiTier
+      operationId: createApiInstanceTier
     head:
       responses:
         '200':
           description: Success. Returns the requested resource.
       description: Retrieves a count tiers of the API version
       summary: Count API tiers
-      operationId: checkApiTiers
+      operationId: checkApiInstanceTiers
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -767,14 +767,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API tier
-      operationId: updateApiTier
+      operationId: updateApiInstanceTier
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes a tier that has no active applications\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
       summary: Delete an API tier
-      operationId: deleteApiTier
+      operationId: deleteApiInstanceTier
     parameters:
     - $ref: '#/components/parameters/param_tier_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -787,7 +787,7 @@ paths:
           description: Success. Returns the requested resource.
       description: Retrieves a count group tiers of the API version
       summary: Count API group tiers
-      operationId: checkApiGroupTiers
+      operationId: checkApiInstanceGroupTiers
     get:
       responses:
         '200':
@@ -799,7 +799,7 @@ paths:
                 data: []
       description: Returns a list of elements.
       summary: List API group tiers
-      operationId: listApiGroupTiers
+      operationId: listApiInstanceGroupTiers
     post:
       responses:
         '201':
@@ -821,7 +821,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API group tier
-      operationId: createApiGroupTier
+      operationId: createApiInstanceGroupTier
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -840,7 +840,7 @@ paths:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a list of group contracts of the API version\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
       summary: List API group contracts
-      operationId: listApiGroupContracts
+      operationId: listApiInstanceGroupContracts
     post:
       responses:
         '201':
@@ -862,7 +862,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API group contract
-      operationId: createApiGroupContract
+      operationId: createApiInstanceGroupContract
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -898,7 +898,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API contract
-      operationId: createApiContract
+      operationId: createApiInstanceContract
     get:
       responses:
         '200':
@@ -945,7 +945,7 @@ paths:
       - $ref: '#/components/parameters/trait_searchable_ascending'
       - $ref: '#/components/parameters/trait_searchable_query'
       summary: List API contracts
-      operationId: listApiContracts
+      operationId: listApiInstanceContracts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -964,7 +964,7 @@ paths:
                   $ref: ./apimanager/examples/responses/contracts.json
       description: "Retrieves a specific contract for the API\n\nConnected Apps require the following scopes:\n  - View Contracts\n"
       summary: Get an API contract
-      operationId: getApiContract
+      operationId: getApiInstanceContract
     patch:
       responses:
         '200':
@@ -988,14 +988,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update API contract conditions
-      operationId: updateApiContract
+      operationId: updateApiInstanceContract
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes the contract\n\nConnected Apps require the following scopes:\n  - Manage Contracts\n"
       summary: Delete an API contract
-      operationId: deleteApiContract
+      operationId: deleteApiInstanceContract
     parameters:
     - $ref: '#/components/parameters/param_contract_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1015,7 +1015,7 @@ paths:
                   $ref: ./apimanager/examples/responses/alerts.json
       description: "Retrieves a list of API alerts\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: List API alerts
-      operationId: listApiAlerts
+      operationId: listApiInstanceAlerts
     post:
       responses:
         '201':
@@ -1039,7 +1039,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create an API alert
-      operationId: createApiAlert
+      operationId: createApiInstanceAlert
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1077,7 +1077,7 @@ paths:
                 message: Resource not found
       description: "Retrieves an API alert\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: Get an API alert
-      operationId: getApiAlert
+      operationId: getApiInstanceAlert
     patch:
       responses:
         '200':
@@ -1127,7 +1127,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update an API alert
-      operationId: updateApiAlert
+      operationId: updateApiInstanceAlert
     delete:
       responses:
         '204':
@@ -1153,7 +1153,7 @@ paths:
                 message: Resource not found
       description: "Deletes the specified alert definition\n\nConnected Apps require the following scopes:\n  - Manage API Alerts\n"
       summary: Delete an API alert
-      operationId: deleteApiAlert
+      operationId: deleteApiInstanceAlert
     parameters:
     - $ref: '#/components/parameters/param_alert_id'
     - $ref: '#/components/parameters/param_environment_api_id'
@@ -1199,7 +1199,7 @@ paths:
           - type: boolean
             default: false
       summary: Export the API bundle
-      operationId: exportApiBundle
+      operationId: exportApiInstanceBundle
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1216,14 +1216,14 @@ paths:
                 message: Resource created successfully
       description: "Adds a new API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Add a new API tag
-      operationId: addApiTag
+      operationId: addApiInstanceTag
     delete:
       responses:
         '204':
           description: No Content. The operation completed successfully with no response body.
       description: "Deletes an API tag\n\nConnected Apps require the following scopes:\n  - Manage APIs Configuration\n"
       summary: Delete an API tag
-      operationId: deleteApiTag
+      operationId: deleteApiInstanceTag
     parameters:
     - name: tag
       in: path
@@ -1254,7 +1254,7 @@ paths:
         schema:
           type: string
       summary: Get API autodiscovery properties
-      operationId: getApiAutodiscoveryProperties
+      operationId: getApiInstanceAutodiscoveryProperties
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -1287,7 +1287,7 @@ paths:
                 message: Resource not found
       description: Retrieves TLS Contexts configuration for a given API endpoint
       summary: Get API TLS context configuration
-      operationId: getApiTlsContexts
+      operationId: getApiInstanceTlsContexts
     post:
       responses:
         '201':
@@ -1323,7 +1323,7 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Create API TLS context configuration
-      operationId: createApiTlsContexts
+      operationId: createApiInstanceTlsContexts
     put:
       responses:
         '200':
@@ -1344,14 +1344,14 @@ paths:
         required: true
         description: Request body containing the data needed for this operation.
       summary: Update API TLS context configuration
-      operationId: updateApiTlsContexts
+      operationId: updateApiInstanceTlsContexts
     delete:
       responses:
         '204':
           description: TLS Contexts successfully deleted
       description: Deletes TLS Contexts configuration
       summary: Delete API TLS context configuration
-      operationId: deleteApiTlsContexts
+      operationId: deleteApiInstanceTlsContexts
     parameters:
     - $ref: '#/components/parameters/param_environment_api_id'
     - $ref: '#/components/parameters/param_environment_id'
@@ -3061,7 +3061,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listApiUpstreams
+        operation: listApiInstanceUpstreams
         values: $.id
         labels: $.name
     param_policy_id:
@@ -3083,7 +3083,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:api-manager
-        operation: listApiAlerts
+        operation: listApiInstanceAlerts
         values: $.id
         labels: $.name
     param_group_instance_id:

--- a/apis/api-platform/api.yaml
+++ b/apis/api-platform/api.yaml
@@ -79,7 +79,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getPublicApis
+      summary: List public APIs
+      operationId: listPublicApisRoot
   /organizations:
     description: Organizations are the container entity for all API Portal-related resources.
   /organizations/active:
@@ -88,7 +89,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsActive
+      summary: Get the active organization
+      operationId: getActiveOrganization
   /organizations/{organizationId}:
     description: The organization's data.
     get:
@@ -114,7 +116,8 @@ paths:
           description: Bad Request.
         '500':
           description: An unknown error occurred.
-      operationId: getOrganizationsByOrganizationid
+      summary: Get an organization
+      operationId: getOrganization
     put:
       description: Update the organization.
       parameters:
@@ -129,7 +132,8 @@ paths:
           description: Bad Request.
         '500':
           description: An unknown error occurred.
-      operationId: updateOrganizationsByOrganizationid
+      summary: Update an organization
+      operationId: updateOrganization
     delete:
       description: Delete the organization.
       parameters:
@@ -137,7 +141,8 @@ paths:
       responses:
         '204':
           description: Organization deleted.
-      operationId: deleteOrganizationsByOrganizationid
+      summary: Delete an organization
+      operationId: deleteOrganization
   /organizations/{organizationId}/migration-mapping:
     get:
       description: Get all api version migration mappings in CSV format. This is for setting up the Crowd upgrade.
@@ -146,7 +151,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidMigrationMapping
+      summary: Export migration mappings as CSV
+      operationId: exportMigrationMappings
   /organizations/{organizationId}/permissions:
     description: A list of available permissions.
     get:
@@ -156,7 +162,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPermissions
+      summary: List organization permissions
+      operationId: listOrgPermissions
   /organizations/{organizationId}/alerts:
     get:
       description: Gets a collection of alerts.
@@ -310,7 +317,8 @@ paths:
                         operator: GREATER_THAN
                         value: 1000
               example: *id001
-      operationId: getOrganizationsByOrganizationidAlerts
+      summary: List organization alerts
+      operationId: listOrgAlerts
     post:
       description: Creates a new element.
       parameters:
@@ -321,7 +329,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidAlerts
+      summary: Create an organization alert
+      operationId: createOrgAlert
   /organizations/{organizationId}/environments:
     description: A list of available environments to deploy to.
     get:
@@ -345,7 +354,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidEnvironments
+      summary: List environments
+      operationId: listEnvironments
   /organizations/{organizationId}/environments/default:
     description: The default environment. This is defined in core services per organization.
     get:
@@ -364,7 +374,8 @@ paths:
                   organizationId: f0c9b011-980e-4928-9430-e60e3a97c043
                   isProduction: false
               example: *id002
-      operationId: getOrganizationsByOrganizationidEnvironmentsDefault
+      summary: Get the default environment
+      operationId: getDefaultEnvironment
       description: Retrieves a default.
   /organizations/{organizationId}/environments/{environmentId}/apis/{apiId}/versions/{apiVersionId}/alerts:
     post:
@@ -583,7 +594,8 @@ paths:
           description: Successfully created alert definition.
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByApiidVersionsByApiversionidAlerts
+      summary: Create an API version alert
+      operationId: createApiVersionAlert
     get:
       description: Returns a list of elements.
       parameters:
@@ -604,7 +616,8 @@ paths:
       responses:
         '200':
           description: Successfully retrieved an API Version's alert definitions.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByApiidVersionsByApiversionidAlerts
+      summary: List API version alerts
+      operationId: listApiVersionAlerts
   /organizations/{organizationId}/environments/{environmentId}/apis/{apiId}/versions/{apiVersionId}/alerts/{alertId}:
     description: An alert Item
     get:
@@ -832,7 +845,8 @@ paths:
           description: Insufficient permissions.
         '404':
           description: Specified alert not found.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByApiidVersionsByApiversionidAlertsByAlertid
+      summary: Get an API version alert
+      operationId: getApiVersionAlert
     patch:
       description: Updates a alert.
       parameters:
@@ -978,7 +992,8 @@ paths:
           description: Insufficient permissions.
         '404':
           description: Specified alert not found.
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByApiidVersionsByApiversionidAlertsByAlertid
+      summary: Patch an API version alert
+      operationId: patchApiVersionAlert
     delete:
       description: Deletes the specified alert definition.
       parameters:
@@ -1011,7 +1026,8 @@ paths:
           description: Insufficient permissions.
         '404':
           description: alert not found.
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByApiidVersionsByApiversionidAlertsByAlertid
+      summary: Delete an API version alert
+      operationId: deleteApiVersionAlert
   /organizations/{organizationId}/theme:
     put:
       description: Update the organization theme.
@@ -1023,7 +1039,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidTheme
+      summary: Update organization theme
+      operationId: updateOrgTheme
   /organizations/{organizationId}/theme/default:
     get:
       description: Get the default theme for an organization.
@@ -1032,7 +1049,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidThemeDefault
+      summary: Get default organization theme
+      operationId: getDefaultOrgTheme
   /organizations/{organizationId}/portals/terms:
     get:
       description: Gets portal terms set for the organization.
@@ -1041,7 +1059,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPortalsTerms
+      summary: Get organization portal terms
+      operationId: getPortalTerms
     put:
       description: Create portal terms for the organization.
       parameters:
@@ -1052,7 +1071,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidPortalsTerms
+      summary: Create organization portal terms
+      operationId: createPortalTerms
     delete:
       description: Deletes portal terms for the organization.
       parameters:
@@ -1060,7 +1080,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidPortalsTerms
+      summary: Delete organization portal terms
+      operationId: deletePortalTerms
   /organizations/{organizationId}/portals/redirectUri:
     put:
       description: Update redirect uri of the list of portals for the organization
@@ -1072,7 +1093,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidPortalsRedirecturi
+      summary: Update portals redirect URI
+      operationId: updatePortalsRedirectUri
   /organizations/{organizationId}/apis:
     description: A collection of APIs.
     get:
@@ -1130,7 +1152,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApis
+      summary: List APIs
+      operationId: listApis
     post:
       description: Creates an API.
       parameters:
@@ -1144,7 +1167,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApis
+      summary: Create an API
+      operationId: createApi
   /organizations/{organizationId}/apis/by-name:
     get:
       description: 'Returns a single API that matches the passed-in API name.
@@ -1163,7 +1187,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByName
+      summary: Get an API by name
+      operationId: getApiByName
   /organizations/{organizationId}/apis/versions:
     post:
       description: Create an API Version from an Exchange Spec. Only available after the Crowd upgrade.
@@ -1235,7 +1260,8 @@ paths:
                   tags: []
                   terms:
               example: *id004
-      operationId: createOrganizationsByOrganizationidApisVersions
+      summary: Create API version from Exchange spec
+      operationId: createApiVersionFromExchange
   /organizations/{organizationId}/apis/versions/by-endpoint:
     get:
       description: Returns a list of API versions for a given list of endpoints.
@@ -1254,7 +1280,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisVersionsByEndpoint
+      summary: List API versions by endpoint
+      operationId: listApiVersionsByEndpoint
   /organizations/{organizationId}/apis/versions/by-name:
     get:
       description: 'Returns a single API that matches the passed-in API name
@@ -1279,7 +1306,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisVersionsByName
+      summary: Get an API version by name
+      operationId: getApiVersionByName
   /organizations/{organizationId}/apis/versions/tiers:
     get:
       description: 'Returns permitted SLA tiers within an organization.
@@ -1292,7 +1320,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisVersionsTiers
+      summary: List permitted SLA tiers
+      operationId: listPermittedTiers
   /organizations/{organizationId}/apis/versions/contracts/applications:
     get:
       description: 'Returns permitted applications within an organization.
@@ -1305,7 +1334,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisVersionsContractsApplications
+      summary: List applications with API contracts
+      operationId: listContractedApplications
   /organizations/{organizationId}/apis/{apiId}:
     description: An API.
     get:
@@ -1316,7 +1346,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiid
+      summary: Get an API and its versions
+      operationId: getApi
     patch:
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -1327,7 +1358,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiid
+      summary: Patch an API
+      operationId: patchApi
       description: Updates a apis.
     delete:
       parameters:
@@ -1336,7 +1368,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiid
+      summary: Delete an API
+      operationId: deleteApi
       description: Deletes a apis.
   /organizations/{organizationId}/apis/{apiId}/portals:
     description: A collection of API portals.
@@ -1348,7 +1381,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidPortals
+      summary: List API portals
+      operationId: listApiPortals
   /organizations/{organizationId}/apis/{apiId}/permissions:
     post:
       description: Grant a user view access to this API.
@@ -1361,7 +1395,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidPermissions
+      summary: Grant view access to an API
+      operationId: grantApiPermission
   /organizations/{organizationId}/apis/{apiId}/versions:
     description: A collection of API versions.
     post:
@@ -1378,7 +1413,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersions
+      summary: Create an API version
+      operationId: createApiVersion
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}:
     description: An API version.
     get:
@@ -1397,7 +1433,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionid
+      summary: Get an API version
+      operationId: getApiVersion
     put:
       description: Updates a single element.
       parameters:
@@ -1417,7 +1454,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionid
+      summary: Update an API version
+      operationId: updateApiVersion
     patch:
       description: Patches a single element.
       parameters:
@@ -1437,7 +1475,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionid
+      summary: Patch an API version
+      operationId: patchApiVersion
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -1454,7 +1493,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionid
+      summary: Delete an API version
+      operationId: deleteApiVersion
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/classify:
     post:
       description: (Only avaliable after the Crowd upgrade) Moves an API Version from the unclassified environment into a specified environment.
@@ -1544,7 +1584,8 @@ paths:
           description: Bad request. The request was malformed or contains invalid parameters.
         '409':
           description: Conflict. The request conflicts with the current state of the resource.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidClassify
+      summary: Classify an API version
+      operationId: classifyApiVersion
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/export:
     get:
       description: Exports an API Version.
@@ -1604,7 +1645,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidExport
+      summary: Export an API version
+      operationId: exportApiVersion
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/users:
     description: Proxy for core services that return users, with exception of API OWNER role and the current user.
     get:
@@ -1649,7 +1691,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidUsers
+      summary: Search API version users
+      operationId: listApiVersionUsers
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/users/by-roles:
     description: 'Proxy for core services that return users for a given set of roles and context parameters.
 
@@ -1684,7 +1727,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidUsersByRoles
+      summary: List API version users by role
+      operationId: listApiVersionUsersByRole
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/users/owners:
     get:
       description: Return all owners of an API version.
@@ -1702,7 +1746,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidUsersOwners
+      summary: List API version owners
+      operationId: listApiVersionOwners
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/permissions:
     post:
       description: Grant a user admin access to this API version.
@@ -1723,7 +1768,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPermissions
+      summary: Grant admin access to API version
+      operationId: grantApiVersionAccess
     delete:
       description: Revoke a user's admin access to this API version.
       parameters:
@@ -1746,7 +1792,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPermissions
+      summary: Revoke admin access to API version
+      operationId: revokeApiVersionAccess
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/migration-mapping:
     description: This is for setting up for the Crowd upgrade.
     get:
@@ -1785,7 +1832,8 @@ paths:
                   migratePortal: true
                   crowdOneAccount: false
               example: *id006
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidMigrationMapping
+      summary: Get API version migration mapping
+      operationId: getApiVersionMigration
     post:
       description: Create a migration mapping for an API version
       parameters:
@@ -1805,7 +1853,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidMigrationMapping
+      summary: Create API version migration mapping
+      operationId: createApiVersionMigration
     put:
       description: Update a migration mapping of an API version
       parameters:
@@ -1825,7 +1874,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidMigrationMapping
+      summary: Update API version migration mapping
+      operationId: updateApiVersionMigration
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal:
     get:
       description: Obtain the portal associated with the API version.
@@ -1849,7 +1899,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortal
+      summary: Get API version portal
+      operationId: getApiVersionPortal
     post:
       description: Create a portal and associates it with an API version.
       parameters:
@@ -1869,7 +1920,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortal
+      summary: Create API version portal
+      operationId: createApiVersionPortal
     patch:
       description: Create a portal and associates it with an API version.
       parameters:
@@ -1889,7 +1941,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortal
+      summary: Patch API version portal
+      operationId: patchApiVersionPortal
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/permissions:
     post:
       description: Grant a user view access to this portal.
@@ -1910,7 +1963,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPermissions
+      summary: Grant view access to API portal
+      operationId: grantApiPortalAccess
     delete:
       description: Revoke a user's view access to portal.
       parameters:
@@ -1933,7 +1987,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPermissions
+      summary: Revoke view access to API portal
+      operationId: revokeApiPortalAccess
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/redirectUri:
     put:
       description: Update redirec uri for a portal
@@ -1954,7 +2009,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalRedirecturi
+      summary: Update API portal redirect URI
+      operationId: updateApiPortalRedirectUri
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/pages:
     description: A collection of portal pages.
     post:
@@ -1976,7 +2032,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPages
+      summary: Create an API portal page
+      operationId: createApiPortalPage
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/pages/{pageId}:
     put:
       description: Update an existing page.
@@ -2005,7 +2062,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPagesByPageid
+      summary: Update an API portal page
+      operationId: updateApiPortalPage
     delete:
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -2029,7 +2087,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPagesByPageid
+      summary: Delete an API portal page
+      operationId: deleteApiPortalPage
       description: Deletes a pages.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/pages/{pageId}/widgets:
     get:
@@ -2056,7 +2115,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPagesByPageidWidgets
+      summary: List API portal page widgets
+      operationId: listApiPortalPageWidgets
     patch:
       description: Updates the collection of widgets.
       parameters:
@@ -2084,7 +2144,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalPagesByPageidWidgets
+      summary: Patch API portal page widgets
+      operationId: patchApiPortalPageWidgets
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/theme:
     put:
       description: Update the portal theme.
@@ -2105,7 +2166,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalTheme
+      summary: Update API portal theme
+      operationId: updateApiPortalTheme
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/files:
     description: A collection of portal files.
     post:
@@ -2127,7 +2189,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalFiles
+      summary: Upload an API portal file
+      operationId: uploadApiPortalFile
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/files/{fileId}:
     get:
       description: Gets the portal file.
@@ -2151,7 +2214,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalFilesByFileid
+      summary: Get an API portal file
+      operationId: getApiPortalFile
     delete:
       description: Removes the Portal file.
       parameters:
@@ -2174,7 +2238,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalFilesByFileid
+      summary: Delete an API portal file
+      operationId: deleteApiPortalFile
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/portal/files/{fileId}/{fileName}:
     get:
       description: Same as parent get but allows to set a file name in the content-disposition header for downloading in a browser environment.
@@ -2204,7 +2269,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPortalFilesByFileidByFilename
+      summary: Download an API portal file
+      operationId: downloadApiPortalFile
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/addRootRaml:
     post:
       description: Adds the root RAML for this API version.
@@ -2225,7 +2291,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidAddrootraml
+      summary: Add root RAML for API version
+      operationId: addApiVersionRootRaml
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/definition:
     description: The fully resolved RAML spec for this version of the API.
     get:
@@ -2244,7 +2311,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidDefinition
+      summary: Get API version RAML spec
+      operationId: getApiVersionSpec
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/endpoint:
     description: The endpoint associated with the API version.
     get:
@@ -2267,7 +2335,8 @@ paths:
           description: Bad request.
         '404':
           description: No endpoint found for this API version.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpoint
+      summary: Get API version endpoint
+      operationId: getApiVersionEndpoint
     post:
       description: Creates an endpoint for the API version.
       parameters:
@@ -2291,7 +2360,8 @@ paths:
           description: Bad request.
         '409':
           description: The endpoint URL already exists.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpoint
+      summary: Create API version endpoint
+      operationId: createApiVersionEndpoint
     put:
       description: Updates the endpoint associated with the API version.
       parameters:
@@ -2313,7 +2383,8 @@ paths:
           description: The endpoint has been updated.
         '409':
           description: The endpoint URL already exists.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpoint
+      summary: Update API version endpoint
+      operationId: updateApiVersionEndpoint
     patch:
       description: Updates the endpoint associated with the API version.
       parameters:
@@ -2333,7 +2404,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpoint
+      summary: Patch API version endpoint
+      operationId: patchApiVersionEndpoint
     delete:
       description: Deletes the endpoint associated with the API version.
       parameters:
@@ -2350,7 +2422,8 @@ paths:
       responses:
         '204':
           description: The endpoint has been succesfully deleted.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpoint
+      summary: Delete API version endpoint
+      operationId: deleteApiVersionEndpoint
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/endpoint/active:
     post:
       description: Records activity for an API version.
@@ -2368,7 +2441,8 @@ paths:
       responses:
         '201':
           description: The API version activity has been recorded.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidEndpointActive
+      summary: Record API version endpoint activity
+      operationId: recordEndpointActivity
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/files:
     description: A collection of API version RAML files and directories.
     post:
@@ -2390,7 +2464,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFiles
+      summary: Create an API version file
+      operationId: createApiVersionFile
     get:
       description: Returns a list of elements.
       parameters:
@@ -2407,7 +2482,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFiles
+      summary: List API version files
+      operationId: listApiVersionFiles
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/files/export:
     get:
       description: Exports all files in the filesystem as a ZIP file.
@@ -2431,7 +2507,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFilesExport
+      summary: Export API version files as ZIP
+      operationId: exportApiVersionFiles
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/files/{apiVersionFileId}:
     description: An API version RAML file (or directory).
     get:
@@ -2458,7 +2535,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFilesByApiversionfileid
+      summary: Get an API version file
+      operationId: getApiVersionFile
     put:
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -2485,7 +2563,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFilesByApiversionfileid
+      summary: Replace an API version file
+      operationId: updateApiVersionFile
       description: Replaces a files.
     delete:
       parameters:
@@ -2510,7 +2589,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidFilesByApiversionfileid
+      summary: Delete an API version file
+      operationId: deleteApiVersionFile
       description: Deletes a files.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/policies:
     description: A collection of API version policies.
@@ -2559,7 +2639,8 @@ paths:
           description: Successful operation.
         '304':
           description: Resource has not been modified since the last request.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPolicies
+      summary: List API version policies
+      operationId: listApiVersionPolicies
     post:
       description: Creates a new element.
       parameters:
@@ -2579,7 +2660,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPolicies
+      summary: Apply a policy to API version
+      operationId: applyApiVersionPolicy
     patch:
       description: Updates multiple policies. Currently, only updates in order field are supported.
       parameters:
@@ -2609,7 +2691,8 @@ paths:
           description: Successful operation.
         '400':
           description: Bad request. The request was malformed or contains invalid parameters.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPolicies
+      summary: Reorder API version policies
+      operationId: reorderApiVersionPolicies
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/policies/{policyId}:
     description: An API version policy.
     patch:
@@ -2631,7 +2714,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPoliciesByPolicyid
+      summary: Patch an API version policy
+      operationId: patchApiVersionPolicy
       description: Updates a policies.
     delete:
       description: Unapplies a policy.
@@ -2650,7 +2734,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPoliciesByPolicyid
+      summary: Unapply an API version policy
+      operationId: unapplyApiVersionPolicy
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/policies/{policyId}/disable:
     description: Disables an API version policy.
     post:
@@ -2673,7 +2758,8 @@ paths:
           description: Bad request. The request was malformed or contains invalid parameters.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPoliciesByPolicyidDisable
+      summary: Disable an API version policy
+      operationId: disableApiVersionPolicy
       description: Creates a disable.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/policies/{policyId}/enable:
     description: Enables an API version policy.
@@ -2697,7 +2783,8 @@ paths:
           description: Bad request. The request was malformed or contains invalid parameters.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidPoliciesByPolicyidEnable
+      summary: Enable an API version policy
+      operationId: enableApiVersionPolicy
       description: Creates a enable.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/tags:
     description: Manages an API version tags.
@@ -2736,7 +2823,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTagsByTag
+      summary: Add a tag to an API version
+      operationId: addApiVersionTag
     delete:
       description: Removes a tag from an API version.
       parameters:
@@ -2760,7 +2848,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTagsByTag
+      summary: Remove a tag from an API version
+      operationId: removeApiVersionTag
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/tiers:
     description: Manages API version tiers.
     get:
@@ -2821,7 +2910,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTiers
+      summary: List API version SLA tiers
+      operationId: listApiVersionTiers
     post:
       description: Creates a sla tier for the API version.
       parameters:
@@ -2841,7 +2931,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTiers
+      summary: Create an API version SLA tier
+      operationId: createApiVersionTier
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/tiers/{tierId}:
     description: A particular tier associated with the API version.
     put:
@@ -2864,7 +2955,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTiersByTierid
+      summary: Update an API version SLA tier
+      operationId: updateApiVersionTier
     delete:
       description: Delete a tier that has no active applications.
       parameters:
@@ -2882,7 +2974,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidTiersByTierid
+      summary: Delete an API version SLA tier
+      operationId: deleteApiVersionTier
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts:
     description: Contracts associated with the API version.
     get:
@@ -2961,7 +3054,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContracts
+      summary: List API version contracts
+      operationId: listApiVersionContracts
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}:
     description: A particular contract associated with the API version.
     get:
@@ -2981,7 +3075,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractid
+      summary: Get an API version contract
+      operationId: getApiVersionContract
     patch:
       description: Patches contract conditions.
       parameters:
@@ -3002,7 +3097,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractid
+      summary: Patch an API version contract
+      operationId: patchApiVersionContract
     delete:
       description: Deletes the contract.
       parameters:
@@ -3020,7 +3116,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractid
+      summary: Delete an API version contract
+      operationId: deleteApiVersionContract
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/approveTierChange:
     description: Approves contract tier change request.
     post:
@@ -3039,7 +3136,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidApprovetierchange
+      summary: Approve contract tier change
+      operationId: approveContractTierChange
       description: Creates a approveTierChange.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/approve:
     description: Approves the contract.
@@ -3059,7 +3157,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidApprove
+      summary: Approve a contract
+      operationId: approveContract
       description: Creates a approve.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/reject:
     description: Rejects the contract.
@@ -3079,7 +3178,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidReject
+      summary: Reject a contract
+      operationId: rejectContract
       description: Creates a reject.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/rejectTierChange:
     description: Rejects contract tier change request.
@@ -3099,7 +3199,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidRejecttierchange
+      summary: Reject contract tier change
+      operationId: rejectContractTierChange
       description: Creates a rejectTierChange.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/restore:
     description: Restores contract.
@@ -3119,7 +3220,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidRestore
+      summary: Restore a contract
+      operationId: restoreContract
       description: Creates a restore.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/contracts/{contractId}/revoke:
     description: Revokes contract.
@@ -3139,7 +3241,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidContractsByContractidRevoke
+      summary: Revoke a contract
+      operationId: revokeContract
       description: Creates a revoke.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/proxy:
     description: Gets a proxy.
@@ -3172,7 +3275,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidProxy
+      summary: Get API version proxy
+      operationId: getApiVersionProxy
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/proxy/deployment:
     post:
       parameters:
@@ -3192,7 +3296,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApisByApiidVersionsByApiversionidProxyDeployment
+      summary: Create proxy deployment
+      operationId: createProxyDeployment
       description: Creates a deployment.
     patch:
       parameters:
@@ -3212,7 +3317,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApisByApiidVersionsByApiversionidProxyDeployment
+      summary: Patch proxy deployment
+      operationId: patchProxyDeployment
       description: Updates a deployment.
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/proxy/deployment/status:
     get:
@@ -3231,7 +3337,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidProxyDeploymentStatus
+      summary: Get proxy deployment status
+      operationId: getProxyDeploymentStatus
   /organizations/{organizationId}/apis/{apiId}/versions/{apiVersionId}/gateway-versions:
     description: Gets the gateway versions compatible for the API version, based on the RAML version tag specified on the root RAML file.
     get:
@@ -3250,7 +3357,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApisByApiidVersionsByApiversionidGatewayVersions
+      summary: List compatible gateway versions
+      operationId: listCompatibleGateways
   /organizations/{organizationId}/policy-templates:
     description: 'Policy Templates are the basis for creating new policies.
 
@@ -3279,7 +3387,8 @@ paths:
           description: The requested accept type is not supported.
         '500':
           description: An unknown error occurred.
-      operationId: getOrganizationsByOrganizationidPolicyTemplates
+      summary: List policy templates
+      operationId: listPolicyTemplates
   /organizations/{organizationId}/policy-templates/{policyTemplateId}:
     get:
       description: 'Retrieve specific details from the policy template, including the full
@@ -3318,7 +3427,8 @@ paths:
           description: The requested accept type is not supported.
         '500':
           description: An unknown error occurred.
-      operationId: getOrganizationsByOrganizationidPolicyTemplatesByPolicytemplateid
+      summary: Get a policy template
+      operationId: getPolicyTemplate
   /organizations/{organizationId}/custom-policy-templates:
     description: 'Custom Policy Templates are the basis for creating new policies.
 
@@ -3370,7 +3480,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidCustomPolicyTemplates
+      summary: List custom policy templates
+      operationId: listCustomPolicyTemplates
     post:
       description: Creates a new custom policy.
       parameters:
@@ -3381,7 +3492,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidCustomPolicyTemplates
+      summary: Create a custom policy template
+      operationId: createCustomPolicyTemplate
   /organizations/{organizationId}/custom-policy-templates/{customPolicyTemplateId}:
     description: A custom policy template.
     get:
@@ -3392,7 +3504,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateid
+      summary: Get a custom policy template
+      operationId: getCustomPolicyTemplate
     put:
       description: Updates a single element.
       parameters:
@@ -3404,7 +3517,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateid
+      summary: Update a custom policy template
+      operationId: updateCustomPolicyTemplate
     patch:
       description: Patches a single element.
       parameters:
@@ -3416,7 +3530,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateid
+      summary: Patch a custom policy template
+      operationId: patchCustomPolicyTemplate
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -3425,7 +3540,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateid
+      summary: Delete a custom policy template
+      operationId: deleteCustomPolicyTemplate
   /organizations/{organizationId}/custom-policy-templates/{customPolicyTemplateId}/configuration:
     get:
       description: The XML configuration for the custom policy template.
@@ -3441,7 +3557,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateidConfiguration
+      summary: Get custom policy XML configuration
+      operationId: getCustomPolicyConfig
   /organizations/{organizationId}/custom-policy-templates/{customPolicyTemplateId}/definition:
     get:
       description: The YAML definition for the custom policy template.
@@ -3457,7 +3574,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidCustomPolicyTemplatesByCustompolicytemplateidDefinition
+      summary: Get custom policy YAML definition
+      operationId: getCustomPolicyDefinition
   /organizations/{organizationId}/portals:
     description: A collection of API portals within organization.
     get:
@@ -3467,7 +3585,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPortals
+      summary: List portals
+      operationId: listPortals
     post:
       description: Creates a new element.
       parameters:
@@ -3478,7 +3597,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidPortals
+      summary: Create a portal
+      operationId: createPortal
   /organizations/{organizationId}/users:
     description: 'Proxy for core services that return organization users.
 
@@ -3522,7 +3642,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidUsers
+      summary: Search organization users
+      operationId: listOrgUsers
   /organizations/{organizationId}/applications:
     description: A collection of applications that consume APIs via contracts.
     get:
@@ -3580,7 +3701,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApplications
+      summary: List applications
+      operationId: listApplications
     post:
       description: Creates a new application.
       parameters:
@@ -3647,7 +3769,8 @@ paths:
           description: The organization is federated and the apiVersionId query parameter is missing.
         '409':
           description: Conflict. The request conflicts with the current state of the resource.
-      operationId: createOrganizationsByOrganizationidApplications
+      summary: Create an application
+      operationId: createApplication
   /organizations/{organizationId}/applications/{applicationId}:
     description: An application.
     get:
@@ -3664,7 +3787,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApplicationsByApplicationid
+      summary: Get an application
+      operationId: getApplication
     put:
       description: Updates a single element.
       parameters:
@@ -3676,7 +3800,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidApplicationsByApplicationid
+      summary: Update an application
+      operationId: updateApplication
     patch:
       description: Patches a single element.
       parameters:
@@ -3688,7 +3813,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApplicationsByApplicationid
+      summary: Patch an application
+      operationId: patchApplication
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -3697,7 +3823,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidApplicationsByApplicationid
+      summary: Delete an application
+      operationId: deleteApplication
   /organizations/{organizationId}/applications/{applicationId}/secret/reset:
     description: Resets client secret for application.
     post:
@@ -3707,7 +3834,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidApplicationsByApplicationidSecretReset
+      summary: Reset application client secret
+      operationId: resetApplicationSecret
       description: Creates a reset.
   /organizations/{organizationId}/applications/{applicationId}/party-ids:
     description: Party Ids associated with the application.
@@ -3725,7 +3853,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApplicationsByApplicationidPartyIds
+      summary: List application party IDs
+      operationId: listApplicationPartyIds
   /organizations/{organizationId}/applications/{applicationId}/owners:
     post:
       description: Adds an owner to an existing application.
@@ -3745,7 +3874,8 @@ paths:
           description: Resource created successfully.
         '404':
           description: The application cannot be found.
-      operationId: createOrganizationsByOrganizationidApplicationsByApplicationidOwners
+      summary: Add an application owner
+      operationId: addApplicationOwner
   /organizations/{organizationId}/applications/{applicationId}/owners/{userId}:
     delete:
       description: Removes an owner from an existing application.
@@ -3763,7 +3893,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '404':
           description: The application cannot be found.
-      operationId: deleteOrganizationsByOrganizationidApplicationsByApplicationidOwnersByUserid
+      summary: Remove an application owner
+      operationId: removeApplicationOwner
   /organizations/{organizationId}/applications/{applicationId}/contracts:
     description: Contracts associated with the application.
     get:
@@ -3810,7 +3941,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidApplicationsByApplicationidContracts
+      summary: List application contracts
+      operationId: listApplicationContracts
     post:
       description: Creates new contract between an API version and the application.
       parameters:
@@ -3822,7 +3954,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidApplicationsByApplicationidContracts
+      summary: Create an application contract
+      operationId: createApplicationContract
   /organizations/{organizationId}/applications/{applicationId}/contracts/{contractId}:
     description: A particular contract associated with the application.
     patch:
@@ -3847,7 +3980,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidApplicationsByApplicationidContractsByContractid
+      summary: Patch an application contract
+      operationId: patchApplicationContract
   /organizations/{organizationId}/contracts:
     get:
       parameters:
@@ -3867,7 +4001,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidContracts
+      summary: List organization contracts
+      operationId: listOrgContracts
       description: Retrieves a contracts.
   /organizations/{organizationId}/deployment-targets:
     description: A collection of deploy targets for Hybrid deploymentTargets.
@@ -3878,7 +4013,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidDeploymentTargets
+      summary: List deployment targets
+      operationId: listDeploymentTargets
       description: Retrieves a deployment targets.
   /organizations/{organizationId}/bundles:
     post:
@@ -3898,7 +4034,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidBundles
+      summary: Create a bundle
+      operationId: createBundle
       description: Creates a bundles.
   /organizations/{organizationId}/public:
     parameters:
@@ -3913,7 +4050,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicThemeLogo
+      summary: Get public organization logo
+      operationId: getPublicOrgLogo
       description: Retrieves a logo.
   /organizations/{organizationId}/public/theme/favicon:
     get:
@@ -3922,7 +4060,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicThemeFavicon
+      summary: Get public organization favicon
+      operationId: getPublicOrgFavicon
       description: Retrieves a favicon.
   /organizations/{organizationId}/public/permissions:
     description: A list of available permissions.
@@ -3932,7 +4071,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPermissions
+      summary: List public permissions
+      operationId: listPublicPermissions
       description: Retrieves a permissions.
   /organizations/{organizationId}/public/portals:
     description: 'A collection of API portals within organization.
@@ -4064,7 +4204,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPortals
+      summary: List public portals
+      operationId: listPublicPortals
     post:
       description: Creates a new element.
       parameters:
@@ -4075,7 +4216,8 @@ paths:
       responses:
         '201':
           description: The new element has been successfully created.
-      operationId: createOrganizationsByOrganizationidPublicPortals
+      summary: Create a public portal
+      operationId: createPublicPortal
   /organizations/{organizationId}/public/portals/{portalId}:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -4113,7 +4255,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPortalsByPortalidThemeLogo
+      summary: Get public portal logo
+      operationId: getPublicPortalLogo
       description: Retrieves a logo.
   /organizations/{organizationId}/public/portals/{portalId}/theme/favicon:
     get:
@@ -4130,7 +4273,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPortalsByPortalidThemeFavicon
+      summary: Get public portal favicon
+      operationId: getPublicPortalFavicon
       description: Retrieves a favicon.
   /organizations/{organizationId}/public/portals/terms:
     description: Portal terms for the organization.
@@ -4140,7 +4284,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPortalsTerms
+      summary: Get public portal terms
+      operationId: getPublicPortalTerms
       description: Retrieves a terms.
   /organizations/{organizationId}/public/portals/terms/acceptance:
     description: Accepted portal terms for current user.
@@ -4150,7 +4295,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicPortalsTermsAcceptance
+      summary: Get portal terms acceptance
+      operationId: getPortalTermsAcceptance
       description: Retrieves a acceptance.
   /organizations/{organizationId}/public/portals/terms/{portalTermsId}/acceptance:
     post:
@@ -4167,7 +4313,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createOrganizationsByOrganizationidPublicPortalsTermsByPortaltermsidAcceptance
+      summary: Accept portal terms
+      operationId: acceptPortalTerms
       description: Creates a acceptance.
   /organizations/{organizationId}/public/apis/{apiId}:
     description: An API.
@@ -4186,7 +4333,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiid
+      summary: Get a public API
+      operationId: getPublicApi
     put:
       description: Updates a single element.
       parameters:
@@ -4205,7 +4353,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidPublicApisByApiid
+      summary: Update a public API
+      operationId: updatePublicApi
     patch:
       description: Patches a single element.
       parameters:
@@ -4224,7 +4373,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidPublicApisByApiid
+      summary: Patch a public API
+      operationId: patchPublicApi
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -4240,7 +4390,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidPublicApisByApiid
+      summary: Delete a public API
+      operationId: deletePublicApi
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}:
     description: An API version.
     get:
@@ -4266,7 +4417,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionid
+      summary: Get a public API version
+      operationId: getPublicApiVersion
     put:
       description: Updates a single element.
       parameters:
@@ -4293,7 +4445,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionid
+      summary: Update a public API version
+      operationId: updatePublicApiVersion
     patch:
       description: Patches a single element.
       parameters:
@@ -4320,7 +4473,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionid
+      summary: Patch a public API version
+      operationId: patchPublicApiVersion
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -4344,7 +4498,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionid
+      summary: Delete a public API version
+      operationId: deletePublicApiVersion
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/portal:
     get:
       parameters:
@@ -4368,7 +4523,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidPortal
+      summary: Get public API portal
+      operationId: getPublicApiPortal
       description: Retrieves a portal.
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/portal/pages/{pageId}/widgets:
     get:
@@ -4399,7 +4555,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidPortalPagesByPageidWidgets
+      summary: List public portal page widgets
+      operationId: listPublicPortalWidgets
       description: Retrieves a widgets.
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/portal/files/{fileId}:
     get:
@@ -4433,7 +4590,8 @@ paths:
           description: Successful.
         '404':
           description: Not Found.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidPortalFilesByFileid
+      summary: Get a public portal file
+      operationId: getPublicPortalFile
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/portal/files/{fileId}/{fileName}:
     get:
       description: Same as parent get but allows to set a file name in the content-disposition header for downloading in a browser environment.
@@ -4470,7 +4628,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidPortalFilesByFileidByFilename
+      summary: Download a public portal file
+      operationId: downloadPublicPortalFile
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/tiers:
     get:
       parameters:
@@ -4494,7 +4653,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidTiers
+      summary: List public API SLA tiers
+      operationId: listPublicApiTiers
       description: Retrieves a tiers.
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/definition:
     description: The fully resolved RAML spec for this version of the API.
@@ -4521,7 +4681,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidDefinition
+      summary: Get public API version spec
+      operationId: getPublicApiSpec
     put:
       description: Updates a single element.
       parameters:
@@ -4548,7 +4709,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidDefinition
+      summary: Update public API version spec
+      operationId: updatePublicApiSpec
     patch:
       description: Patches a single element.
       parameters:
@@ -4575,7 +4737,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidDefinition
+      summary: Patch public API version spec
+      operationId: patchPublicApiSpec
     delete:
       description: Deletes the instance of the element specified.
       parameters:
@@ -4599,7 +4762,8 @@ paths:
       responses:
         '204':
           description: The element has been deleted successfully.
-      operationId: deleteOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidDefinition
+      summary: Delete public API version spec
+      operationId: deletePublicApiSpec
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/files:
     description: Serves RAML files for the portal.
     get:
@@ -4627,7 +4791,8 @@ paths:
           description: Temporary redirect to the root RAML file.
         '404':
           description: No RAML file found.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidFiles
+      summary: Redirect to public API root RAML
+      operationId: redirectPublicApiRoot
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/files/root:
     get:
       description: Retrieve the root RAML file contents.
@@ -4654,7 +4819,8 @@ paths:
           description: Temporary redirect to the root RAML file.
         '404':
           description: Not Found.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidFilesRoot
+      summary: Get public API root RAML file
+      operationId: getPublicApiRootFile
   /organizations/{organizationId}/public/apis/{apiId}/versions/{apiVersionId}/files/{+fileName}:
     get:
       description: Retrieve the RAML contents by file name.
@@ -4687,7 +4853,8 @@ paths:
           description: Successful.
         '404':
           description: Not Found.
-      operationId: getOrganizationsByOrganizationidPublicApisByApiidVersionsByApiversionidFilesByFilename
+      summary: Get public API file by name
+      operationId: getPublicApiFile
   /policies: {}
   /policies/{policyId}:
     description: A policy.
@@ -4704,7 +4871,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getPoliciesByPolicyid
+      summary: Get a policy
+      operationId: getPolicy
       description: Retrieves a policies.
   /ch-domains/{domainName}:
     description: Returns information about the availability desired CH domain.
@@ -4719,7 +4887,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getChDomainsByDomainname
+      summary: Get a CloudHub domain
+      operationId: getCloudhubDomain
       description: Retrieves a ch domains.
   /gateway-versions:
     description: A collection of supported gateway versions.
@@ -4728,7 +4897,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getGatewayVersions
+      summary: List gateway versions
+      operationId: listGatewayVersions
 components:
   securitySchemes:
     bearerAuth:
@@ -4783,7 +4953,7 @@ components:
         maximum: 2147483647
       x-origin:
       - api: urn:api:api-platform
-        operation: getOrganizationsByOrganizationidApis
+        operation: listApis
         description: GET `/organizations/{organizationId}/apis` in this API; use `id` values as `apiId`.
         values: $.id
       description: The api ID to identify the target resource.

--- a/apis/api-portal-xapi/api.yaml
+++ b/apis/api-portal-xapi/api.yaml
@@ -22,6 +22,7 @@ paths:
   /apimanager/xapi/v1/organizations/{organizationId}/exchange-policy-templates:
     get:
       description: Retrieve all policy templates (OOTB or custom) stored in Exchange for a given organization. Optionally filter by environment, API instance, Mule runtime version, or automation scope.
+      summary: List exchange policy templates
       operationId: getExchangePolicyTemplates
       parameters:
       - name: apiInstanceId
@@ -81,6 +82,7 @@ paths:
   /apimanager/xapi/v1/organizations/{organizationId}/environments/{environmentId}/gateway-targets:
     get:
       description: Retrieve a paged list of gateway targets registered in a given environment. Optionally filter by gateway name, kind, or status.
+      summary: List gateway targets
       operationId: getGatewayTargets
       responses:
         '200':

--- a/apis/arm-monitoring-query/api.yaml
+++ b/apis/arm-monitoring-query/api.yaml
@@ -40,6 +40,8 @@ servers:
 paths:
   /applications:
     get:
+      summary: List application metrics
+      operationId: listApplicationMetrics
       description: |
         Returns a list of application metrics with aggregated values.
       parameters:
@@ -2213,6 +2215,8 @@ paths:
             The user is not authorized to request the resource metric on the
             organization/environment.  
     post:
+      summary: List application metrics by IDs
+      operationId: listApplicationMetricsByIds
       description: >
         Returns a list of application metrics with aggregated values
         corresponding with the provided ids.      
@@ -4380,6 +4384,8 @@ paths:
             organization/environment.  
   "/applications/{id}":
     get:
+      summary: Get application metrics by ID
+      operationId: getApplicationMetricsById
       description: |
         Returns a list of application metrics with the aggregated values.
       parameters:
@@ -6564,6 +6570,8 @@ paths:
                     type: string
   "/applications/{id}/flows":
     get:
+      summary: List application flow metrics
+      operationId: listApplicationFlowMetrics
       description: |
         Returns a list of flow metrics with aggregated values.
       parameters:
@@ -6861,6 +6869,8 @@ paths:
             The user is not authorized to request the resource metric on the
             organization/environment.  
     post:
+      summary: List application flow metrics by IDs
+      operationId: listApplicationFlowMetricsByIds
       description: >
         Returns a list of flow metrics with aggregated values corresponding with
         the provided ids.      
@@ -7152,6 +7162,8 @@ paths:
             organization/environment.  
   /targets:
     get:
+      summary: List target metrics
+      operationId: listTargetMetrics
       description: |
         Returns a list of target metrics with aggregated values.
       parameters:
@@ -42152,6 +42164,8 @@ paths:
             The user is not authorized to request the resource metric on the
             organization/environment.  
     post:
+      summary: List target metrics by IDs
+      operationId: listTargetMetricsByIds
       description: >
         Returns a list of target metrics with aggregated values corresponding
         with the provided ids.      
@@ -77146,6 +77160,8 @@ paths:
             organization/environment.  
   "/targets/{id}":
     get:
+      summary: Get target metrics by ID
+      operationId: getTargetMetricsById
       description: |
         Returns a list of target metrics with the aggregated values.
       parameters:

--- a/apis/arm-rest-services/api.yaml
+++ b/apis/arm-rest-services/api.yaml
@@ -155,6 +155,7 @@ paths:
                 example: &id005
                   message: 'Unable to process Core Services response. Returned status code: 409'
               example: *id005
+      summary: Register server
       operationId: createServers
     get:
       description: Get the registered servers information.
@@ -196,6 +197,7 @@ paths:
                       clusterId: 2195
                       clusterName: Cluster-1
               example: *id006
+      summary: List servers
       operationId: getServers
   /servers/{serverId}:
     description: Operate on a server.
@@ -280,6 +282,7 @@ paths:
                 example: &id008
                   message: server not found
               example: *id008
+      summary: Get server by ID
       operationId: getServersByServerid
     patch:
       description: Modify a server name.
@@ -359,6 +362,7 @@ paths:
                   runtimeInformation:
                     type: object
               example: *id009
+      summary: Update server name
       operationId: patchServersByServerid
     delete:
       description: "remove the server from Runtime Manager: \n\nDeletes related server artifacts from all deployments. Does not attempt to undeploy the server artifacts from the server. Records are simply deleted.\n\nIf the server is connected, the connection is terminated and cannot be accepted in future.\n\nTo cleanly delete a server, first:\n\nRemove the server from its group/cluster.\n\nDelete all deployments whose deployment target is this server.\n\nWait until all applications are undeployed.\n"
@@ -381,6 +385,7 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
+      summary: Delete server
       operationId: deleteServersByServerid
   /servers/{serverId}/actions:
     description: "Performs stateless synchronic actions immediately. \nPossible options are:\n- RESTART\n- DELETE\n- RENEW_CERTIFICATE\n- SHUTDOWN\n"
@@ -416,6 +421,7 @@ paths:
                     reason: ''
                     description: ''
               example: *id010
+      summary: Execute server action
       operationId: createServersByServeridActions
   /servers/registrationToken:
     description: Get a registration token. This token needs to be used to register a new server.
@@ -455,6 +461,7 @@ paths:
                 example: &id012
                   message: registrationToken not found
               example: *id012
+      summary: Get server registration token
       operationId: getServersRegistrationtoken
     patch:
       parameters:
@@ -476,6 +483,7 @@ paths:
                   data:
                     type: string
               example: *id013
+      summary: Refresh server registration token
       operationId: patchServersRegistrationtoken
       description: Updates registrationToken.
   /serverGroups:
@@ -530,6 +538,7 @@ paths:
                     type: SERVER_GROUP
                     status: DISCONNECTED
               example: *id014
+      summary: List server groups
       operationId: getServergroups
     post:
       description: Create a server group from a list of servers. The servers must not belong to any other server group or cluster.
@@ -592,6 +601,7 @@ paths:
                     type: SERVER_GROUP
                     status: DISCONNECTED
               example: *id015
+      summary: Create server group
       operationId: createServergroups
   /serverGroups/{serverGroupId}:
     description: Performs operations on a server group.
@@ -655,6 +665,7 @@ paths:
                 example: &id017
                   message: serverGroup not found
               example: *id017
+      summary: Get server group by ID
       operationId: getServergroupsByServergroupid
     patch:
       description: Modify a server group. The only field that can be modified is the name of the server group.
@@ -769,6 +780,7 @@ paths:
                     - PARTIAL
                     type: string
               example: *id018
+      summary: Update server group
       operationId: patchServergroupsByServergroupid
     delete:
       description: Delete a server group.
@@ -779,6 +791,7 @@ paths:
       responses:
         '202':
           description: Request accepted for processing.
+      summary: Delete server group
       operationId: deleteServergroupsByServergroupid
   /serverGroups/{serverGroupId}/servers/{serverId}:
     description: Perform operations on a server that is part of a server group.
@@ -908,7 +921,8 @@ paths:
                 example: &id020
                   message: There are applications already deployed on the servers to be added
               example: *id020
-      operationId: createServergroupsByServergroupidServersByServerid
+      summary: Add server to server group
+      operationId: addServerToServerGroup
     delete:
       description: Remove a server from a server group. This undeploys any artifacts from the server that are deployed to this server group.
       parameters:
@@ -924,7 +938,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteServergroupsByServergroupidServersByServerid
+      summary: Remove server from server group
+      operationId: removeServerFromServerGroup
   /clusters:
     description: A server cluster consists of a set of tightly connected servers that work together and can be viewed as a single system. Unlike server groups, server clusters share information and status between nodes.
     post:
@@ -966,6 +981,7 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
+      summary: Create cluster
       operationId: createClusters
     get:
       description: Get a list of all registered clusters.
@@ -1029,6 +1045,7 @@ paths:
                       unknownNodeIps: []
                   status: RUNNING
               example: *id021
+      summary: List clusters
       operationId: getClusters
   /clusters/{clusterId}:
     description: Perform actions in a particular cluster.
@@ -1109,6 +1126,7 @@ paths:
                 example: &id023
                   message: cluster not found
               example: *id023
+      summary: Get cluster by ID
       operationId: getClustersByClusterid
     patch:
       description: Modify a cluster. The only field that can be modified is the name of the cluster.
@@ -1182,6 +1200,7 @@ paths:
                 type: array
                 items: {}
               example: *id024
+      summary: Update cluster
       operationId: patchClustersByClusterid
     delete:
       description: Delete a cluster.
@@ -1209,6 +1228,7 @@ paths:
       responses:
         '202':
           description: Request accepted for processing.
+      summary: Delete cluster
       operationId: deleteClustersByClusterid
   /clusters/{clusterId}/servers:
     description: Perform actions on a particular server in a cluster.
@@ -1252,6 +1272,7 @@ paths:
                 example: &id025
                   message: There are applications already deployed on the servers to be added
               example: *id025
+      summary: Add server to cluster
       operationId: createClustersByClusteridServers
   /clusters/{clusterId}/servers/{serverId}:
     description: Perform actions on a particular server in a cluster.
@@ -1287,7 +1308,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteClustersByClusteridServersByServerid
+      summary: Remove server from cluster
+      operationId: removeServerFromCluster
     put:
       description: Modifies clustering information for a server. The server must be part of a cluster.
       parameters:
@@ -1345,7 +1367,8 @@ paths:
                 - message: Server does not exist for this organization.
                 - message: Cluster does not exist in your organization.
               example: *id027
-      operationId: updateClustersByClusteridServersByServerid
+      summary: Update clustered server configuration
+      operationId: updateClusterServer
   /targets:
     description: A target can be a Server, Server Group or Cluster.
   /targets/{targetId}/components:
@@ -1363,6 +1386,7 @@ paths:
       responses:
         '200':
           description: Successful operation.
+      summary: List target components
       operationId: getTargetsByTargetidComponents
       description: Retrieves a components.
   /targets/{targetId}/components/{componentId}:
@@ -1408,7 +1432,8 @@ paths:
                 example: &id029
                   message: component not found
               example: *id029
-      operationId: getTargetsByTargetidComponentsByComponentid
+      summary: Get target component by ID
+      operationId: getTargetComponent
     put:
       parameters:
       - name: targetId
@@ -1423,7 +1448,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateTargetsByTargetidComponentsByComponentid
+      summary: Replace target component
+      operationId: replaceTargetComponent
       description: Replaces a components.
     patch:
       parameters:
@@ -1468,7 +1494,8 @@ paths:
                         - type: object
                         - type: string
               example: *id030
-      operationId: patchTargetsByTargetidComponentsByComponentid
+      summary: Update target component
+      operationId: updateTargetComponent
       description: Updates a components.
   /applications:
     description: An application refers to a Mule application or proxy that is running in a Mule Runtime. It's important to differentiate the application from its corresponding binary. The same binary can be deployed twice and represents two different applications.
@@ -1684,6 +1711,7 @@ paths:
               example: *id031
         '202':
           description: Request accepted for processing.
+      summary: Deploy application
       operationId: createApplications
     get:
       description: Get deployed applications that matches the query params.
@@ -1784,6 +1812,7 @@ paths:
                       discoveredArtifactNames: []
                       status: PARTIAL
               example: *id032
+      summary: List deployed applications
       operationId: getApplications
   /applications/{applicationId}:
     description: Operate over a single application.
@@ -1876,6 +1905,7 @@ paths:
                 example: &id034
                   message: application not found
               example: *id034
+      summary: Get application deployment status
       operationId: getApplicationsByApplicationid
     delete:
       description: Undeploy artifact from all servers in deployment target and delete the deployment.
@@ -1886,6 +1916,7 @@ paths:
       responses:
         '204':
           description: Undeployment is in progress.
+      summary: Undeploy application
       operationId: deleteApplicationsByApplicationid
     patch:
       description: Redeploys the app with a new artifact. If the file is not specified in the request then Runtime Manager redeploys the same file that was already in the server. If the content type is application/json then it changes the status of the deployed application from started to stopped or from stopped to started. No other application status changes are allowed. If the file is not specified and the content-type of the request body is multipart/form-data the application is RESTARTED.
@@ -2192,6 +2223,7 @@ paths:
                     - DEPLOYING
                     type: string
               example: *id035
+      summary: Redeploy or change application status
       operationId: patchApplicationsByApplicationid
   /applications/{applicationId}/artifact:
     get:
@@ -2208,6 +2240,7 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
+      summary: Download application artifact binary
       operationId: getApplicationsByApplicationidArtifact
     patch:
       description: Redeploys the app with a new artifact from the provided source.
@@ -2270,6 +2303,7 @@ paths:
       responses:
         '200':
           description: Successful operation.
+      summary: Redeploy application with new artifact
       operationId: patchApplicationsByApplicationidArtifact
   /applications/{applicationId}/flows:
     description: Default structure with which Mule applications are built.
@@ -2305,6 +2339,7 @@ paths:
                 example: &id037
                   message: Deployment does not exist in your organization
               example: *id037
+      summary: List application flows
       operationId: getApplicationsByApplicationidFlows
     patch:
       description: Updates the flows defined in the request body.
@@ -2356,6 +2391,7 @@ paths:
                 example: &id039
                   message: Deployment does not exist in your organization
               example: *id039
+      summary: Update application flows
       operationId: patchApplicationsByApplicationidFlows
     post:
       parameters:
@@ -2382,6 +2418,7 @@ paths:
                     - id: 54456
                       lastReportedStatus: STARTED
               example: *id040
+      summary: Create application flow
       operationId: createApplicationsByApplicationidFlows
       description: Creates a flows.
   /applications/{applicationId}/flows/{flowId}:
@@ -2409,7 +2446,8 @@ paths:
                 example: &id041
                   message: The given flow does not exist in this deployment.
               example: *id041
-      operationId: getApplicationsByApplicationidFlowsByFlowid
+      summary: Get application flow by ID
+      operationId: getApplicationFlow
     patch:
       description: Updates the flow with the specified ID.
       parameters:
@@ -2512,7 +2550,8 @@ paths:
                 example: &id044
                   message: The given flow does not exist in this deployment.
               example: *id044
-      operationId: patchApplicationsByApplicationidFlowsByFlowid
+      summary: Update application flow
+      operationId: updateApplicationFlow
   /applications/{applicationId}/schedulers:
     description: Retrieves all discovered schedulers for an application with its corresponding configuration.
     get:
@@ -2559,6 +2598,7 @@ paths:
                 example: &id046
                   message: Deployment does not exist in your organization
               example: *id046
+      summary: List application schedulers
       operationId: getApplicationsByApplicationidSchedulers
     patch:
       description: Updates the schedulers specified in the request body.
@@ -2624,7 +2664,8 @@ paths:
                 example: &id047
                   message: Scheduler does not exist in the specified deployment.
               example: *id047
-      operationId: patchApplicationsByApplicationidSchedulers
+      summary: Update application schedulers
+      operationId: updateApplicationSchedulers
     post:
       parameters:
       - $ref: '#/components/parameters/XOrigin_applicationId_Path'
@@ -2662,7 +2703,8 @@ paths:
                     startDelay: 0
                     timeUnit: MILLISECONDS
               example: *id048
-      operationId: createApplicationsByApplicationidSchedulers
+      summary: Create application schedulers
+      operationId: createApplicationSchedulers
       description: Creates a schedulers.
   /alerts:
     description: Alerts are the composition of a trigger and an event which is triggered based on conditions that are evaluated for Runtime Manager resources. This endpoint allows you to administrate the alerts that can be triggered by Runtime Manager.
@@ -2697,6 +2739,7 @@ paths:
                       - 45
                       event: DISCONNECTED
               example: *id049
+      summary: List alerts
       operationId: getAlerts
     post:
       parameters:
@@ -2731,6 +2774,7 @@ paths:
                       - 45
                       event: DISCONNECTED
               example: *id050
+      summary: Create alert
       operationId: createAlerts
       description: Creates alerts.
   /alerts/{alertId}:
@@ -2787,6 +2831,7 @@ paths:
                 example: &id052
                   message: alert not found
               example: *id052
+      summary: Get alert by ID
       operationId: getAlertsByAlertid
     patch:
       parameters:
@@ -2919,6 +2964,7 @@ paths:
                           - DEPLOYMENT_FAILED
                     type: object
               example: *id053
+      summary: Update alert
       operationId: patchAlertsByAlertid
       description: Updates a alerts.
   /alerts/{alertId}/history:
@@ -2965,6 +3011,7 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
+      summary: List alert history
       operationId: getAlertsByAlertidHistory
   /alerts/resources/{resourceId}/history:
     get:
@@ -3033,6 +3080,7 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
+      summary: List alert history for resource
       operationId: getAlertsResourcesByResourceidHistory
 components:
   securitySchemes:

--- a/apis/citizen-platform-experience/api.yaml
+++ b/apis/citizen-platform-experience/api.yaml
@@ -69,7 +69,8 @@ paths:
                   lastUpdatedDate: 2020-04-09 03:19:14
         '401':
           description: Unauthorized user.
-      operationId: getOrganizationsByOrganizationidFlows
+      summary: List organization flows
+      operationId: listFlows
     post:
       description: Creates a new flow.
       parameters:
@@ -97,7 +98,8 @@ paths:
           description: Unauthorized user.
         '409':
           description: Duplicated flow name.
-      operationId: createOrganizationsByOrganizationidFlows
+      summary: Create flow
+      operationId: createFlow
   /organizations/{organizationId}/flows/{flowId}:
     description: Retrieves a flow.
     get:
@@ -231,7 +233,8 @@ paths:
                       componentType: TEXT
                   createdDate: 2020-05-18 09:22:19.297000+00:00
                   lastUpdatedDate: 2020-05-18 09:22:19.297000+00:00
-      operationId: getOrganizationsByOrganizationidFlowsByFlowid
+      summary: Get flow by ID
+      operationId: getFlowById
     put:
       description: Save changes in a flow.
       parameters:
@@ -379,7 +382,8 @@ paths:
           description: You are not the owner of this flow.
         '404':
           description: Flow not found.
-      operationId: updateOrganizationsByOrganizationidFlowsByFlowid
+      summary: Update flow
+      operationId: updateFlow
     delete:
       description: Deletes a flow
       parameters:
@@ -395,7 +399,8 @@ paths:
       responses:
         '204':
           description: User flow was successfully deleted.
-      operationId: deleteOrganizationsByOrganizationidFlowsByFlowid
+      summary: Delete flow
+      operationId: deleteFlow
   /organizations/{organizationId}/flows/{flowId}/clone:
     description: Clones a Flow
     post:
@@ -426,7 +431,8 @@ paths:
           content:
             '*/*':
               schema: {}
-      operationId: createOrganizationsByOrganizationidFlowsByFlowidClone
+      summary: Clone flow
+      operationId: cloneFlow
   /organizations/{organizationId}/flows/{flowId}/execute:
     description: ''
     post:
@@ -455,7 +461,8 @@ paths:
           description: Flow not found.
         '409':
           description: Flow already running or it is being started/stopped.
-      operationId: createOrganizationsByOrganizationidFlowsByFlowidExecute
+      summary: Execute flow
+      operationId: executeFlow
   /organizations/{organizationId}/flows/{flowId}/stop:
     description: ''
     post:
@@ -484,7 +491,8 @@ paths:
           description: Flow not found.
         '409':
           description: Flow is not running or it is being stopped.
-      operationId: createOrganizationsByOrganizationidFlowsByFlowidStop
+      summary: Stop flow
+      operationId: stopFlow
   /organizations/{organizationId}/flows/{flowId}/status:
     description: ''
     get:
@@ -509,7 +517,8 @@ paths:
                 description: Status available
         '404':
           description: Flow not found.
-      operationId: getOrganizationsByOrganizationidFlowsByFlowidStatus
+      summary: Get flow status
+      operationId: getFlowStatus
   /organizations/{organizationId}/flows/{flowId}/test:
     post:
       description: Starts a test for a flow.
@@ -662,7 +671,8 @@ paths:
           description: Flow does not exists.
         '409':
           description: Flow already running.
-      operationId: createOrganizationsByOrganizationidFlowsByFlowidTest
+      summary: Start flow test
+      operationId: startFlowTest
     delete:
       description: Stops a test for a flow.
       parameters:
@@ -693,7 +703,8 @@ paths:
           description: Flow does not exists.
         '409':
           description: Flow not running.
-      operationId: deleteOrganizationsByOrganizationidFlowsByFlowidTest
+      summary: Stop flow test
+      operationId: stopFlowTest
   /organizations/{organizationId}/flows/{flowId}/test-status:
     get:
       description: Returns the status of a flow test.
@@ -734,7 +745,8 @@ paths:
           description: Flow does not exist.
         '429':
           description: Quota Limit reached for concurrent Design Operations.
-      operationId: getOrganizationsByOrganizationidFlowsByFlowidTestStatus
+      summary: Get flow test status
+      operationId: getFlowTestStatus
   /organizations/{organizationId}/flows/{flowId}/test-messages:
     get:
       description: Returns the messages of a flow test.
@@ -788,7 +800,8 @@ paths:
           description: Flow does not exist.
         '429':
           description: Quota Limit reached for concurrent Design Operations.
-      operationId: getOrganizationsByOrganizationidFlowsByFlowidTestMessages
+      summary: Get flow test messages
+      operationId: getFlowTestMessages
   /organizations/{organizationId}/connectors:
     description: List the available systems that the user can choose from.
     get:
@@ -818,7 +831,8 @@ paths:
                 hasConnection: 'true'
                 hasTrigger: 'true'
                 hasAction: 'true'
-      operationId: getOrganizationsByOrganizationidConnectors
+      summary: List connectors
+      operationId: listConnectors
   /organizations/{organizationId}/connectors/{connectorName}:
     description: Returns the citizen model for a given connector.
     get:
@@ -937,7 +951,8 @@ paths:
               example: *id006
         '404':
           description: Connector not found.
-      operationId: getOrganizationsByOrganizationidConnectorsByConnectorname
+      summary: Get connector
+      operationId: getConnector
       description: Retrieves a connectors.
   /organizations/{organizationId}/connectors/{connectorName}/sample-data:
     description: Returns the sample data for a connector element associated with a given connection.
@@ -1078,7 +1093,8 @@ paths:
           description: Connection not found.
         '429':
           description: Quota Limit reached for concurrent Design Operations.
-      operationId: createOrganizationsByOrganizationidConnectorsByConnectornameSampleData
+      summary: Get connector sample data
+      operationId: getConnectorSampleData
   /organizations/{organizationId}/connectors/{connectorName}/entity-provider:
     description: Returns the entity provider data for a connector element associated with a given connection.
     post:
@@ -1638,7 +1654,8 @@ paths:
           description: Bad request.
         '401':
           description: Unauthorized.
-      operationId: createOrganizationsByOrganizationidConnectorsByConnectornameEntityProvider
+      summary: Get connector entity provider
+      operationId: getConnectorEntityProvider
   /organizations/{organizationId}/connectors/{connectorName}/connections:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -1736,7 +1753,8 @@ paths:
           description: Connection not found.
         '429':
           description: Quota Limit reached for concurrent Design Operations.
-      operationId: createOrganizationsByOrganizationidConnectorsByConnectornameConnectionsByConnectionidValueResolver
+      summary: Resolve connection data provider values
+      operationId: resolveConnectionValues
   /organizations/{organizationId}/connectors/{connectorName}/connections/{connectionId}/metadata:
     description: Returns the metadata for a connector element associated with a given connection.
     post:
@@ -1869,7 +1887,8 @@ paths:
           description: Connection not found.
         '429':
           description: Quota Limit reached for concurrent Design Operations.
-      operationId: createOrganizationsByOrganizationidConnectorsByConnectornameConnectionsByConnectionidMetadata
+      summary: Get connection metadata
+      operationId: getConnectionMetadata
   /organizations/{organizationId}/connection-schemas:
     description: Represent the avaliable connection schemas.
     parameters:
@@ -1910,7 +1929,8 @@ paths:
               example: *id011
         '400':
           description: Bad Request.
-      operationId: getOrganizationsByOrganizationidConnectionSchemasConnectorsByConnectorname
+      summary: List connector connection schemas
+      operationId: listConnectorConnectionSchemas
   /organizations/{organizationId}/connections:
     description: Manage connections.
     get:
@@ -1975,7 +1995,8 @@ paths:
               example: *id012
         '400':
           description: Bad Request.
-      operationId: getOrganizationsByOrganizationidConnections
+      summary: List connections
+      operationId: listConnections
     post:
       description: Creates a new **non-OAuth** connection. For starting OAuth dance, please use `/ocs-connections`.
       parameters:
@@ -2011,7 +2032,8 @@ paths:
               example: *id013
         '400':
           description: Bad Request.
-      operationId: createOrganizationsByOrganizationidConnections
+      summary: Create non-OAuth connection
+      operationId: createConnection
   /organizations/{organizationId}/connections/connectors:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -2054,7 +2076,8 @@ paths:
               example: *id014
         '400':
           description: Bad Request.
-      operationId: getOrganizationsByOrganizationidConnectionsConnectorsByConnectorname
+      summary: List connections by connector
+      operationId: listConnectionsByConnector
       description: Retrieves a connectors.
   /organizations/{organizationId}/connections/{connectionId}:
     get:
@@ -2085,7 +2108,8 @@ paths:
               example: *id015
         '400':
           description: Bad Request.
-      operationId: getOrganizationsByOrganizationidConnectionsByConnectionid
+      summary: Get connection by ID
+      operationId: getConnectionById
     patch:
       description: Update a connection.
       parameters:
@@ -2114,7 +2138,8 @@ paths:
           description: Connection was successfully updated.
         '400':
           description: Bad Request.
-      operationId: patchOrganizationsByOrganizationidConnectionsByConnectionid
+      summary: Update connection
+      operationId: updateConnection
     delete:
       description: Delete a connection.
       parameters:
@@ -2134,7 +2159,8 @@ paths:
           description: Unauthorized.
         '429':
           description: Quota Limit reached.
-      operationId: deleteOrganizationsByOrganizationidConnectionsByConnectionid
+      summary: Delete connection
+      operationId: deleteConnection
   /organizations/{organizationId}/connections/{connectionId}/test:
     post:
       description: Test the connectivity of an existing connection.
@@ -2175,7 +2201,8 @@ paths:
               example: *id016
         '400':
           description: Bad Request.
-      operationId: createOrganizationsByOrganizationidConnectionsByConnectionidTest
+      summary: Test connection
+      operationId: testConnection
   /organizations/{organizationId}/connections/test:
     post:
       description: Test the connectivity of a draft connection.
@@ -2221,7 +2248,8 @@ paths:
               example: *id017
         '400':
           description: Bad Request.
-      operationId: createOrganizationsByOrganizationidConnectionsTest
+      summary: Test draft connection
+      operationId: testDraftConnection
   /organizations/{organizationId}/ocs-connections:
     description: Handles the process for creating OAuth connections.
     post:
@@ -2247,7 +2275,8 @@ paths:
               example: *id018
         '400':
           description: Bad Request.
-      operationId: createOrganizationsByOrganizationidOcsConnections
+      summary: Start OAuth connection dance
+      operationId: startOauthConnection
 components:
   requestBodies:
     Generated:

--- a/apis/cloudhub-20/api.yaml
+++ b/apis/cloudhub-20/api.yaml
@@ -119,7 +119,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespaces
+      summary: List Private Spaces
+      operationId: listPrivateSpaces
     post:
       description: create a Private Space
       parameters:
@@ -229,7 +230,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespaces
+      summary: Create a Private Space
+      operationId: createPrivateSpace
   /organizations/{organizationId}/privatespaces/supportedVpnConfigs:
     get:
       description: get supported vpn configs
@@ -238,7 +240,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesSupportedvpnconfigs
+      summary: List supported VPN configurations
+      operationId: listSupportedVpnConfigs
   /organizations/{organizationId}/privatespaces/monthlypatchwindow:
     get:
       description: get the latest upcoming monthly patch window schedule
@@ -259,7 +262,8 @@ paths:
                 sandboxEndDate: &id006 2024-03-22 23:59:59.999000+00:00
                 productionStartDate: &id007 2024-03-23 00:00:00+00:00
                 productionEndDate: &id008 2024-03-24 23:59:59.999000+00:00
-      operationId: getOrganizationsByOrganizationidPrivatespacesMonthlypatchwindow
+      summary: Get monthly patch window schedule
+      operationId: getMonthlyPatchWindow
   /organizations/{organizationId}/privatespaces/{privateSpaceId}:
     description: Get an entity representing a privatespace
     delete:
@@ -270,7 +274,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Delete a Private Space
+      operationId: deletePrivateSpace
     get:
       description: get the Private Space
       parameters:
@@ -330,7 +335,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Get a Private Space
+      operationId: getPrivateSpace
     patch:
       description: Update existing Private Space
       parameters:
@@ -391,7 +397,8 @@ paths:
                         filters: []
                       protocol: https-redirect
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceid
+      summary: Update a Private Space
+      operationId: updatePrivateSpace
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/associations:
     post:
       description: create associations for Private space with business groups and environments
@@ -423,7 +430,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/Association'
               example: *id001
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociations
+      summary: Create Private Space associations
+      operationId: createAssociations
     get:
       description: get all associations of a private space.
       parameters:
@@ -447,7 +455,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/Association'
               example: *id002
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociations
+      summary: List Private Space associations
+      operationId: listAssociations
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/associations/{associationId}:
     get:
       description: get a specific associations of a private space.
@@ -472,7 +481,8 @@ paths:
                 id: d282e462-07af-4146-b7d8-8bd7e6b18d83
                 environmentId: 2ea3eff9-569a-4495-b7b6-1e28c6440aeb
                 organizationId: 1ffdaa42-4702-4747-aeb9-aecab0f5ac1b
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociationsByAssociationid
+      summary: Get a Private Space association
+      operationId: getAssociation
     delete:
       description: delete an association
       parameters:
@@ -487,7 +497,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAssociationsByAssociationid
+      summary: Delete a Private Space association
+      operationId: deleteAssociation
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/ports:
     get:
       description: Get the next set of available ports.
@@ -522,7 +533,8 @@ paths:
                 - 0
         '409':
           description: All the available ports for the space are in use.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidPorts
+      summary: Get available ports
+      operationId: getAvailablePorts
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/iamroles:
     get:
       description: get the IAM roles associated with the space.
@@ -543,7 +555,8 @@ paths:
                 organizationId: string
                 spaceId: string
                 message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidIamroles
+      summary: Get IAM roles for the Private Space
+      operationId: getPrivateSpaceIamRoles
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/accounts:
     get:
       description: get the AWS account Id a string value.
@@ -553,7 +566,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidAccounts
+      summary: Get AWS account ID for the Private Space
+      operationId: getPrivateSpaceAwsAccountId
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/upgrade:
     patch:
       description: Either upgrade now or (re)schedule an upgrade later
@@ -583,7 +597,8 @@ paths:
               example:
                 scheduledUpdateTime: &id003 2024-02-28 17:57:36+00:00
                 status: QUEUED
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgrade
+      summary: Schedule or trigger Private Space upgrade
+      operationId: schedulePrivateSpaceUpgrade
     delete:
       description: cancel a scheduled upgrade
       parameters:
@@ -592,7 +607,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgrade
+      summary: Cancel a scheduled Private Space upgrade
+      operationId: cancelPrivateSpaceUpgrade
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/upgradestatus:
     get:
       description: get the upgrade status of the space
@@ -610,7 +626,8 @@ paths:
               example:
                 scheduledUpdateTime: *id003
                 status: QUEUED
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidUpgradestatus
+      summary: Get Private Space upgrade status
+      operationId: getPrivateSpaceUpgradeStatus
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/egress:
     post:
       description: create an egress rule group
@@ -635,7 +652,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgress
+      summary: Create an egress rule group
+      operationId: createEgressRuleGroup
     get:
       description: get all egress rule groups of a private space.
       parameters:
@@ -662,7 +680,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/EgressRuleGroup'
               example: *id004
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgress
+      summary: List egress rule groups
+      operationId: listEgressRuleGroups
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/egress/{ruleGroupId}:
     delete:
       description: delete egress rule group
@@ -678,7 +697,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Delete an egress rule group
+      operationId: deleteEgressRuleGroup
     get:
       description: get a specific egress rule group
       parameters:
@@ -705,7 +725,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Get an egress rule group
+      operationId: getEgressRuleGroup
     patch:
       description: Update egress rule group.
       parameters:
@@ -735,7 +756,8 @@ paths:
                 - id: string
                   type: string
                 isDefault: true
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidEgressByRulegroupid
+      summary: Update an egress rule group
+      operationId: updateEgressRuleGroup
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/routes:
     get:
       description: get the list of CIDR's in the private space.
@@ -755,7 +777,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidRoutes
+      summary: List Private Space routes
+      operationId: listPrivateSpaceRoutes
     patch:
       description: Update the CIDRs that the Cloudhub VPC will send traffic to via the IGW.
       parameters:
@@ -781,7 +804,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidRoutes
+      summary: Update Private Space routes
+      operationId: updatePrivateSpaceRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections:
     description: The collection of connections
     get:
@@ -857,7 +881,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnections
+      summary: List Private Space connections
+      operationId: listConnections
     post:
       description: create a Private Space Connection
       parameters:
@@ -955,7 +980,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnections
+      summary: Create a Private Space connection
+      operationId: createConnection
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/{connectionId}:
     description: Get an entity representing a connection
     delete:
@@ -967,7 +993,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Delete a Private Space connection
+      operationId: deleteConnection
     get:
       description: get the Private Space Connection
       parameters:
@@ -1015,7 +1042,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Get a Private Space connection
+      operationId: getConnection
     patch:
       description: Update existing Private Space Connection
       parameters:
@@ -1075,7 +1103,8 @@ paths:
                       vpnTunnels: []
                       vpnTunnelsConfig: []
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsByConnectionid
+      summary: Update a Private Space connection
+      operationId: updateConnection
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns:
     post:
       description: add a vpn to an existing connection.
@@ -1126,7 +1155,8 @@ paths:
               example: {}
         '409':
           description: Conflict. The request conflicts with the current state of the resource.
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpns
+      summary: Add a VPN to a connection
+      operationId: addConnectionVpn
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns/{vpnId}:
     delete:
       description: delete a vpn from a connection.
@@ -1142,7 +1172,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnid
+      summary: Delete a VPN from a connection
+      operationId: deleteConnectionVpn
     patch:
       description: delete a vpn from a connection.
       parameters:
@@ -1180,7 +1211,8 @@ paths:
                 vpnTunnels:
                 - id: string
                   type: string
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnid
+      summary: Update a VPN in a connection
+      operationId: updateConnectionVpn
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/connections/vpns/{vpnId}/connectionGuide:
     description: download connection guide for vpn.
     get:
@@ -1214,7 +1246,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidConnectionsVpnsByVpnidConnectionguide
+      summary: Download VPN connection guide
+      operationId: getVpnConnectionGuide
       description: Retrieves a connectionGuide.
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways:
     description: The collection of transitgateways
@@ -1313,7 +1346,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+      summary: List Private Space Transit Gateway connections
+      operationId: listPrivateSpaceTgws
     post:
       description: create a private space TGW connection.
       parameters:
@@ -1405,7 +1439,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+      summary: Create a Private Space Transit Gateway connection
+      operationId: createPrivateSpaceTgw
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/{tgwId}:
     description: Get an entity representing a transitgateway
     delete:
@@ -1417,7 +1452,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Detach a Transit Gateway from a Private Space
+      operationId: deletePrivateSpaceTgw
     patch:
       description: patch the Private Space TGW Connection
       parameters:
@@ -1475,7 +1511,8 @@ paths:
                       - 10.0.0.0/21
                       - 10.0.0.0/22
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Update a Private Space Transit Gateway
+      operationId: updatePrivateSpaceTgw
     get:
       description: 'Get the transitgateway
 
@@ -1523,7 +1560,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwid
+      summary: Get a Private Space Transit Gateway
+      operationId: getPrivateSpaceTgw
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/{tgwId}/routes:
     patch:
       description: patch routes for a TGW connection.
@@ -1543,7 +1581,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwidRoutes
+      summary: Update Transit Gateway connection routes
+      operationId: updateTgwConnectionRoutes
     get:
       description: get TGW routes configured to tgw connection.
       parameters:
@@ -1553,7 +1592,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysByTgwidRoutes
+      summary: List Transit Gateway connection routes
+      operationId: listTgwConnectionRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways/routes:
     get:
       description: get TGW routes configured to private space.
@@ -1563,7 +1603,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgatewaysRoutes
+      summary: List Transit Gateway routes for Private Space
+      operationId: listPrivateSpaceTgwRoutes
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/tlsContexts:
     description: The collection of tlsContexts
     get:
@@ -1793,7 +1834,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontexts
+      summary: List TLS contexts
+      operationId: listTlsContexts
     post:
       description: create a TLS context
       parameters:
@@ -2004,7 +2046,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontexts
+      summary: Create a TLS context
+      operationId: createTlsContext
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/tlsContexts/{contextId}:
     description: Get an entity representing a tlsContext
     delete:
@@ -2021,7 +2064,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Delete a TLS context
+      operationId: deleteTlsContext
     get:
       description: get the TLS context
       parameters:
@@ -2112,7 +2156,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Get a TLS context
+      operationId: getTlsContext
     patch:
       description: Update an existing TLS context
       parameters:
@@ -2215,7 +2260,8 @@ paths:
                       tlsAes128GcmSha256: true
                     type: custom
               example: {}
-      operationId: patchOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTlscontextsByContextid
+      summary: Update a TLS context
+      operationId: updateTlsContext
   /organizations/{organizationId}/privatespaces/{privateSpaceId}/logs:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -2241,7 +2287,8 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
-      operationId: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidLogsIngress
+      summary: Download ingress logs
+      operationId: downloadIngressLogs
   /organizations/{organizationId}:
     parameters:
     - $ref: '#/components/parameters/XOrigin_networkOrganizationId_Path'
@@ -2353,7 +2400,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidTransitgateways
+      summary: List Transit Gateway connections for the org
+      operationId: listOrgTransitGateways
   /organizations/{organizationId}/transitgateways/{tgwId}:
     delete:
       description: Remove the Transit gateway from your Anypoint Platform organization
@@ -2363,7 +2411,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidTransitgatewaysByTgwid
+      summary: Remove a Transit Gateway from the organization
+      operationId: deleteOrgTransitGateway
   /organizations/{organizationId}/transitgateways/{tgwId}/routes:
     get:
       description: get TGW routes configured for a gateway
@@ -2373,7 +2422,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getOrganizationsByOrganizationidTransitgatewaysByTgwidRoutes
+      summary: Get Transit Gateway routes
+      operationId: listOrgTgwRoutes
   /organizations/{organizationId}/targets:
     description: The collection of targets
     get:
@@ -2537,7 +2587,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidTargets
+      summary: List deployment targets
+      operationId: listTargets
   /organizations/{organizationId}/targets/{id}:
     get:
       description: get the target
@@ -2573,7 +2624,8 @@ paths:
                 environments:
                 - string
                 isAvailableForDeployments: true
-      operationId: getOrganizationsByOrganizationidTargetsById
+      summary: Get a deployment target
+      operationId: getTarget
   /organizations/{organizationId}/migration:
     parameters:
     - $ref: '#/components/parameters/XOrigin_vpnOrganizationId_Path'
@@ -2701,7 +2753,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidMigrationVpcsByVpcidPrivatespaces
+      summary: Migrate a Cloudhub VPC to a Private Space
+      operationId: migrateVpcToPrivateSpace
   /organizations/{organizationId}/migration/vpcs:
     get:
       description: get Cloudhub VPCs upgrade eligibility information
@@ -2712,7 +2765,8 @@ paths:
           description: Successful operation.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getOrganizationsByOrganizationidMigrationVpcs
+      summary: List Cloudhub VPCs eligible for upgrade
+      operationId: listMigratableVpcs
   /organizations/{organizationId}/migration/vpcs/{vpcId}:
     get:
       description: get Cloudhub VPC upgrade eligibility information
@@ -2734,7 +2788,8 @@ paths:
           description: Successful operation.
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getOrganizationsByOrganizationidMigrationVpcsByVpcid
+      summary: Get VPC upgrade eligibility
+      operationId: getVpcMigrationInfo
 components:
   securitySchemes:
     bearerAuth:
@@ -4661,7 +4716,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidPrivatespaces
+        operation: listPrivateSpaces
         description: GET `/organizations/{organizationId}/privatespaces` in this API; use `id` values as `privateSpaceId`.
         values: $.id
         labels: $.name
@@ -4676,7 +4731,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidPrivatespacesByPrivatespaceidTransitgateways
+        operation: listPrivateSpaceTgws
         description: GET `/organizations/{organizationId}/privatespaces/{privateSpaceId}/transitgateways` in this API; use `id` values as `tgwId`.
         values: $.id
         labels: $.name
@@ -4691,7 +4746,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub-20
-        operation: getOrganizationsByOrganizationidTransitgateways
+        operation: listOrgTransitGateways
         description: GET `/organizations/{organizationId}/transitgateways` in this API; use `id` values as `tgwId`.
         values: $.id
         labels: $.name

--- a/apis/cloudhub/api.yaml
+++ b/apis/cloudhub/api.yaml
@@ -103,7 +103,8 @@ paths:
                 lastModified: 1458115909470
                 isSystem: false
                 createdAt: 1458115909470
-      operationId: getV2Alerts
+      summary: List alerts
+      operationId: listV2Alerts
     post:
       description: 'Create an alert
 
@@ -143,7 +144,8 @@ paths:
                 lastModified: 1458115909470
                 isSystem: false
                 createdAt: 1458115909470
-      operationId: createV2Alerts
+      summary: Create alert
+      operationId: createV2Alert
   /v2/alerts/{id}:
     put:
       description: 'Update an existing alert
@@ -168,7 +170,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetAlertResponse'
               example: *id001
-      operationId: updateV2AlertsById
+      summary: Update alert by ID
+      operationId: updateV2AlertById
     get:
       description: 'Retrieve a single alert
 
@@ -189,7 +192,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetAlertResponse'
               example: *id001
-      operationId: getV2AlertsById
+      summary: Get alert by ID
+      operationId: getV2AlertById
     delete:
       description: 'Delete a single alert
 
@@ -206,7 +210,8 @@ paths:
           description: 'Alert deleted
 
             '
-      operationId: deleteV2AlertsById
+      summary: Delete alert by ID
+      operationId: deleteV2AlertById
   /v2/alerts/{id}/history:
     get:
       description: 'Retrieve the history describing when this alert was triggered
@@ -250,7 +255,8 @@ paths:
                   - state: failed
                     type: email
                 total: 2
-      operationId: getV2AlertsByIdHistory
+      summary: Get alert trigger history
+      operationId: getV2AlertHistory
   /v2/applications:
     description: 'Applications resource
 
@@ -364,7 +370,8 @@ paths:
                   logLevels: []
                   ipAddresses: []
               example: *id002
-      operationId: getV2Applications
+      summary: List applications (v2)
+      operationId: listV2Applications
     post:
       description: 'Create a new application.
 
@@ -480,7 +487,8 @@ paths:
                   logLevels: []
                   ipAddresses: []
               example: *id003
-      operationId: createV2Applications
+      summary: Create application (v2)
+      operationId: createV2Application
     put:
       description: 'Bulk Action (UPDATE, START, STOP, RESTART, DELETE) for Applications.
 
@@ -524,7 +532,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateV2Applications
+      summary: Run bulk action on applications
+      operationId: bulkActionV2Applications
   /v2/applications/{domain}:
     description: 'A single application
 
@@ -612,7 +621,8 @@ paths:
                   logLevels: []
                   ipAddresses: []
               example: *id004
-      operationId: getV2ApplicationsByDomain
+      summary: Get application by domain (v2)
+      operationId: getV2ApplicationByDomain
     delete:
       description: 'Delete a single application
 
@@ -628,7 +638,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteV2ApplicationsByDomain
+      summary: Delete application by domain (v2)
+      operationId: deleteV2ApplicationByDomain
     put:
       description: 'Update a single application.
 
@@ -1071,7 +1082,8 @@ paths:
                   logLevels: []
                   ipAddresses: []
               example: *id005
-      operationId: updateV2ApplicationsByDomain
+      summary: Update application by domain (v2)
+      operationId: updateV2ApplicationByDomain
   /v2/applications/{domain}/dashboardStats:
     description: 'Dashboard statistics
 
@@ -1219,7 +1231,8 @@ paths:
                         '1431145680000': 344
                         '1431146580000': 344
               example: *id006
-      operationId: getV2ApplicationsByDomainDashboardstats
+      summary: Get application dashboard stats
+      operationId: getV2ApplicationDashboardStats
   /v2/applications/{domain}/files:
     description: 'Deploy or re-deploy an application with the specified application file.
 
@@ -1265,7 +1278,8 @@ paths:
           description: 'Application deployment queued successfully.
 
             '
-      operationId: createV2ApplicationsByDomainFiles
+      summary: Deploy application file
+      operationId: deployV2ApplicationFile
   /v2/applications/{domain}/queueStatistics:
     description: Retrieve statistics for persistent queues.
     get:
@@ -1372,7 +1386,8 @@ paths:
                       dequeued: {}
                   total: 1
               example: *id007
-      operationId: getV2ApplicationsByDomainQueuestatistics
+      summary: Get application queue statistics
+      operationId: getV2ApplicationQueueStats
   /v2/applications/{domain}/staticips:
     description: Manage the static Ips
     get:
@@ -1408,7 +1423,8 @@ paths:
                     address: 0.0.0.0
                     state: ASSIGNED
               example: *id008
-      operationId: getV2ApplicationsByDomainStaticips
+      summary: List application static IPs
+      operationId: listV2ApplicationStaticIps
     post:
       description: 'Request a static IP for the application.
 
@@ -1445,7 +1461,8 @@ paths:
           description: 'A static IP is already reserved for the app
 
             '
-      operationId: createV2ApplicationsByDomainStaticips
+      summary: Request application static IP
+      operationId: requestV2ApplicationStaticIp
   /v2/applications/{domain}/staticips/{region}:
     delete:
       description: Release any unused static IP address(es) assigned to the application for that region back to the pool.
@@ -1480,7 +1497,8 @@ paths:
           description: 'A concurrent request has modified the status of the IP before freeing.
 
             '
-      operationId: deleteV2ApplicationsByDomainStaticipsByRegion
+      summary: Release static IPs in region
+      operationId: releaseV2StaticIpsByRegion
   /v2/applications/{domain}/deployments:
     get:
       description: 'description: Retrieve deploymentIds and InstanceIds using this API. These Ids are useful for downloading mule application and worker logs.
@@ -1576,7 +1594,8 @@ paths:
                     instances: []
                   total: 5
               example: *id009
-      operationId: getV2ApplicationsByDomainDeployments
+      summary: List application deployments
+      operationId: listV2ApplicationDeployments
   /v2/applications/{domain}/deployments/{deploymentId}/logs:
     get:
       description: 'Retrieve deployment log for a specific depoymentId. May be subject of rate limit.
@@ -1644,7 +1663,8 @@ paths:
               example: *id010
         '429':
           description: Rejected due to rate limit.
-      operationId: getV2ApplicationsByDomainDeploymentsByDeploymentidLogs
+      summary: Get deployment logs
+      operationId: getV2DeploymentLogs
   /v2/applications/{domain}/instances:
     parameters:
     - name: domain
@@ -1850,7 +1870,8 @@ paths:
               example: *id011
         '429':
           description: Rejected due to rate limit.
-      operationId: getV2ApplicationsByDomainInstancesByInstanceidLogs
+      summary: Get instance logs
+      operationId: getV2InstanceLogs
   /v2/applications/{domain}/instances/{instanceId}/diagnostics:
     get:
       description: 'description: Retrieve thread dump of a worker.
@@ -1903,7 +1924,8 @@ paths:
                 \n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"qtp1864616119-30\" #30 prio=5 os_prio=0 tid=0x00007f9cc1a10000 nid=0xace waiting on condition [0x00007f9cab48d000]\n   java.lang.Thread.State: TIMED_WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\t- parking to wait for  <0x00000000eca0aac0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)\n\n\n\n\n\n\n\tat org.eclipse.jetty.util.BlockingArrayQueue.poll(BlockingArrayQueue.java:390)\n\n\n\n\n\n\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool.idleJobPoll(QueuedThreadPool.java:509)\n\n\n\n\n\n\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool.access$700(QueuedThreadPool.java:48)\n\n\n\n\n\n\n\tat org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:563)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"DateCache\" #29 daemon prio=5 os_prio=0 tid=0x00007f9cc19a8800 nid=0xacd in Object.wait() [0x00007f9cab58e000]\n   java.lang.Thread.State: TIMED_WAITING (on object monitor)\n\tat java.lang.Object.wait(Native Method)\n\n\n\n\n\n\n\tat java.util.TimerThread.mainLoop(Timer.java:552)\n\n\n\n\n\n\n\t- locked <0x00000000ecb0d9b0> (a java.util.TaskQueue)\n\n\n\n\n\n\n\tat java.util.TimerThread.run(Timer.java:505)\n\n\n\n\n\n\n\n\"[.agent].processing.time.monitor\" #27 daemon prio=5 os_prio=0 tid=0x00007f9cc1880000 nid=0xacc in Object.wait() [0x00007f9cab88f000]\n   java.lang.Thread.State: WAITING (on object monitor)\n\tat java.lang.Object.wait(Native Method)\n\n\n\n\n\n\n\t- waiting on <0x00000000eca01d30> (a java.lang.ref.ReferenceQueue$Lock)\n\n\n\n\n\n\n\tat java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:143)\n\n\n\n\n\n\n\t- locked <0x00000000eca01d30> (a java.lang.ref.ReferenceQueue$Lock)\n\n\n\n\n\n\n\tat java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:164)\n\n\n\n\n\n\n\tat org.mule.management.stats.DefaultProcessingTimeWatcher$ProcessingTimeChecker.run(DefaultProcessingTimeWatcher.java:76)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"Thread-3\" #26 prio=5 os_prio=0 tid=0x00007f9cc1197800 nid=0xacb waiting on condition [0x00007f9cab990000]\n   java.lang.Thread.State: TIMED_WAITING (sleeping)\n\tat java.lang.Thread.sleep(Native Method)\n\n\n\n\n\n\n\tat org.apache.commons.io.monitor.FileAlterationMonitor.run(FileAlterationMonitor.java:188)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"MapDB writer #2\" #24 daemon prio=5 os_prio=0 tid=0x00007f9cc19e1800 nid=0xaca waiting on condition [0x00007f9cabbfd000]\n   java.lang.Thread.State: TIMED_WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:338)\n\n\n\n\n\n\n\tat org.mapdb.AsyncWriteEngine$WriterRunnable.run(AsyncWriteEngine.java:165)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"MapDB writer #1\" #22 daemon prio=5 os_prio=0 tid=0x00007f9cc19ce000 nid=0xac9 waiting on condition [0x00007f9cabefe000]\n   java.lang.Thread.State: TIMED_WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:338)\n\n\n\n\n\n\n\tat org.mapdb.AsyncWriteEngine$WriterRunnable.run(AsyncWriteEngine.java:165)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"[.agent].Mule.01\" #20 prio=5 os_prio=0 tid=0x00007f9cc1412800 nid=0xac8 waiting on condition [0x00007f9cb8ac1000]\n   java.lang.Thread.State: TIMED_WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\t- parking to wait for  <0x00000000ec7de190> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2078)\n\
                 \n\n\n\n\n\n\tat java.util.concurrent.LinkedBlockingDeque.pollFirst(LinkedBlockingDeque.java:522)\n\n\n\n\n\n\n\tat java.util.concurrent.LinkedBlockingDeque.poll(LinkedBlockingDeque.java:684)\n\n\n\n\n\n\n\tat org.mule.context.notification.ServerNotificationManager.run(ServerNotificationManager.java:270)\n\n\n\n\n\n\n\tat org.mule.work.WorkerContext.run(WorkerContext.java:286)\n\n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"Log4j2-AsyncLoggerConfig-2\" #18 daemon prio=5 os_prio=0 tid=0x00007f9cc1351800 nid=0xac7 waiting on condition [0x00007f9cb8dc2000]\n   java.lang.Thread.State: WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\t- parking to wait for  <0x00000000ec4344e0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)\n\n\n\n\n\n\n\tat com.lmax.disruptor.BlockingWaitStrategy.waitFor(BlockingWaitStrategy.java:45)\n\n\n\n\n\n\n\tat com.lmax.disruptor.ProcessingSequenceBarrier.waitFor(ProcessingSequenceBarrier.java:55)\n\n\n\n\n\n\n\tat com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:123)\n\n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"DestroyJavaVM\" #15 prio=5 os_prio=0 tid=0x00007f9cdc00b000 nid=0xab8 waiting on condition [0x0000000000000000]\n   java.lang.Thread.State: RUNNABLE\n\n\"Wrapper-Connection\" #14 daemon prio=10 os_prio=0 tid=0x00007f9cdc3f5000 nid=0xac5 runnable [0x00007f9ccc324000]\n   java.lang.Thread.State: RUNNABLE\n\tat java.net.SocketInputStream.socketRead0(Native Method)\n\n\n\n\n\n\n\tat java.net.SocketInputStream.socketRead(SocketInputStream.java:116)\n\n\n\n\n\n\n\tat java.net.SocketInputStream.read(SocketInputStream.java:170)\n\n\n\n\n\n\n\tat java.net.SocketInputStream.read(SocketInputStream.java:141)\n\n\n\n\n\n\n\tat java.net.SocketInputStream.read(SocketInputStream.java:223)\n\n\n\n\n\n\n\tat java.io.DataInputStream.readByte(DataInputStream.java:265)\n\n\n\n\n\n\n\tat org.tanukisoftware.wrapper.WrapperManager.handleBackend(WrapperManager.java:5505)\n\n\n\n\n\n\n\tat org.tanukisoftware.wrapper.WrapperManager.run(WrapperManager.java:5889)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"Wrapper-Control-Event-Monitor\" #12 daemon prio=5 os_prio=0 tid=0x00007f9cdc440800 nid=0xac3 waiting on condition [0x00007f9ccc526000]\n   java.lang.Thread.State: TIMED_WAITING (sleeping)\n\tat java.lang.Thread.sleep(Native Method)\n\n\n\n\n\n\n\tat org.tanukisoftware.wrapper.WrapperManager$3.run(WrapperManager.java:1040)\n\n\n\n\n\n\n\n\"Log4j2-AsyncLoggerConfig-1\" #9 daemon prio=5 os_prio=0 tid=0x00007f9cdc34b000 nid=0xac2 waiting on condition [0x00007f9ce0199000]\n   java.lang.Thread.State: WAITING (parking)\n\tat sun.misc.Unsafe.park(Native Method)\n\n\n\n\n\n\n\t- parking to wait for  <0x00000000eb551618> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)\n\n\n\n\n\n\n\tat java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)\n\n\n\n\n\n\n\tat com.lmax.disruptor.BlockingWaitStrategy.waitFor(BlockingWaitStrategy.java:45)\n\n\n\n\n\n\n\tat com.lmax.disruptor.ProcessingSequenceBarrier.waitFor(ProcessingSequenceBarrier.java:55)\n\n\n\n\n\n\n\tat com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:123)\n\n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)\n\
                 \n\n\n\n\n\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)\n\n\n\n\n\n\n\tat java.lang.Thread.run(Thread.java:745)\n\n\n\n\n\n\n\n\"Service Thread\" #7 daemon prio=9 os_prio=0 tid=0x00007f9cdc0c8000 nid=0xac0 runnable [0x0000000000000000]\n   java.lang.Thread.State: RUNNABLE\n\n\"C1 CompilerThread1\" #6 daemon prio=9 os_prio=0 tid=0x00007f9cdc0c3000 nid=0xabf waiting on condition [0x0000000000000000]\n   java.lang.Thread.State: RUNNABLE\n\n\"C2 CompilerThread0\" #5 daemon prio=9 os_prio=0 tid=0x00007f9cdc0c0800 nid=0xabe waiting on condition [0x0000000000000000]\n   java.lang.Thread.State: RUNNABLE\n\n\"Signal Dispatcher\" #4 daemon prio=9 os_prio=0 tid=0x00007f9cdc0bf000 nid=0xabd runnable [0x0000000000000000]\n   java.lang.Thread.State: RUNNABLE\n\n\"Finalizer\" #3 daemon prio=8 os_prio=0 tid=0x00007f9cdc087000 nid=0xabc in Object.wait() [0x00007f9ce0c46000]\n   java.lang.Thread.State: WAITING (on object monitor)\n\tat java.lang.Object.wait(Native Method)\n\n\n\n\n\n\n\tat java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:143)\n\n\n\n\n\n\n\t- locked <0x00000000eb415da8> (a java.lang.ref.ReferenceQueue$Lock)\n\n\n\n\n\n\n\tat java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:164)\n\n\n\n\n\n\n\tat java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:209)\n\n\n\n\n\n\n\n\"Reference Handler\" #2 daemon prio=10 os_prio=0 tid=0x00007f9cdc085000 nid=0xabb in Object.wait() [0x00007f9ce0d47000]\n   java.lang.Thread.State: WAITING (on object monitor)\n\tat java.lang.Object.wait(Native Method)\n\n\n\n\n\n\n\tat java.lang.Object.wait(Object.java:502)\n\n\n\n\n\n\n\tat java.lang.ref.Reference$ReferenceHandler.run(Reference.java:157)\n\n\n\n\n\n\n\t- locked <0x00000000eb497a60> (a java.lang.ref.Reference$Lock)\n\n\n\n\n\n\n\n\"VM Thread\" os_prio=0 tid=0x00007f9cdc080000 nid=0xaba runnable \n\n\"Gang worker#0 (Parallel GC Threads)\" os_prio=0 tid=0x00007f9cdc01c800 nid=0xab9 runnable \n\n\"VM Periodic Task Thread\" os_prio=0 tid=0x00007f9cdc0cb000 nid=0xac1 waiting on condition \n\nJNI global references: 331\n\n"
-      operationId: getV2ApplicationsByDomainInstancesByInstanceidDiagnostics
+      summary: Get instance diagnostics
+      operationId: getV2InstanceDiagnostics
   /v2/applications/{domain}/instances/{instanceId}/log-file:
     get:
       description: 'Download the log file associated with your application
@@ -1945,7 +1967,8 @@ paths:
                 * Application: test-test                                             *\n* OS encoding: /, Mule encoding: UTF-8                               *\n*                                                                    *\n* Agents Running:                                                    *\n*   DevKit Extension Information                                     *\n*   JMX Agent                                                        *\n*   Batch module default engine                                      *\n*   Wrapper Manager                                                  *\n**********************************************************************\n[2015-12-14 17:54:02.865] INFO    org.mule.api.processor.LoggerMessageProcessor [[test-test].Copy_of_echoFlow.stage1.02]: (t:null) \norg.mule.DefaultMuleMessage\n{\n  id=a93bf1a0-a28b-11e5-9d9b-0e4b77f24b53\n  payload=org.glassfish.grizzly.utils.BufferInputStream\n  correlationId=<not set>\n  correlationGroup=-1\n  correlationSeq=-1\n  encoding=UTF-8\n  exceptionPayload=<not set>\n\nMessage properties:\n  INVOCATION scoped properties:\n    pollingFrequency=1000\n  INBOUND scoped properties:\n    MULE_ORIGINATING_ENDPOINT=endpoint.polling.1912630717\n    cache-control=public, no-cache=\"Set-Cookie\", max-age=59\n    cf-ray=254bc58d3e052390-IAD\n    connection=keep-alive\n    content-type=text/html; charset=utf-8\n    date=Mon, 14 Dec 2015 17:54:02 GMT\n    expires=Mon, 14 Dec 2015 17:55:01 GMT\n    http.reason=OK\n    http.status=200\n    last-modified=Mon, 14 Dec 2015 17:54:01 GMT\n    server=cloudflare-nginx\n    set-cookie=[__cfduid=dc3171fe8e760735d044f568ddc7fa1f61450115642; expires=Tue, 13-Dec-16 17:54:02 GMT; path=/; domain=.stackoverflow.com; HttpOnly, prov=7f585e15-49e0-41cb-b57f-ffa557f4d075; domain=.stackoverflow.com; expires=Fri, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly]\n    transfer-encoding=chunked\n    vary=*\n    x-frame-options=SAMEORIGIN\n    x-request-guid=6deef0ce-64d0-4dc9-b6a0-a40a6b22ce08\n  OUTBOUND scoped properties:\n  SESSION scoped properties:\n}\n[2015-12-14 17:54:02.867] INFO    org.mule.api.processor.LoggerMessageProcessor [[test-test].echoFlow.stage1.02]: (t:null) \norg.mule.DefaultMuleMessage\n{\n  id=a93ba380-a28b-11e5-9d9b-0e4b77f24b53\n  payload=org.glassfish.grizzly.utils.BufferInputStream\n  correlationId=<not set>\n  correlationGroup=-1\n  correlationSeq=-1\n  encoding=UTF-8\n  exceptionPayload=<not set>\n\nMessage properties:\n  INVOCATION scoped properties:\n    pollingFrequency=1000\n  INBOUND scoped properties:\n    MULE_ORIGINATING_ENDPOINT=endpoint.polling.1912630717\n    cache-control=public, no-cache=\"Set-Cookie\", max-age=59\n    cf-ray=254bc58d2f4723fc-IAD\n    connection=keep-alive\n    content-type=text/html; charset=utf-8\n    date=Mon, 14 Dec 2015 17:54:02 GMT\n    expires=Mon, 14 Dec 2015 17:55:01 GMT\n    http.reason=OK\n    http.status=200\n    last-modified=Mon, 14 Dec 2015 17:54:01 GMT\n    server=cloudflare-nginx\n    set-cookie=[__cfduid=dd5351ad84577c9a97c84f87d6c5fe1f41450115642; expires=Tue, 13-Dec-16 17:54:02 GMT; path=/; domain=.stackoverflow.com; HttpOnly, prov=36c7d2b8-01d1-4f3f-abea-4a4d0a563034; domain=.stackoverflow.com; expires=Fri, 01-Jan-2055 00:00:00 GMT; path=/; HttpOnly]\n    transfer-encoding=chunked\n    vary=*\n    x-frame-options=SAMEORIGIN\n    x-request-guid=74d2f249-e609-4369-b631-bd116b129291\n  OUTBOUND scoped properties:\n  SESSION scoped properties:\n}\n[2015-12-14 17:54:23.248] INFO    org.mule.api.processor.LoggerMessageProcessor [[test-test].Copy_of_echoFlow.stage1.02]: (t:null) \norg.mule.DefaultMuleMessage\n{\n  id=b5681800-a28b-11e5-9d9b-0e4b77f24b53\n  payload=org.glassfish.grizzly.utils.BufferInputStream\n  correlationId=<not set>\n  correlationGroup=-1\n  correlationSeq=-1\n  encoding=UTF-8\n  exceptionPayload=<not set>\""
         '429':
           description: Rejected due to rate limit.
-      operationId: getV2ApplicationsByDomainInstancesByInstanceidLogFile
+      summary: Download instance log file
+      operationId: downloadV2InstanceLogFile
   /v2/applications/{domain}/insight:
     parameters:
     - name: domain
@@ -1975,7 +1998,8 @@ paths:
       responses:
         '204':
           description: Replay Data deleted successfully
-      operationId: deleteV2ApplicationsByDomainInsightTransactionsReplays
+      summary: Delete replay data
+      operationId: deleteV2ReplayData
   /v2/applications/{domain}/insight/transactions/hasReplays:
     get:
       description: Checks if Replay Data Exists on Amazon S3 for the given application
@@ -1996,7 +2020,8 @@ paths:
                 example: &id012
                   objectsExist: true
               example: *id012
-      operationId: getV2ApplicationsByDomainInsightTransactionsHasreplays
+      summary: Check replay data exists
+      operationId: checkV2ReplayDataExists
   /v2/applications/{domain}/autoscalepolicies:
     get:
       description: Retrieve auto-scaling policies
@@ -2035,7 +2060,8 @@ paths:
                       periodMins: 1
                       periodCount: 10
               example: *id013
-      operationId: getV2ApplicationsByDomainAutoscalepolicies
+      summary: List auto-scaling policies
+      operationId: listV2AutoscalePolicies
     post:
       description: Create new Auto-scaling Policy
       parameters:
@@ -2080,7 +2106,8 @@ paths:
                       periodMins: 1
                       periodCount: 10
               example: *id014
-      operationId: createV2ApplicationsByDomainAutoscalepolicies
+      summary: Create auto-scaling policy
+      operationId: createV2AutoscalePolicy
   /v2/applications/{domain}/autoscalepolicies/{policyId}:
     get:
       description: Retrieve specified auto scaling policy
@@ -2122,7 +2149,8 @@ paths:
               example: *id015
         '404':
           description: Specified auto scaling policy does not exist
-      operationId: getV2ApplicationsByDomainAutoscalepoliciesByPolicyid
+      summary: Get auto-scaling policy
+      operationId: getV2AutoscalePolicy
     put:
       description: Update specified auto scaling policy
       parameters:
@@ -2179,7 +2207,8 @@ paths:
               example: *id017
         '404':
           description: Specified auto scaling policy does not exist
-      operationId: updateV2ApplicationsByDomainAutoscalepoliciesByPolicyid
+      summary: Update auto-scaling policy
+      operationId: updateV2AutoscalePolicy
     delete:
       description: Delete auto-scaling policy
       parameters:
@@ -2194,7 +2223,8 @@ paths:
       responses:
         '204':
           description: Auto-scaling Policy deleted
-      operationId: deleteV2ApplicationsByDomainAutoscalepoliciesByPolicyid
+      summary: Delete auto-scaling policy
+      operationId: deleteV2AutoscalePolicy
   /v2/applications/{domain}/logs:
     post:
       description: 'Search logs for the application.
@@ -2244,7 +2274,8 @@ paths:
               example: *id018
         '429':
           description: Rejected due to rate limit.
-      operationId: createV2ApplicationsByDomainLogs
+      summary: Search application logs
+      operationId: searchV2ApplicationLogs
   /account:
     description: 'User account
 
@@ -2348,6 +2379,7 @@ paths:
                     production: true
                   activeEnvironment: 54f7ed78e4b0d48f31a30892
               example: *id019
+      summary: Get current user account
       operationId: getAccount
   /applications:
     description: 'Applications resource (V1) - deprecated, use V2 equivalents instead
@@ -2424,7 +2456,8 @@ paths:
                   secureDataGatewayEnabled: false
                   vpnEnabled: false
               example: *id020
-      operationId: getApplications
+      summary: List applications
+      operationId: listApplications
     post:
       description: 'Create a new application.
 
@@ -2491,7 +2524,8 @@ paths:
                   secureDataGatewayEnabled: false
                   vpnEnabled: false
               example: *id021
-      operationId: createApplications
+      summary: Create application
+      operationId: createApplication
   /applications/domains/{domain}:
     description: 'Domain name availability
 
@@ -2521,7 +2555,8 @@ paths:
               example: *id022
         '400':
           description: Domain name is invalid.
-      operationId: getApplicationsDomainsByDomain
+      summary: Check domain availability
+      operationId: checkDomainAvailability
   /applications/{domain}:
     description: 'A single application (V1), deprecated, use V2 equivalents instead
 
@@ -2582,7 +2617,8 @@ paths:
                   secureDataGatewayEnabled: false
                   vpnEnabled: false
               example: *id023
-      operationId: getApplicationsByDomain
+      summary: Get application by domain
+      operationId: getApplicationByDomain
     put:
       description: 'Update a single application.
 
@@ -2659,7 +2695,8 @@ paths:
                   secureDataGatewayEnabled: false
                   vpnEnabled: false
               example: *id024
-      operationId: updateApplicationsByDomain
+      summary: Update application by domain
+      operationId: updateApplicationByDomain
     delete:
       description: 'Delete a single application.
 
@@ -2677,7 +2714,8 @@ paths:
       responses:
         '200':
           description: Application deleted successfully.
-      operationId: deleteApplicationsByDomain
+      summary: Delete application by domain
+      operationId: deleteApplicationByDomain
   /applications/{domain}/download/{filename}:
     description: 'Retrieve the Mule package file for the application.
 
@@ -2708,7 +2746,8 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
-      operationId: getApplicationsByDomainDownloadByFilename
+      summary: Download application file
+      operationId: downloadApplicationFile
   /applications/{domain}/logs/levels:
     description: 'Log levels for java packages
 
@@ -2734,7 +2773,8 @@ paths:
                 - packageName: com.mulesoft
                   level: INFO
               example: *id025
-      operationId: getApplicationsByDomainLogsLevels
+      summary: List application log levels
+      operationId: listApplicationLogLevels
     put:
       description: Add/Update log levels for current application
       parameters:
@@ -2757,7 +2797,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateApplicationsByDomainLogsLevels
+      summary: Update application log levels
+      operationId: updateApplicationLogLevels
   /applications/{domain}/logs/levels/{name}:
     get:
       description: Get single log level with name
@@ -2785,7 +2826,8 @@ paths:
                   packageName: com.mulesoft
                   level: INFO
               example: *id026
-      operationId: getApplicationsByDomainLogsLevelsByName
+      summary: Get application log level
+      operationId: getApplicationLogLevel
     delete:
       description: Delete single log level with name
       parameters:
@@ -2804,7 +2846,8 @@ paths:
       responses:
         '200':
           description: Log Level deleted succesfully
-      operationId: deleteApplicationsByDomainLogsLevelsByName
+      summary: Delete application log level
+      operationId: deleteApplicationLogLevel
   /applications/{domain}/notifications:
     description: 'Retrieve notifications for the applications
 
@@ -2862,7 +2905,8 @@ paths:
                     read: false
                     href: http://anypoint.mulesoft.com:8080/api/notifications/5553812ee4b0a1b2e9faf2f9
               example: *id027
-      operationId: getApplicationsByDomainNotifications
+      summary: List application notifications
+      operationId: listApplicationNotifications
   /applications/{domain}/schedules:
     description: Application schedules
     get:
@@ -2915,7 +2959,8 @@ paths:
                     period: 30
                   run-href: http://qa.anypoint.mulesoft.com:8080/api/applications/poll-test/schedules/565f7691e4b0365bb4f4d774_echoFlow_polling_echoFlow_1/run
               example: *id028
-      operationId: getApplicationsByDomainSchedules
+      summary: List application schedules
+      operationId: listApplicationSchedules
       description: Retrieves a schedules.
     put:
       description: 'Batch update of the schedules. Enable/Disable or run all or subset of schedules.
@@ -2986,7 +3031,8 @@ paths:
                     period: 30
                   run-href: http://qa.anypoint.mulesoft.com:8080/api/applications/poll-test/schedules/565f7691e4b0365bb4f4d774_echoFlow_polling_echoFlow_1/run
               example: *id029
-      operationId: updateApplicationsByDomainSchedules
+      summary: Update application schedules
+      operationId: updateApplicationSchedules
   /applications/{domain}/schedules/{jobId}:
     get:
       parameters:
@@ -3022,7 +3068,8 @@ paths:
                     period: 10
                   run-href: http://anypoint.mulesoft.com:8080/api/applications/polltest/schedules/566a0359e4b0dc517fef5bbb_echoFlow_polling_echoFlow_1/run
               example: *id030
-      operationId: getApplicationsByDomainSchedulesByJobid
+      summary: Get application schedule
+      operationId: getApplicationSchedule
       description: Retrieves a schedules.
     put:
       parameters:
@@ -3060,7 +3107,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: updateApplicationsByDomainSchedulesByJobid
+      summary: Replace application schedule
+      operationId: replaceApplicationSchedule
       description: Replaces a schedules.
   /applications/{domain}/schedules/{jobId}/run:
     post:
@@ -3086,7 +3134,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: createApplicationsByDomainSchedulesByJobidRun
+      summary: Run application schedule
+      operationId: runApplicationSchedule
       description: Creates a run.
   /applications/{domain}/settings:
     parameters:
@@ -3115,7 +3164,8 @@ paths:
                 example: &id031
                   trackingLevel: METADATA_AND_REPLAY
               example: *id031
-      operationId: getApplicationsByDomainSettingsTracking
+      summary: Get tracking settings
+      operationId: getApplicationTrackingSettings
       description: Retrieves a tracking.
     put:
       description: 'Possible values are ''DISABLED'' , ''METADATA'' and ''METADATA_AND_REPLAY''.
@@ -3143,7 +3193,8 @@ paths:
           description: 'The insight replay feature is not supported for mule 4 applications and for free and trial users.
 
             '
-      operationId: updateApplicationsByDomainSettingsTracking
+      summary: Update tracking settings
+      operationId: updateApplicationTrackingSettings
   /applications/{domain}/statistics:
     description: 'Retrieve application statistics. Defaults to a week long search.
 
@@ -3203,7 +3254,8 @@ paths:
                   '1430903299087': 2
                   '1430915395087': 0
               example: *id032
-      operationId: getApplicationsByDomainStatistics
+      summary: Get application statistics
+      operationId: getApplicationStatistics
   /applications/{domain}/status:
     description: 'Application status
 
@@ -3234,7 +3286,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: createApplicationsByDomainStatus
+      summary: Update application status
+      operationId: updateApplicationStatus
     get:
       description: 'Retrieve status of the application.
 
@@ -3270,7 +3323,8 @@ paths:
               schema:
                 example: STARTED
               example: STARTED
-      operationId: getApplicationsByDomainStatus
+      summary: Get application status
+      operationId: getApplicationStatus
   /applications/{domain}/tracking:
     parameters:
     - name: domain
@@ -3302,7 +3356,8 @@ paths:
                 - customkey-2
                 - customkey-3
               example: *id033
-      operationId: getApplicationsByDomainTrackingCustomKeys
+      summary: List tracking custom keys
+      operationId: listTrackingCustomKeys
   /applications/{domain}/tracking/searches:
     get:
       description: To use a non-default environment, set this header
@@ -3327,7 +3382,8 @@ paths:
                   startDate: 2012-08-12 04:00:00+00:00
                   endDate: 2012-08-13 04:00:00+00:00
               example: *id034
-      operationId: getApplicationsByDomainTrackingSearches
+      summary: List tracking searches
+      operationId: listTrackingSearches
   /applications/{domain}/tracking/searches/{name}:
     post:
       description: To use a non-default environment, set this header
@@ -3351,7 +3407,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: createApplicationsByDomainTrackingSearchesByName
+      summary: Create tracking search
+      operationId: createTrackingSearch
     put:
       description: To use a non-default environment, set this header
       parameters:
@@ -3374,7 +3431,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: updateApplicationsByDomainTrackingSearchesByName
+      summary: Update tracking search
+      operationId: updateTrackingSearch
     delete:
       description: To use a non-default environment, set this header
       parameters:
@@ -3397,7 +3455,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteApplicationsByDomainTrackingSearchesByName
+      summary: Delete tracking search
+      operationId: deleteTrackingSearch
   /applications/{domain}/tracking/statistics:
     post:
       description: 'Retrieve a list of application statistics, filtered by parameters passed in the request body.
@@ -3430,7 +3489,8 @@ paths:
                   - 2015-03-07 00:46:59.376000+00:00: 3
                   total: 1
               example: *id035
-      operationId: createApplicationsByDomainTrackingStatistics
+      summary: Search tracking statistics
+      operationId: searchTrackingStatistics
     get:
       description: 'Retrieve a list of application statistics.
 
@@ -3459,7 +3519,8 @@ paths:
                   - 2015-03-07 00:46:59.376000+00:00: 3
                   total: 1
               example: *id036
-      operationId: getApplicationsByDomainTrackingStatistics
+      summary: List tracking statistics
+      operationId: listTrackingStatistics
   /applications/{domain}/tracking/transactions:
     description: 'Application transactions
 
@@ -3525,7 +3586,8 @@ paths:
                     fields: {}
                   totalTranscations: 1
               example: *id037
-      operationId: createApplicationsByDomainTrackingTransactions
+      summary: Search tracking transactions
+      operationId: searchTrackingTransactions
   /applications/{domain}/tracking/transactions/{transactionId}:
     description: A single transaction
     get:
@@ -3572,7 +3634,8 @@ paths:
                   name: Flow Returned
                   flow: helloworldFlow
               example: *id038
-      operationId: getApplicationsByDomainTrackingTransactionsByTransactionid
+      summary: Get tracking transaction
+      operationId: getTrackingTransaction
   /applications/{domain}/tracking/transactions/{transactionId}/{flowName}/replay:
     description: Replay transaction
     get:
@@ -3609,7 +3672,8 @@ paths:
                 example: &id039
                   id: flow-id
               example: *id039
-      operationId: getApplicationsByDomainTrackingTransactionsByTransactionidByFlownameReplay
+      summary: Replay tracking transaction
+      operationId: replayTrackingTransaction
   /applications/{domain}/workers:
     description: Application workers
     get:
@@ -3640,7 +3704,8 @@ paths:
                   status: STARTED
                   staticIPEnabled: false
               example: *id040
-      operationId: getApplicationsByDomainWorkers
+      summary: List application workers
+      operationId: listApplicationWorkers
   /mule-versions:
     description: Mule runtimes
     get:
@@ -3735,7 +3800,8 @@ paths:
                     default: false
                   total: 16
               example: *id041
-      operationId: getMuleVersions
+      summary: List Mule versions
+      operationId: listMuleVersions
   /mule-versions/{version}:
     get:
       description: 'Retrieve specified Mule Version
@@ -3781,7 +3847,8 @@ paths:
                   javaVersion: '8'
                   default: false
               example: *id042
-      operationId: getMuleVersionsByVersion
+      summary: Get Mule version
+      operationId: getMuleVersion
   /mule-versions/{version}/updates/{updateId}:
     get:
       description: 'Retrieve a single update for a muleVersion
@@ -3823,7 +3890,8 @@ paths:
                     diagnosticsSupported: true
                     persistentQueuesSupported: true
               example: *id043
-      operationId: getMuleVersionsByVersionUpdatesByUpdateid
+      summary: Get Mule version update
+      operationId: getMuleVersionUpdate
   /notifications:
     description: Application notifications
     post:
@@ -3848,7 +3916,8 @@ paths:
       responses:
         '201':
           description: Resource created successfully.
-      operationId: createNotifications
+      summary: Create notification
+      operationId: createNotification
     get:
       description: 'Retrieve notifications.
 
@@ -3916,7 +3985,8 @@ paths:
                     read: false
                     href: http://anypoint.mulesoft.com:8080/api/notifications/5553812ee4b0a1b2e9faf2f9
               example: *id044
-      operationId: getNotifications
+      summary: List notifications
+      operationId: listNotifications
     put:
       description: 'Mark all notifications for this application as read or unread.
 
@@ -3939,7 +4009,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: updateNotifications
+      summary: Mark all notifications read
+      operationId: markAllNotifications
   /notifications/{id}:
     description: A single notification
     get:
@@ -3972,7 +4043,8 @@ paths:
                   readOn: 2015-05-13 17:10:15.619000+00:00
                   href: http://anypoint.mulesoft.com:8080/api/notifications/5553812ee4b0a1b2e9faf2f9
               example: *id045
-      operationId: getNotificationsById
+      summary: Get notification by ID
+      operationId: getNotificationById
     put:
       description: 'Mark a single notification  as read or unread.
 
@@ -3993,7 +4065,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: updateNotificationsById
+      summary: Mark notification by ID
+      operationId: markNotificationById
   /organization:
     description: Organization resource
     get:
@@ -4077,6 +4150,7 @@ paths:
                     productionWorkers: 1
                     sandboxWorkers: 0
               example: *id046
+      summary: Get current organization
       operationId: getOrganization
   /organization/plan:
     description: Subscription plan
@@ -4133,6 +4207,7 @@ paths:
                   globalCloud: false
                   directVpn: false
               example: *id047
+      summary: Get organization plan
       operationId: getOrganizationPlan
   /organization/usage:
     description: Usage details
@@ -4163,6 +4238,7 @@ paths:
                   productionWorkers: 1
                   sandboxWorkers: 0
               example: *id048
+      summary: Get organization usage
       operationId: getOrganizationUsage
   /organization/{orgid}:
     description: A single organization
@@ -4248,7 +4324,8 @@ paths:
                     productionWorkers: 1
                     sandboxWorkers: 0
               example: *id049
-      operationId: getOrganizationByOrgid
+      summary: Get organization by ID
+      operationId: getOrganizationById
   /organizations:
     description: Organizations resource
   /organizations/{orgid}:
@@ -4277,7 +4354,8 @@ paths:
                 productionVCoresConsumed: 4
                 sandboxVCoresConsumed: 1
                 staticIpsConsumed: 10
-      operationId: getOrganizationsByOrgidUsage
+      summary: Get organization usage by ID
+      operationId: getOrganizationUsageById
   /organizations/{orgid}/logs:
     parameters:
     - $ref: '#/components/parameters/XOrigin_orgid_Path'
@@ -4323,7 +4401,8 @@ paths:
           description: Forbidden - Insufficient permissions or feature disabled
         '404':
           description: Resource not found
-      operationId: createOrganizationsByOrgidLogsDownload
+      summary: Request log download
+      operationId: requestLogDownload
   /organizations/{orgid}/logs/download/status:
     get:
       description: 'Check the status of a log download execution.
@@ -4369,7 +4448,8 @@ paths:
           description: A download request is already in progress for this resource
         '500':
           description: Log download execution failed
-      operationId: getOrganizationsByOrgidLogsDownloadStatus
+      summary: Get log download status
+      operationId: getLogDownloadStatus
   /organizations/{orgid}/loadbalancers:
     get:
       description: List existing Load balancers for the organization
@@ -4453,7 +4533,8 @@ paths:
                         appUri: /
                   total: 1
               example: *id050
-      operationId: getOrganizationsByOrgidLoadbalancers
+      summary: List load balancers
+      operationId: listOrgLoadBalancers
   /organizations/{orgid}/loadbalancers/testcerts:
     post:
       description: Test if LB certificates, keys, crls and their combinations are valid
@@ -4591,7 +4672,8 @@ paths:
               example: *id051
         '400':
           description: invalid certificate, key, clr or their combination
-      operationId: createOrganizationsByOrgidLoadbalancersTestcerts
+      summary: Test load balancer certificates
+      operationId: testLoadBalancerCerts
   /organizations/{orgid}/tgws:
     get:
       description: Get a list of all Transit Gateways belonging to the master organization
@@ -4626,7 +4708,8 @@ paths:
                     lastModifiedTime: 1623368877614
                   total: 1
               example: *id052
-      operationId: getOrganizationsByOrgidTgws
+      summary: List transit gateways
+      operationId: listTransitGateways
     post:
       description: Create a new Transit Gateway
       parameters:
@@ -4660,7 +4743,8 @@ paths:
           description: Wrong Request
         '404':
           description: Resource Not Found
-      operationId: createOrganizationsByOrgidTgws
+      summary: Create transit gateway
+      operationId: createTransitGateway
   /organizations/{orgid}/tgws/{id}:
     put:
       description: Add a new TGW-VPC attachment, modify VPC routes or update the TGW name
@@ -4739,7 +4823,8 @@ paths:
           description: Wrong Request
         '404':
           description: Resource Not Found
-      operationId: updateOrganizationsByOrgidTgwsById
+      summary: Update transit gateway
+      operationId: updateTransitGateway
     delete:
       description: Delete a TGW-VPC attachment or a TGW Resource Share
       parameters:
@@ -4763,7 +4848,8 @@ paths:
           description: Wrong Request
         '404':
           description: Resource Not Found
-      operationId: deleteOrganizationsByOrgidTgwsById
+      summary: Delete transit gateway
+      operationId: deleteTransitGateway
   /organizations/{orgid}/vpcs:
     post:
       description: Create new VPC
@@ -4811,7 +4897,8 @@ paths:
           description: wrong request
         '404':
           description: organization is not found
-      operationId: createOrganizationsByOrgidVpcs
+      summary: Create VPC
+      operationId: createVpc
     get:
       description: Get a list of existing VPCs
       parameters:
@@ -4867,7 +4954,8 @@ paths:
                       toPort: 8092
                   total: 1
               example: *id055
-      operationId: getOrganizationsByOrgidVpcs
+      summary: List VPCs
+      operationId: listVpcs
   /organizations/{orgid}/vpcs/{vpcId}:
     get:
       description: Obtain VPC information by its id
@@ -4911,7 +4999,8 @@ paths:
               example: *id056
         '404':
           description: VPC is not found
-      operationId: getOrganizationsByOrgidVpcsByVpcid
+      summary: Get VPC by ID
+      operationId: getVpcById
     delete:
       description: Remove VPC by its id
       parameters:
@@ -4922,7 +5011,8 @@ paths:
           description: Deleted successfully
         '404':
           description: VPC cannot be found
-      operationId: deleteOrganizationsByOrgidVpcsByVpcid
+      summary: Delete VPC by ID
+      operationId: deleteVpcById
     put:
       description: 'Changes the configuration of the VPC by overriding the values of the properties passed in the JSON. ownerId, region and cidrBlock cannot be overriden.
 
@@ -4968,7 +5058,8 @@ paths:
               example: *id057
         '404':
           description: VPC is not found
-      operationId: updateOrganizationsByOrgidVpcsByVpcid
+      summary: Update VPC by ID
+      operationId: updateVpcById
   /organizations/{orgid}/vpcs/{vpcId}/loadbalancers:
     post:
       description: Create new Load balancer
@@ -5036,7 +5127,8 @@ paths:
           description: wrong request
         '404':
           description: Load balancer is not found
-      operationId: createOrganizationsByOrgidVpcsByVpcidLoadbalancers
+      summary: Create VPC load balancer
+      operationId: createVpcLoadBalancer
     get:
       description: Get list of existing Load balancers
       parameters:
@@ -5113,7 +5205,8 @@ paths:
                         appUri: /
                   total: 1
               example: *id059
-      operationId: getOrganizationsByOrgidVpcsByVpcidLoadbalancers
+      summary: List VPC load balancers
+      operationId: listVpcLoadBalancers
   /organizations/{orgid}/vpcs/{vpcId}/loadbalancers/{lbId}:
     get:
       description: returns load balancer by its ID
@@ -5153,7 +5246,8 @@ paths:
                 httpMode: true
         '404':
           description: there is no load balancer with this lbId or there is no VPC with such vpcId
-      operationId: getOrganizationsByOrgidVpcsByVpcidLoadbalancersByLbid
+      summary: Get VPC load balancer
+      operationId: getVpcLoadBalancer
     delete:
       description: deletes load balancer by its ID
       parameters:
@@ -5170,7 +5264,8 @@ paths:
           description: the load balancer was deleted successfully
         '404':
           description: there is no load balancer with this lbId or there is no VPC with such vpcId
-      operationId: deleteOrganizationsByOrgidVpcsByVpcidLoadbalancersByLbid
+      summary: Delete VPC load balancer
+      operationId: deleteVpcLoadBalancer
     patch:
       description: updates a load balancer
       parameters:
@@ -5265,7 +5360,8 @@ paths:
               example: *id060
         '404':
           description: there is no load balancer with this lbId or there is no VPC with such vpcId
-      operationId: patchOrganizationsByOrgidVpcsByVpcidLoadbalancersByLbid
+      summary: Patch VPC load balancer
+      operationId: patchVpcLoadBalancer
   /organizations/{orgid}/vpcs/{vpcId}/loadbalancers/{lbId}/deployments:
     get:
       description: returns all the deployments
@@ -5335,7 +5431,8 @@ paths:
               example: *id061
         '404':
           description: there is no load balancer with this lbId or there is no VPC with such vpcId
-      operationId: getOrganizationsByOrgidVpcsByVpcidLoadbalancersByLbidDeployments
+      summary: List load balancer deployments
+      operationId: listLoadBalancerDeployments
   /organizations/{orgid}/vpcs/{vpcId}/loadbalancers/{lbId}/testmapping:
     get:
       description: makes a test call to the load balancer rules and returns a response with the rule number which will be applied to the input.
@@ -5369,7 +5466,8 @@ paths:
               example: *id062
         '404':
           description: there is no load balancer with this lbId or there is no VPC with such vpcId
-      operationId: getOrganizationsByOrgidVpcsByVpcidLoadbalancersByLbidTestmapping
+      summary: Test load balancer mapping
+      operationId: testLoadBalancerMapping
   /organizations/{orgid}/vpcs/{vpcId}/ipsec:
     post:
       description: Create a VPN connection from a VPC, up to a limit of 10 total VPN Connections per VPC
@@ -5390,7 +5488,8 @@ paths:
           description: bad request
         '404':
           description: there is no org or VPC with this id
-      operationId: createOrganizationsByOrgidVpcsByVpcidIpsec
+      summary: Create VPC IPsec connection
+      operationId: createVpcIpsec
     get:
       description: get the configuration and state of a <<resourcePathName|!pluralize>>
       parameters:
@@ -5443,7 +5542,8 @@ paths:
                       status: DOWN
                       statusMessage: ''
                 total: 1
-      operationId: getOrganizationsByOrgidVpcsByVpcidIpsec
+      summary: List VPC IPsec connections
+      operationId: listVpcIpsec
   /organizations/{orgid}/vpcs/{vpcId}/ipsec/ipsec/{vpnId}:
     description: A single VPN endpoint
     get:
@@ -5499,7 +5599,8 @@ paths:
                     statusMessage: ''
         '404':
           description: The orgId, vpcId or vpnId was not found
-      operationId: getOrganizationsByOrgidVpcsByVpcidIpsecIpsecByVpnid
+      summary: Get VPC IPsec connection
+      operationId: getVpcIpsecConnection
     delete:
       description: Delete a VPN connection
       parameters:
@@ -5514,7 +5615,8 @@ paths:
       responses:
         '204':
           description: Deleted successfully
-      operationId: deleteOrganizationsByOrgidVpcsByVpcidIpsecIpsecByVpnid
+      summary: Delete VPC IPsec connection
+      operationId: deleteVpcIpsecConnection
   /ping:
     description: Endpoint to test connectivity.
     get:
@@ -5527,6 +5629,7 @@ paths:
               schema:
                 example: pong
               example: pong
+      summary: Ping the service
       operationId: getPing
       description: Lists ping.
   /queues: {}
@@ -5559,7 +5662,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: updateQueuesByQueueidClear
+      summary: Clear queue messages
+      operationId: clearQueueMessages
       description: Replaces a clear.
   /queues/{queueId}/statistics:
     description: 'returns queue statistic types.
@@ -5594,7 +5698,8 @@ paths:
                   functions:
                   - COUNT
               example: *id063
-      operationId: getQueuesByQueueidStatistics
+      summary: Get queue statistics
+      operationId: getQueueStatistics
       description: Retrieves a statistics.
   /queues/{queueId}/statistics/{statistic}:
     get:
@@ -5643,7 +5748,8 @@ paths:
                     inFlight: {}
                     dequeued: {}
               example: *id064
-      operationId: getQueuesByQueueidStatisticsByStatistic
+      summary: Get queue statistic
+      operationId: getQueueStatistic
       description: Retrieves a statistics.
   /regions:
     description: 'Retrieve all CloudHub worker regions
@@ -5677,7 +5783,8 @@ paths:
                   name: US West (N. California)
                   default: false
               example: *id065
-      operationId: getRegions
+      summary: List regions
+      operationId: listRegions
       description: Lists regions.
   /users/current/permissions:
     description: User permissions
@@ -5753,7 +5860,8 @@ paths:
                     dashboard:
                       read: true
               example: *id066
-      operationId: getUsersCurrentPermissions
+      summary: Get current user permissions
+      operationId: getCurrentUserPermissions
 components:
   requestBodies:
     PostPutAlert:
@@ -8195,7 +8303,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:cloudhub
-        operation: getOrganizationsByOrgidVpcs
+        operation: listVpcs
         description: GET `/organizations/{orgid}/vpcs` in this API; use `id` values as `vpcId`.
         values: $.id
         labels: $.name

--- a/apis/exchange-experience/api.yaml
+++ b/apis/exchange-experience/api.yaml
@@ -45,7 +45,8 @@ paths:
       responses:
         '201':
           description: Asset created
-      operationId: createAssets
+      summary: Upload asset
+      operationId: uploadAsset
   /assets/search:
     summary: Assets Search
     description: Assets Search
@@ -103,7 +104,8 @@ paths:
                 type: array
                 items:
                   type: object
-      operationId: getAssetsSearch
+      summary: Search assets
+      operationId: searchAssets
   /assets/{groupId}/{assetId}:
     summary: Assets
     description: Asset by groupId and assetId
@@ -119,9 +121,11 @@ paths:
           description: Asset deleted
         '409':
           description: There were conflicts while deleting
-      operationId: deleteAssetsByGroupidByAssetid
+      summary: Delete asset
+      operationId: deleteAsset
     patch:
-      operationId: patchAssetsByGroupidByAssetid
+      summary: Update asset metadata
+      operationId: updateAsset
       description: Updates asset metadata (name and description)
       requestBody:
         content:
@@ -163,7 +167,8 @@ paths:
               examples:
                 MetricsCSV:
                   $ref: examples/metrics.yaml#/MetricsCSV
-      operationId: getAssetsByGroupidByAssetidMetrics
+      summary: Get asset metrics
+      operationId: getAssetMetrics
   /assets/{groupId}/{assetId}/metrics/versions:
     summary: Asset metrics
     description: Asset metrics
@@ -197,7 +202,8 @@ paths:
                   $ref: examples/metrics.yaml#/MetricVersionsCSV
               schema:
                 type: string
-      operationId: getAssetsByGroupidByAssetidMetricsVersions
+      summary: Get asset metrics by version
+      operationId: getAssetMetricsByVersion
   /assets/{groupId}/{assetId}/icon:
     summary: Icon
     description: Asset icon
@@ -205,7 +211,8 @@ paths:
     - $ref: '#/components/parameters/GroupId'
     - $ref: '#/components/parameters/AssetId'
     put:
-      operationId: updateAssetsByGroupidByAssetidIcon
+      summary: Upload asset icon
+      operationId: uploadAssetIcon
       description: Uploads an icon as a binary file
       requestBody:
         content:
@@ -233,7 +240,8 @@ paths:
       responses:
         '204':
           description: Icon deleted
-      operationId: deleteAssetsByGroupidByAssetidIcon
+      summary: Delete asset icon
+      operationId: deleteAssetIcon
   /assets/{groupId}/{assetId}/public:
     summary: Public Versions
     description: Public asset versions
@@ -241,7 +249,8 @@ paths:
     - $ref: '#/components/parameters/GroupId'
     - $ref: '#/components/parameters/AssetId'
     put:
-      operationId: updateAssetsByGroupidByAssetidPublic
+      summary: Set asset public versions
+      operationId: setAssetPublicVersions
       description: Sets the public versions for the asset
       requestBody:
         content:
@@ -273,7 +282,8 @@ paths:
               examples:
                 Asset:
                   $ref: examples/assets.yaml#/AssetWithFiles
-      operationId: getAssetsByGroupidByAssetidAsset
+      summary: Get asset files
+      operationId: getAssetFiles
   /assets/{groupId}/{assetId}/minorVersions/{minorVersion}/portal/search:
     summary: Asset portal search
     description: Search for a term within an asset portal
@@ -305,7 +315,8 @@ paths:
                 items:
                   type: object
               example: *id002
-      operationId: getAssetsByGroupidByAssetidMinorversionsByMinorversionPortalSearch
+      summary: Search asset portal pages
+      operationId: searchAssetPortalPages
       description: Retrieves a search.
   /assets/{groupId}/{assetId}/versionGroups:
     summary: Version Groups
@@ -328,7 +339,8 @@ paths:
                 type: array
                 items:
                   type: object
-      operationId: getAssetsByGroupidByAssetidVersiongroups
+      summary: List asset version groups
+      operationId: listAssetVersionGroups
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/apiGroupInstances:
     summary: API Groups Instances
     description: API Groups instances
@@ -350,7 +362,8 @@ paths:
               examples:
                 APIGroupInstances:
                   $ref: examples/instances.yaml#/APIGroupInstances
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupApigroupinstances
+      summary: List API group instances
+      operationId: listApiGroupInstances
   ? /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/environments/{environmentId}/apiGroupInstances/{apiGroupInstanceId}
   : summary: Instance
     description: A single API Group instance identified by a "apiGroupInstanceId"
@@ -361,7 +374,8 @@ paths:
     - $ref: '#/components/parameters/EnvironmentId'
     - $ref: '#/components/parameters/APIGroupInstanceId'
     patch:
-      operationId: patchAssetsByGroupidByAssetidVersiongroupsByVersiongroupEnvironmentsByEnvironmentidApigroupinstancesByApigroupinstanceid
+      summary: Update API group visibility
+      operationId: updateApiGroupInstanceVisibility
       description: Updates API Group visibility
       requestBody:
         content:
@@ -393,7 +407,8 @@ paths:
               examples:
                 Tiers:
                   $ref: examples/tiers.yaml#/Tiers
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupEnvironmentsByEnvironmentidApigroupinstancesByApigroupinstanceidTiers
+      summary: List API group instance tiers
+      operationId: listApiGroupInstanceTiers
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/terms:
     summary: Terms and Conditions
     description: Gets underlying API terms and conditions for an asset version group
@@ -411,7 +426,8 @@ paths:
               examples:
                 Terms:
                   $ref: examples/instances.yaml#/Terms
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupTerms
+      summary: Get asset terms
+      operationId: getAssetTerms
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances:
     summary: API Instances
     description: A collection of API instances
@@ -433,7 +449,8 @@ paths:
                 type: array
                 items:
                   type: object
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstances
+      summary: List asset instances
+      operationId: listAssetInstances
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances/{apiInstanceId}/relatedApiGroupInstances:
     summary: API Group Instances
     description: API Group instances that include an API instance
@@ -464,7 +481,8 @@ paths:
                   version: 2.0.0
                   isPublic: false
               example: *id003
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesByApiinstanceidRelatedapigroupinstances
+      summary: List related API group instances
+      operationId: listRelatedApiGroupInstances
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances/{apiId}/tiers:
     summary: Instance Tiers
     description: A collection of the available SLA Tiers for a given API instance
@@ -485,12 +503,14 @@ paths:
               examples:
                 Tiers:
                   $ref: examples/tiers.yaml#/Tiers
-      operationId: getAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesByApiidTiers
+      summary: List instance tiers
+      operationId: listInstanceTiers
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances/evented-apis/external:
     summary: External Instances
     description: Evented API External instances
     post:
-      operationId: createAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesEventedApisExternal
+      summary: Create evented external instance
+      operationId: createEventedExternalInstance
       description: Creates a new external API instance for an evented API
       parameters:
       - $ref: '#/components/parameters/GroupId'
@@ -519,7 +539,8 @@ paths:
     summary: Instance Id
     description: A single instance for an evented API
     patch:
-      operationId: patchAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesEventedApisExternalById
+      summary: Update evented external instance
+      operationId: updateEventedExternalInstance
       description: Updates an existing external API instance
       parameters:
       - $ref: '#/components/parameters/GroupId'
@@ -548,7 +569,8 @@ paths:
     - $ref: '#/components/parameters/AssetId'
     - $ref: '#/components/parameters/VersionGroup'
     post:
-      operationId: createAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesExternal
+      summary: Create external instance
+      operationId: createExternalInstance
       description: Creates a new external API instance
       requestBody:
         content:
@@ -574,7 +596,8 @@ paths:
       responses:
         '204':
           description: deleted all external instances
-      operationId: deleteAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesExternal
+      summary: Delete external instances
+      operationId: deleteExternalInstances
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances/external/{id}:
     summary: Instance Id
     description: A single instance
@@ -584,7 +607,8 @@ paths:
     - $ref: '#/components/parameters/VersionGroup'
     - $ref: '#/components/parameters/ExternalInstanceId'
     patch:
-      operationId: patchAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesExternalById
+      summary: Update external instance
+      operationId: updateExternalInstance
       description: Updates an existing external API instance
       requestBody:
         content:
@@ -607,12 +631,14 @@ paths:
           description: External instance deleted
         '404':
           description: External instance not found
-      operationId: deleteAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesExternalById
+      summary: Delete external instance
+      operationId: deleteExternalInstance
   /assets/{groupId}/{assetId}/versionGroups/{versionGroup}/instances/managed/{id}:
     summary: Instance Id
     description: A single managed instance
     patch:
-      operationId: patchAssetsByGroupidByAssetidVersiongroupsByVersiongroupInstancesManagedById
+      summary: Update managed instance
+      operationId: updateManagedInstance
       description: Updates an existing managed API instance
       parameters:
       - $ref: '#/components/parameters/GroupId'
@@ -665,9 +691,11 @@ paths:
                     domain: mulesoft-inc
                 type: object
               example: *id004
-      operationId: getAssetsByGroupidByAssetidIdentities
+      summary: List asset identities
+      operationId: listAssetIdentities
     put:
-      operationId: updateAssetsByGroupidByAssetidIdentities
+      summary: Assign asset identities
+      operationId: assignAssetIdentities
       description: Assigns identities to an asset
       parameters:
       - name: x-skip-notifications
@@ -713,7 +741,8 @@ paths:
               schema:
                 example: domain
               example: domain
-      operationId: getAssetsByGroupidByAssetidDomain
+      summary: Get asset domain
+      operationId: getAssetDomain
   /assets/{groupId}/{assetId}/{version}:
     summary: Asset Version
     description: Asset version
@@ -735,7 +764,8 @@ paths:
               examples:
                 Asset:
                   $ref: examples/assets.yaml#/AssetWithFiles
-      operationId: getAssetsByGroupidByAssetidByVersion
+      summary: Get asset version
+      operationId: getAssetVersion
     delete:
       description: Deletes an asset by its ID
       parameters:
@@ -745,7 +775,8 @@ paths:
           description: Asset deleted
         '409':
           description: There were conflicts while deleting
-      operationId: deleteAssetsByGroupidByAssetidByVersion
+      summary: Delete asset version
+      operationId: deleteAssetVersion
   /assets/{groupId}/{assetId}/{version}/icon:
     summary: Icon
     description: Asset icon
@@ -773,7 +804,8 @@ paths:
           description: Invalid icon
         '404':
           description: Asset does not exist
-      operationId: updateAssetsByGroupidByAssetidByVersionIcon
+      summary: Upload asset version icon
+      operationId: uploadAssetVersionIcon
   /assets/{groupId}/{assetId}/{version}/asset:
     summary: Asset
     description: Asset
@@ -791,7 +823,8 @@ paths:
               examples:
                 Asset:
                   $ref: examples/assets.yaml#/AssetWithFiles
-      operationId: getAssetsByGroupidByAssetidByVersionAsset
+      summary: Get asset version files
+      operationId: getAssetVersionFiles
   /assets/{groupId}/{assetId}/{version}/rating:
     summary: Rating
     description: Rating of the asset
@@ -811,7 +844,8 @@ paths:
               examples:
                 Rating:
                   $ref: examples/ratings.yaml#/Rating
-      operationId: getAssetsByGroupidByAssetidByVersionRating
+      summary: Get asset rating
+      operationId: getAssetRating
   /assets/{groupId}/{assetId}/{version}/reviews:
     summary: Reviews
     description: Reviews of the asset
@@ -838,7 +872,8 @@ paths:
               examples:
                 Reviews:
                   $ref: examples/reviews.yaml#/Reviews
-      operationId: getAssetsByGroupidByAssetidByVersionReviews
+      summary: List asset reviews
+      operationId: listAssetReviews
     post:
       description: Creates a new asset review
       requestBody:
@@ -860,7 +895,8 @@ paths:
               examples:
                 Review:
                   $ref: examples/reviews.yaml#/Review
-      operationId: createAssetsByGroupidByAssetidByVersionReviews
+      summary: Create asset review
+      operationId: createAssetReview
   /assets/{groupId}/{assetId}/{version}/reviews/{reviewId}:
     summary: Review
     description: A single asset review identified by a "reviewId"
@@ -890,13 +926,15 @@ paths:
               examples:
                 Review:
                   $ref: examples/reviews.yaml#/Review
-      operationId: patchAssetsByGroupidByAssetidByVersionReviewsByReviewid
+      summary: Update asset review
+      operationId: updateAssetReview
     delete:
       description: Deletes an specific asset review.
       responses:
         '204':
           description: Review deleted
-      operationId: deleteAssetsByGroupidByAssetidByVersionReviewsByReviewid
+      summary: Delete asset review
+      operationId: deleteAssetReview
   /assets/{groupId}/{assetId}/{version}/api/model:
     summary: API Model
     description: API Model
@@ -914,7 +952,8 @@ paths:
               examples:
                 JsonLD:
                   $ref: examples/web-api.yaml#/JsonLD
-      operationId: getAssetsByGroupidByAssetidByVersionApiModel
+      summary: Get asset API model
+      operationId: getAssetApiModel
   /assets/{groupId}/{assetId}/{version}/api/root:
     summary: Root File
     description: Root file for the API
@@ -927,7 +966,8 @@ paths:
       responses:
         '301':
           description: Redirection to root file if available.
-      operationId: getAssetsByGroupidByAssetidByVersionApiRoot
+      summary: Get asset API root file
+      operationId: getAssetApiRoot
   /assets/{groupId}/{assetId}/{version}/api/{filePath}*:
     summary: File Path
     description: API file path
@@ -951,7 +991,8 @@ paths:
             - For example, if api.raml was specified the response will be that raml.
 
             '
-      operationId: getAssetsByGroupidByAssetidByVersionApiFilepath
+      summary: Get asset API file
+      operationId: getAssetApiFile
   /assets/{groupId}/{assetId}/{version}/domain:
     summary: Domain
     description: Allowed domain for the asset
@@ -969,7 +1010,8 @@ paths:
               schema:
                 example: domain
               example: domain
-      operationId: getAssetsByGroupidByAssetidByVersionDomain
+      summary: Get asset version domain
+      operationId: getAssetVersionDomain
   /assets/{groupId}/{assetId}/{version}/portal:
     summary: Portal Documentation
     description: Asset portal documentation
@@ -978,7 +1020,8 @@ paths:
     - $ref: '#/components/parameters/AssetId'
     - $ref: '#/components/parameters/Version'
     patch:
-      operationId: patchAssetsByGroupidByAssetidByVersionPortal
+      summary: Publish asset portal
+      operationId: publishAssetPortal
       description: 'Publishes draft version.
 
         This endpoint should be executed without specifying any body.
@@ -1007,7 +1050,8 @@ paths:
               examples:
                 Pages:
                   $ref: examples/pages.yaml#/PortalPages
-      operationId: getAssetsByGroupidByAssetidByVersionPortal
+      summary: Get asset portal
+      operationId: getAssetPortal
   /assets/{groupId}/{assetId}/{version}/portal/pages:
     summary: Pages
     description: Asset documentation pages
@@ -1031,7 +1075,8 @@ paths:
               examples:
                 value:
                   $ref: examples/pages.yaml#/Pages
-      operationId: getAssetsByGroupidByAssetidByVersionPortalPages
+      summary: List asset portal pages
+      operationId: listAssetPortalPages
   /assets/{groupId}/{assetId}/{version}/portal/pages/{pagePath}*:
     summary: Page
     description: A single documentation page path identified by a "pagePath"
@@ -1068,7 +1113,8 @@ paths:
               examples:
                 Page:
                   $ref: examples/pages.yaml#/Page
-      operationId: getAssetsByGroupidByAssetidByVersionPortalPagesPagepath
+      summary: Get asset portal page
+      operationId: getAssetPortalPage
   /assets/{groupId}/{assetId}/{version}/portal/resources:
     summary: Resources
     description: Asset documentation resources
@@ -1087,7 +1133,8 @@ paths:
                 example: &id005
                 - path: resources/file-a0a5db36-940e-447b-9100-05b166b2c084.jpg
               example: *id005
-      operationId: getAssetsByGroupidByAssetidByVersionPortalResources
+      summary: List asset portal resources
+      operationId: listAssetPortalResources
   /assets/{groupId}/{assetId}/{version}/portal/resources/{resourceId}:
     summary: Resource
     description: A single asset documentation resource identified by a "resourceId"
@@ -1101,7 +1148,8 @@ paths:
       responses:
         '200':
           description: Retrieved file as a binary content
-      operationId: getAssetsByGroupidByAssetidByVersionPortalResourcesByResourceid
+      summary: Get asset portal resource
+      operationId: getAssetPortalResource
   /assets/{groupId}/{assetId}/{version}/portal/draft:
     summary: Draft
     description: Asset documentation draft
@@ -1114,9 +1162,11 @@ paths:
       responses:
         '204':
           description: Draft deleted
-      operationId: deleteAssetsByGroupidByAssetidByVersionPortalDraft
+      summary: Discard asset portal draft
+      operationId: discardAssetPortalDraft
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionPortalDraft
+      summary: Publish asset portal draft
+      operationId: publishAssetPortalDraft
       description: 'Publishes asset documentation draft.
 
         This endpoint should be executed without specifying any body.
@@ -1145,7 +1195,8 @@ paths:
               examples:
                 Pages:
                   $ref: examples/pages.yaml#/PortalPages
-      operationId: getAssetsByGroupidByAssetidByVersionPortalDraft
+      summary: Get asset portal draft
+      operationId: getAssetPortalDraft
   /assets/{groupId}/{assetId}/{version}/portal/draft/pages:
     summary: Pages
     description: Asset documentation draft pages
@@ -1175,7 +1226,8 @@ paths:
           description: Page created.
         '409':
           description: Page already exists
-      operationId: createAssetsByGroupidByAssetidByVersionPortalDraftPages
+      summary: Create asset portal draft page
+      operationId: createAssetPortalDraftPage
     get:
       description: Gets a list of pages
       responses:
@@ -1192,7 +1244,8 @@ paths:
               examples:
                 Page:
                   $ref: examples/pages.yaml#/Page
-      operationId: getAssetsByGroupidByAssetidByVersionPortalDraftPages
+      summary: List asset portal draft pages
+      operationId: listAssetPortalDraftPages
   /assets/{groupId}/{assetId}/{version}/portal/draft/pages/{pagePath}*:
     summary: Page
     description: A single documentation page path identified by a "pagePath"
@@ -1231,7 +1284,8 @@ paths:
                   $ref: examples/pages.yaml#/Page
         '404':
           description: Page not found
-      operationId: getAssetsByGroupidByAssetidByVersionPortalDraftPagesPagepath
+      summary: Get asset portal draft page
+      operationId: getAssetPortalDraftPage
     put:
       description: Updates a page for a version of an asset portal
       requestBody:
@@ -1246,13 +1300,15 @@ paths:
       responses:
         '204':
           description: Page updated
-      operationId: updateAssetsByGroupidByAssetidByVersionPortalDraftPagesPagepath
+      summary: Update asset portal draft page
+      operationId: updateAssetPortalDraftPage
     delete:
       description: Deletes a page of a version of an asset portal
       responses:
         '204':
           description: Page deleted
-      operationId: deleteAssetsByGroupidByAssetidByVersionPortalDraftPagesPagepath
+      summary: Delete asset portal draft page
+      operationId: deleteAssetPortalDraftPage
   /assets/{groupId}/{assetId}/{version}/portal/draft/pagesOrder:
     summary: Pages Order
     description: Asset documentation pages order
@@ -1286,7 +1342,8 @@ paths:
               description: The X-Pages-Order-Revision response header value.
         '409':
           description: Pages order out of syncs
-      operationId: updateAssetsByGroupidByAssetidByVersionPortalDraftPagesorder
+      summary: Update asset portal draft page order
+      operationId: updateAssetPortalDraftPageOrder
   /assets/{groupId}/{assetId}/{version}/portal/draft/resources:
     summary: Resources
     description: Asset documentation resources
@@ -1305,9 +1362,11 @@ paths:
                 example: &id006
                 - path: resources/file-a0a5db36-940e-447b-9100-05b166b2c084.jpg
               example: *id006
-      operationId: getAssetsByGroupidByAssetidByVersionPortalDraftResources
+      summary: List asset portal draft resources
+      operationId: listAssetPortalDraftResources
     post:
-      operationId: createAssetsByGroupidByAssetidByVersionPortalDraftResources
+      summary: Create asset portal draft resource
+      operationId: createAssetPortalDraftResource
       description: 'Creates a resource for the portal draft.
 
         The required multipart fields in the body are the path of the resource and the content type. Ex:
@@ -1347,13 +1406,15 @@ paths:
       responses:
         '204':
           description: Resource deleted
-      operationId: deleteAssetsByGroupidByAssetidByVersionPortalDraftResourcesByResourceid
+      summary: Delete asset portal draft resource
+      operationId: deleteAssetPortalDraftResource
     get:
       description: Gets portals resource
       responses:
         '200':
           description: Retrieved file as a binary content
-      operationId: getAssetsByGroupidByAssetidByVersionPortalDraftResourcesByResourceid
+      summary: Get asset portal draft resource
+      operationId: getAssetPortalDraftResource
   /assets/{groupId}/{assetId}/{version}/policies/instances:
     summary: API Instances
     description: API instances affected by the policy
@@ -1396,7 +1457,8 @@ paths:
                   apiVersion: v1
                   url: localhost:8088/api/v1
               example: *id008
-      operationId: getAssetsByGroupidByAssetidByVersionPoliciesInstances
+      summary: List policy instances
+      operationId: listPolicyInstances
   /assets/{groupId}/{assetId}/{version}/policies/implementations:
     summary: Implementations
     description: Implementations of a specific policy
@@ -1455,7 +1517,8 @@ paths:
                   minRuntimeVersion: 1.0.0
                   maxRuntimeVersion: 2.0.0
               example: *id009
-      operationId: getAssetsByGroupidByAssetidByVersionPoliciesImplementations
+      summary: List policy implementations
+      operationId: listPolicyImplementations
   /assets/{groupId}/{assetId}/{version}/policies/environments:
     summary: Environments
     description: Environments affected by the policy
@@ -1490,7 +1553,8 @@ paths:
                 - environment: production
                   url: localhost:8088/api/v1
               example: *id010
-      operationId: getAssetsByGroupidByAssetidByVersionPoliciesEnvironments
+      summary: List policy environments
+      operationId: listPolicyEnvironments
   /assets/{groupId}/{assetId}/{version}/tags:
     summary: Tags
     description: Asset tags
@@ -1499,7 +1563,8 @@ paths:
     - $ref: '#/components/parameters/AssetId'
     - $ref: '#/components/parameters/Version'
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionTags
+      summary: Update asset tags
+      operationId: updateAssetTags
       description: Upserts asset tags
       requestBody:
         content:
@@ -1522,13 +1587,15 @@ paths:
     - $ref: '#/components/parameters/Version'
     - $ref: '#/components/parameters/TagKey'
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionTagsFieldsByTagkey
+      summary: Update asset tag field
+      operationId: updateAssetTagField
       description: Update or create a custom field
       responses:
         '200':
           description: Custom field updated
     delete:
-      operationId: deleteAssetsByGroupidByAssetidByVersionTagsFieldsByTagkey
+      summary: Delete asset tag field
+      operationId: deleteAssetTagField
       description: Delete a custom field
       responses:
         '204':
@@ -1542,7 +1609,8 @@ paths:
     - $ref: '#/components/parameters/Version'
     - $ref: '#/components/parameters/TagKey'
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionTagsCategoriesByTagkey
+      summary: Update asset tag category
+      operationId: updateAssetTagCategory
       description: Updates or creates a category.
       requestBody:
         content:
@@ -1561,7 +1629,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteAssetsByGroupidByAssetidByVersionTagsCategoriesByTagkey
+      summary: Delete asset tag category
+      operationId: deleteAssetTagCategory
   /assets/{groupId}/{assetId}/{version}/status:
     summary: Status
     description: The status of the asset
@@ -1570,7 +1639,8 @@ paths:
     - $ref: '#/components/parameters/AssetId'
     - $ref: '#/components/parameters/Version'
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionStatus
+      summary: Update asset status
+      operationId: updateAssetStatus
       description: Updates asset status
       requestBody:
         content:
@@ -1631,7 +1701,8 @@ paths:
                       description: Cannot hard delete asset after more than 7 days
                     targetStatus: hard-deleted
               example: *id011
-      operationId: getAssetsByGroupidByAssetidByVersionActions
+      summary: Get asset version actions
+      operationId: getAssetVersionActions
   /assets/{groupId}/{assetId}/{version}/owner:
     summary: Owner
     description: Asset ownership
@@ -1640,7 +1711,8 @@ paths:
     - $ref: '#/components/parameters/AssetId'
     - $ref: '#/components/parameters/Version'
     put:
-      operationId: updateAssetsByGroupidByAssetidByVersionOwner
+      summary: Update asset owner
+      operationId: updateAssetOwner
       description: Update Asset ownership
       requestBody:
         content:
@@ -1799,7 +1871,8 @@ paths:
                 2,"7f3d510c-bf27-4395-9b49-8ac8a9504d30","asssetname","7f3d510c-bf27-4395-9b49-8ac8a9504d30","1.0.0","AsssetName","","http-api","2022-10-13T14:54:32.507Z",,,"2022-10-13T14:54:32.716Z",76,1000,22,2000,0,0,0
 
                 '
-      operationId: createOrganizationsMetricsTop
+      summary: List top assets by metric
+      operationId: listTopAssets
       description: Creates top.
   /organizations/{masterOrganizationId}/clientProviders/{clientProviderId}/grantTypes:
     summary: Grant Types
@@ -1855,7 +1928,8 @@ paths:
                     exclude: []
                     required: false
               example: *id013
-      operationId: getOrganizationsByMasterorganizationidClientprovidersByClientprovideridGranttypes
+      summary: List client provider grant types
+      operationId: listClientProviderGrantTypes
   /organizations/{organizationId}/identities:
     summary: Identities
     description: Identities of an organization
@@ -1883,7 +1957,8 @@ paths:
                     domain: mulesoft-inc
                 type: object
               example: *id014
-      operationId: getOrganizationsByOrganizationidIdentities
+      summary: List organization identities
+      operationId: listOrganizationIdentities
   /organizations/{organizationId}/identities/{identityId}/assets/authorize:
     description: Authorizes provided resources against a given identity. For now, only teams are supported.
     post:
@@ -1907,7 +1982,8 @@ paths:
       responses:
         '201':
           description: success
-      operationId: createOrganizationsByOrganizationidIdentitiesByIdentityidAssetsAuthorize
+      summary: Authorize identity assets
+      operationId: authorizeIdentityAssets
   /organizations/{masterOrganizationId}/applications:
     summary: Applications
     description: A collection of applications that consume APIs via contracts
@@ -1956,7 +2032,8 @@ paths:
               examples:
                 ClientApplications:
                   $ref: examples/client-applications.yaml#/ClientApplications
-      operationId: getOrganizationsByMasterorganizationidApplications
+      summary: List client applications
+      operationId: listClientApplications
     post:
       description: Adds a client application
       parameters:
@@ -1977,7 +2054,8 @@ paths:
               examples:
                 ClientApplication:
                   $ref: examples/client-applications.yaml#/ClientApplication
-      operationId: createOrganizationsByMasterorganizationidApplications
+      summary: Create client application
+      operationId: createClientApplication
   /organizations/{masterOrganizationId}/applications/{applicationId}:
     summary: Application
     description: A single application identified by an "applicationId"
@@ -1994,9 +2072,11 @@ paths:
               examples:
                 ClientApplication:
                   $ref: examples/client-applications.yaml#/ClientApplication
-      operationId: getOrganizationsByMasterorganizationidApplicationsByApplicationid
+      summary: Get client application
+      operationId: getClientApplication
     patch:
-      operationId: patchOrganizationsByMasterorganizationidApplicationsByApplicationid
+      summary: Update client application
+      operationId: updateClientApplication
       description: Updates a client application
       requestBody:
         content:
@@ -2018,7 +2098,8 @@ paths:
       responses:
         '204':
           description: Client application deleted.
-      operationId: deleteOrganizationsByMasterorganizationidApplicationsByApplicationid
+      summary: Delete client application
+      operationId: deleteClientApplication
   ? /organizations/{masterOrganizationId}/applications/{applicationId}/environments/{environmentId}/apiGroupInstances/{apiGroupInstanceId}/limits
   : summary: Limits
     description: Limits of each instance part of the API Group
@@ -2072,7 +2153,8 @@ paths:
                       maximumRequests: 1
                       timePeriodInMilliseconds: 1000
               example: *id015
-      operationId: getOrganizationsByMasterorganizationidApplicationsByApplicationidEnvironmentsByEnvironmentidApigroupinstancesByApigroupinstanceidLimits
+      summary: List API group instance limits
+      operationId: listApiGroupInstanceLimits
   /organizations/{masterOrganizationId}/applications/{applicationId}/instances:
     summary: Application Instances
     description: Application instances
@@ -2089,7 +2171,8 @@ paths:
               examples:
                 Instances:
                   $ref: examples/instances.yaml#/Instances
-      operationId: getOrganizationsByMasterorganizationidApplicationsByApplicationidInstances
+      summary: List application instances
+      operationId: listApplicationInstances
   /organizations/{masterOrganizationId}/applications/{applicationId}/instances/{instanceId}/contracts:
     summary: Contracts
     description: The contracts for an API instance
@@ -2107,7 +2190,8 @@ paths:
               examples:
                 InstanceContracts:
                   $ref: examples/client-applications.yaml#/InstanceContracts
-      operationId: getOrganizationsByMasterorganizationidApplicationsByApplicationidInstancesByInstanceidContracts
+      summary: List instance contracts
+      operationId: listInstanceContracts
   /organizations/{masterOrganizationId}/applications/{applicationId}/contracts:
     summary: Application Contracts
     description: Contracts associated with an application
@@ -2133,9 +2217,11 @@ paths:
               examples:
                 Contracts:
                   $ref: examples/client-applications.yaml#/Contracts
-      operationId: getOrganizationsByMasterorganizationidApplicationsByApplicationidContracts
+      summary: List application contracts
+      operationId: listApplicationContracts
     post:
-      operationId: createOrganizationsByMasterorganizationidApplicationsByApplicationidContracts
+      summary: Create application contract
+      operationId: createApplicationContract
       description: Creates a contract for an API or an API Group
       requestBody:
         content:
@@ -2160,7 +2246,8 @@ paths:
     summary: Contract
     description: A single contract associated with an application and identified by a "contractId"
     patch:
-      operationId: patchOrganizationsByMasterorganizationidApplicationsByApplicationidContractsByContractid
+      summary: Update application contract
+      operationId: updateApplicationContract
       description: Updates contract SLA tier for an API or an API Group
       parameters:
       - $ref: '#/components/parameters/MasterOrganizationId'
@@ -2219,7 +2306,8 @@ paths:
     - $ref: '#/components/parameters/MasterOrganizationId'
     - $ref: '#/components/parameters/ApplicationId'
     post:
-      operationId: createOrganizationsByMasterorganizationidApplicationsByApplicationidSecretReset
+      summary: Reset application secret
+      operationId: resetApplicationSecret
       description: 'Resets the client secret for the application.
 
         This endpoint should be executed without specifying any body.
@@ -2238,7 +2326,8 @@ paths:
       responses:
         '204':
           description: Organization deleted
-      operationId: deleteOrganizationsByOrganizationid
+      summary: Delete organization
+      operationId: deleteOrganization
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}:
     summary: Asset Version
     description: Asset version
@@ -2301,7 +2390,8 @@ paths:
                   publicationStatusLink: https://anypoint.mulesoft.com/exchange/api/v2/organizations/1da12ec1-7614-43a3-bf24-ff754cab8ddf/assets/1da12ec1-7614-43a3-bf24-ff754cab8ddf/mulapp/1.0.0/publication/status/543254325432
                 type: object
               example: *id018
-      operationId: createOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersion
+      summary: Upload organization asset version
+      operationId: uploadOrganizationAssetVersion
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/mutabledata:
     summary: Asset mutable data
     description: Asset mutable data
@@ -2329,7 +2419,8 @@ paths:
                 example: &id019
                   mutableDataStatusLink: https://anypoint.mulesoft.com/exchange/api/v2/organizations/1da12ec1-7614-43a3-bf24-ff754cab8ddf/assets/1da12ec1-7614-43a3-bf24-ff754cab8ddf/mulapp/1.0.0/mutabledata/status/543254325432
               example: *id019
-      operationId: patchOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersionMutabledata
+      summary: Update asset mutable data
+      operationId: updateAssetMutableData
   /organizations/{organizationId}/groups/{groupId}/assets/{assetId}/nextAvailableVersion:
     summary: Next Available Version
     description: Next Available Version
@@ -2359,7 +2450,8 @@ paths:
                 example: &id020
                   nextAvailableVersion: 1.2.0
               example: *id020
-      operationId: getOrganizationsByOrganizationidGroupsByGroupidAssetsByAssetidNextavailableversion
+      summary: Get next available version
+      operationId: getNextAvailableVersion
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/mutabledata/status/{runId}:
     summary: By RunId
     description: Mutable data publication status by "runId"
@@ -2389,7 +2481,8 @@ paths:
                     errors: []
                 type: object
               example: *id021
-      operationId: getOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersionMutabledataStatusByRunid
+      summary: Get asset mutable data status
+      operationId: getAssetMutableDataStatus
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/publication/extendedStatus/{runId}:
     summary: By RunId
     description: Extended asset publication status by "runId"
@@ -2409,7 +2502,8 @@ paths:
               schema:
                 type: string
               example: string
-      operationId: getOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersionPublicationExtendedstatusByRunid
+      summary: Get asset publication extended status
+      operationId: getAssetPublicationExtendedStatus
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/publication/status:
     summary: Status
     description: Asset publication status
@@ -2438,7 +2532,8 @@ paths:
                     errors: []
                 type: object
               example: *id022
-      operationId: getOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersionPublicationStatus
+      summary: Get asset publication status
+      operationId: getAssetPublicationStatus
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/publication/status/{runId}:
     summary: By RunId
     description: Asset publication status by "runId"
@@ -2468,11 +2563,13 @@ paths:
                     errors: []
                 type: object
               example: *id023
-      operationId: getOrganizationsByOrganizationidAssetsByGroupidByAssetidByVersionPublicationStatusByRunid
+      summary: Get asset publication status by run
+      operationId: getAssetPublicationStatusByRun
   /organizations/{organizationId}/assets/{groupId}/{assetId}/{version}/documentation/generate:
     summary: Generate Documentation
     description: AI-powered documentation generation for an asset
     post:
+      summary: Generate asset documentation
       operationId: generateAssetDocumentation
       description: |
         Generates AI-powered documentation for an asset version.
@@ -2587,9 +2684,11 @@ paths:
               examples:
                 Categories:
                   $ref: examples/categories.yaml#/FieldsConfigurations
-      operationId: getOrganizationsByOrganizationidFields
+      summary: List custom fields
+      operationId: listCustomFields
     post:
-      operationId: createOrganizationsByOrganizationidFields
+      summary: Create custom field
+      operationId: createCustomField
       description: 'Adds a field configuration to the organization.
 
         - Body should be application/json. This is not specified in the raml as it conflicts with Osprey.
@@ -2612,7 +2711,8 @@ paths:
     - $ref: '#/components/parameters/OrganizationId'
     - $ref: '#/components/parameters/Id'
     patch:
-      operationId: patchOrganizationsByOrganizationidFieldsById
+      summary: Update custom field
+      operationId: updateCustomField
       description: Updates a custom field configuration
       parameters:
       - $ref: '#/components/parameters/ForceUpdate'
@@ -2626,7 +2726,8 @@ paths:
       responses:
         '204':
           description: Custom field deleted
-      operationId: deleteOrganizationsByOrganizationidFieldsById
+      summary: Delete custom field
+      operationId: deleteCustomField
   /organizations/{organizationId}/categories:
     summary: Categories
     description: Tags of type "category"
@@ -2649,7 +2750,8 @@ paths:
               examples:
                 Categories:
                   $ref: examples/categories.yaml#/CategoriesConfigurations
-      operationId: getOrganizationsByOrganizationidCategories
+      summary: List categories
+      operationId: listCategories
     post:
       description: Add a category configuration to the organization
       requestBody:
@@ -2668,7 +2770,8 @@ paths:
               examples:
                 Category:
                   $ref: examples/categories.yaml#/CategoryConfiguration
-      operationId: createOrganizationsByOrganizationidCategories
+      summary: Create category
+      operationId: createCategory
   /organizations/{organizationId}/categories/{id}:
     summary: Category Key
     description: The key that identifies the category
@@ -2676,7 +2779,8 @@ paths:
     - $ref: '#/components/parameters/OrganizationId'
     - $ref: '#/components/parameters/Id'
     patch:
-      operationId: patchOrganizationsByOrganizationidCategoriesById
+      summary: Update category
+      operationId: updateCategory
       description: 'Updates a category configuration
 
         - Body should be application/json. This is not specified in the raml as it conflicts with Osprey.
@@ -2694,7 +2798,8 @@ paths:
       responses:
         '204':
           description: Category deleted
-      operationId: deleteOrganizationsByOrganizationidCategoriesById
+      summary: Delete category
+      operationId: deleteCategory
   /organizations/{organizationId}/queries:
     summary: Organization Queries
     description: Saved searches queries that belong to an organization
@@ -2717,9 +2822,10 @@ paths:
               examples:
                 SearchQueries:
                   $ref: examples/search-queries.yaml#/SearchQueries
-      operationId: getOrganizationsByOrganizationidQueries
+      summary: List organization queries
+      operationId: listOrganizationQueries
     post:
-      summary: Creates a new query
+      summary: Create organization query
       requestBody:
         required: true
         content:
@@ -2740,7 +2846,7 @@ paths:
               examples:
                 SearchQuery:
                   $ref: examples/search-queries.yaml#/SearchQuery
-      operationId: createOrganizationsByOrganizationidQueries
+      operationId: createOrganizationQuery
       description: Creates a new query
   /organizations/{organizationId}/softDeleted:
     summary: Soft Deleted Assets
@@ -2762,7 +2868,8 @@ paths:
                 type: array
                 items:
                   type: object
-      operationId: getOrganizationsByOrganizationidSoftdeleted
+      summary: List soft deleted assets
+      operationId: listSoftDeletedAssets
   /organizations/{organizationId}/settings:
     summary: Organization Settings
     get:
@@ -2791,7 +2898,8 @@ paths:
         '400':
           description: No valid values were provided
           content: {}
-      operationId: getOrganizationsByOrganizationidSettings
+      summary: Get organization settings
+      operationId: getOrganizationSettings
     patch:
       description: Updates root organization level settings
       parameters:
@@ -2811,7 +2919,8 @@ paths:
         '400':
           description: If no valid values are provided
           content: {}
-      operationId: patchOrganizationsByOrganizationidSettings
+      summary: Update organization settings
+      operationId: updateOrganizationSettings
   /organizations/{organizationId}/queries/{queryId}:
     summary: Query
     description: A single organization saved search query identified by a "queryId"
@@ -2839,20 +2948,23 @@ paths:
               examples:
                 SearchQuery:
                   $ref: examples/search-queries.yaml#/SearchQuery
-      operationId: patchOrganizationsByOrganizationidQueriesByQueryid
+      summary: Update organization query
+      operationId: updateOrganizationQuery
     delete:
       description: Deletes the query
       responses:
         '204':
           description: Saved search query deleted
-      operationId: deleteOrganizationsByOrganizationidQueriesByQueryid
+      summary: Delete organization query
+      operationId: deleteOrganizationQuery
   /portals/{organizationDomain}:
     summary: Portal Domain
     description: Public portal domain
     parameters:
     - $ref: '#/components/parameters/OrganizationDomain'
     patch:
-      operationId: patchPortalsByOrganizationdomain
+      summary: Publish portal customization
+      operationId: publishPortalCustomization
       description: 'Publishes draft portal customization.
 
         This endpoint should be executed without specifying any body.
@@ -2875,7 +2987,8 @@ paths:
               examples:
                 Customization:
                   $ref: examples/customizations.yaml#/Customization
-      operationId: getPortalsByOrganizationdomain
+      summary: Get portal customization
+      operationId: getPortalCustomization
   /portals/{organizationDomain}/metadata:
     summary: Metadata
     description: Organization domain metadata
@@ -2893,7 +3006,8 @@ paths:
                   isFederated: false
                   name: Mulesoft Inc
               example: *id024
-      operationId: getPortalsByOrganizationdomainMetadata
+      summary: Get portal metadata
+      operationId: getPortalMetadata
   /portals/{organizationDomain}/resources:
     summary: Resources
     description: Public portal customization resources
@@ -2910,7 +3024,8 @@ paths:
                 example: &id025
                 - path: resources/file-a0a5db36-940e-447b-9100-05b166b2c084.jpg
               example: *id025
-      operationId: getPortalsByOrganizationdomainResources
+      summary: List portal resources
+      operationId: listPortalResources
   /portals/{organizationDomain}/resources/{resourceId}:
     summary: Resource
     description: A single portal resource identified by a "resourceId"
@@ -2922,7 +3037,8 @@ paths:
       responses:
         '200':
           description: Retrieved file as a binary content
-      operationId: getPortalsByOrganizationdomainResourcesByResourceid
+      summary: Get portal resource
+      operationId: getPortalResource
   /portals/{organizationDomain}/assets/search:
     summary: Public Assets Search
     description: Public Assets Search
@@ -2946,7 +3062,8 @@ paths:
                 type: array
                 items:
                   type: object
-      operationId: getPortalsByOrganizationdomainAssetsSearch
+      summary: Search public assets
+      operationId: searchPublicAssets
   /portals/{organizationDomain}/assets/{groupId}/{assetId}:
     summary: Asset
     description: Public asset by groupId and assetId
@@ -2960,7 +3077,8 @@ paths:
       responses:
         '200':
           description: success
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetid
+      summary: Get public asset
+      operationId: getPublicAsset
       description: Retrieves a assets.
   /portals/{organizationDomain}/assets/{groupId}/{assetId}/asset:
     summary: Asset
@@ -2981,7 +3099,8 @@ paths:
                   $ref: examples/assets.yaml#/AssetWithFiles
               schema:
                 type: object
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetidAsset
+      summary: Get public asset files
+      operationId: getPublicAssetFiles
   /portals/{organizationDomain}/assets/{groupId}/{assetId}/versionGroups/{versionGroup}/apiGroupInstances:
     summary: API Group instances
     description: API Group instances for an asset version group
@@ -3004,7 +3123,8 @@ paths:
               examples:
                 APIGroupInstances:
                   $ref: examples/assets.yaml#/VersionGroups
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetidVersiongroupsByVersiongroupApigroupinstances
+      summary: List public API group instances
+      operationId: listPublicApiGroupInstances
   ? /portals/{organizationDomain}/assets/{groupId}/{assetId}/versionGroups/{versionGroup}/environments/{environmentId}/apiGroupInstances/{apiGroupInstanceId}/tiers
   : summary: Tiers
     description: Tiers for a public API Group instance
@@ -3025,7 +3145,8 @@ paths:
               examples:
                 CompleteTiers:
                   $ref: examples/tiers.yaml#/CompleteTiers
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetidVersiongroupsByVersiongroupEnvironmentsByEnvironmentidApigroupinstancesByApigroupinstanceidTiers
+      summary: List public API group instance tiers
+      operationId: listPublicApiGroupInstanceTiers
   /portals/{organizationDomain}/assets/{groupId}/{assetId}/versionGroups/{versionGroup}/terms:
     summary: Terms and Conditions
     description: Gets public underlying API terms and conditions for a public asset version group
@@ -3044,7 +3165,8 @@ paths:
               examples:
                 Terms:
                   $ref: examples/instances.yaml#/Terms
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetidVersiongroupsByVersiongroupTerms
+      summary: Get public asset terms
+      operationId: getPublicAssetTerms
   /portals/{organizationDomain}/assets/{groupId}/{assetId}/{version}/asset:
     summary: Asset
     description: Asset
@@ -3063,7 +3185,8 @@ paths:
               examples:
                 Asset:
                   $ref: examples/assets.yaml#/AssetWithFiles
-      operationId: getPortalsByOrganizationdomainAssetsByGroupidByAssetidByVersionAsset
+      summary: Get public asset version files
+      operationId: getPublicAssetVersionFiles
   /portals/{organizationDomain}/applications/{applicationId}/instances:
     summary: Instances
     description: Public application instances
@@ -3080,14 +3203,16 @@ paths:
               examples:
                 Instances:
                   $ref: examples/instances.yaml#/Instances
-      operationId: getPortalsByOrganizationdomainApplicationsByApplicationidInstances
+      summary: List public application instances
+      operationId: listPublicApplicationInstances
   /portals/{organizationDomain}/domain:
     summary: Organization Domain
     description: Public portal domain
     parameters:
     - $ref: '#/components/parameters/OrganizationDomain'
     put:
-      operationId: updatePortalsByOrganizationdomainDomain
+      summary: Update portal domain
+      operationId: updatePortalDomain
       description: Updates a domain for an organization
       requestBody:
         content:
@@ -3103,7 +3228,8 @@ paths:
       responses:
         '204':
           description: Domain deleted
-      operationId: deletePortalsByOrganizationdomainDomain
+      summary: Delete portal domain
+      operationId: deletePortalDomain
     get:
       description: Gets domain
       responses:
@@ -3114,14 +3240,16 @@ paths:
               schema:
                 example: domain
               example: domain
-      operationId: getPortalsByOrganizationdomainDomain
+      summary: Get portal domain
+      operationId: getPortalDomain
   /portals/{organizationDomain}/cookieConsentId:
     summary: Organization CookieConsentId
     description: Public portal cookie consent id
     parameters:
     - $ref: '#/components/parameters/OrganizationDomain'
     put:
-      operationId: updatePortalsByOrganizationdomainCookieconsentid
+      summary: Update portal cookie consent
+      operationId: updatePortalCookieConsent
       description: Updates a cookie consent id for an organization
       requestBody:
         content:
@@ -3137,7 +3265,8 @@ paths:
       responses:
         '204':
           description: Cookie consent id deleted
-      operationId: deletePortalsByOrganizationdomainCookieconsentid
+      summary: Delete portal cookie consent
+      operationId: deletePortalCookieConsent
     get:
       description: Gets cookie consent id
       responses:
@@ -3149,14 +3278,16 @@ paths:
                 type: string
                 example: 88520c5c-fa3c-4381-85bb-8Ccdb9b543974
               example: 88520c5c-fa3c-4381-85bb-8Ccdb9b543974
-      operationId: getPortalsByOrganizationdomainCookieconsentid
+      summary: Get portal cookie consent
+      operationId: getPortalCookieConsent
   /portals/{organizationDomain}/status:
     summary: Organization public portal status
     description: Public portal status
     parameters:
     - $ref: '#/components/parameters/OrganizationDomain'
     put:
-      operationId: updatePortalsByOrganizationdomainStatus
+      summary: Update portal status
+      operationId: updatePortalStatus
       description: Updates a public portal status for an organization
       requestBody:
         content:
@@ -3179,14 +3310,16 @@ paths:
                 type: string
                 example: enabled
               example: enabled
-      operationId: getPortalsByOrganizationdomainStatus
+      summary: Get portal status
+      operationId: getPortalStatus
   /portals/{organizationDomain}/draft:
     summary: Draft
     description: Public portal customization draft
     parameters:
     - $ref: '#/components/parameters/OrganizationDomain'
     put:
-      operationId: updatePortalsByOrganizationdomainDraft
+      summary: Update portal customization draft
+      operationId: updatePortalCustomizationDraft
       description: Updates the portal customization draft
       requestBody:
         content:
@@ -3207,7 +3340,8 @@ paths:
           description: Draft portal deleted
         '404':
           description: Draft does not exist
-      operationId: deletePortalsByOrganizationdomainDraft
+      summary: Delete portal customization draft
+      operationId: deletePortalCustomizationDraft
     get:
       description: Gets the customization portal
       responses:
@@ -3218,7 +3352,8 @@ paths:
               examples:
                 Customization:
                   $ref: examples/customizations.yaml#/Customization
-      operationId: getPortalsByOrganizationdomainDraft
+      summary: Get portal customization draft
+      operationId: getPortalCustomizationDraft
   /portals/{organizationDomain}/draft/pages:
     summary: Pages
     description: Public portal customization draft pages
@@ -3247,7 +3382,8 @@ paths:
           description: Page already exists
         '422':
           description: Maximum page quantity exceeded
-      operationId: createPortalsByOrganizationdomainDraftPages
+      summary: Create portal draft page
+      operationId: createPortalDraftPage
   /portals/{organizationDomain}/draft/pages/{pagePath}*:
     summary: Page
     description: A single portal draft page identified by a "pagePath"
@@ -3268,13 +3404,15 @@ paths:
       responses:
         '204':
           description: Page updated
-      operationId: updatePortalsByOrganizationdomainDraftPagesPagepath
+      summary: Update portal draft page
+      operationId: updatePortalDraftPage
     delete:
       description: Deletes a page of a custom draft portal
       responses:
         '204':
           description: Page deleted
-      operationId: deletePortalsByOrganizationdomainDraftPagesPagepath
+      summary: Delete portal draft page
+      operationId: deletePortalDraftPage
     get:
       description: Gets a particular page
       parameters:
@@ -3303,7 +3441,8 @@ paths:
               examples:
                 Page:
                   $ref: examples/pages.yaml#/Page
-      operationId: getPortalsByOrganizationdomainDraftPagesPagepath
+      summary: Get portal draft page
+      operationId: getPortalDraftPage
   /portals/{organizationDomain}/draft/pagesOrder:
     summary: Pages Order
     description: Public portal pages order
@@ -3334,7 +3473,8 @@ paths:
               description: The X-Pages-Order-Revision response header value.
         '409':
           description: Pages order out of syncs
-      operationId: updatePortalsByOrganizationdomainDraftPagesorder
+      summary: Update portal draft page order
+      operationId: updatePortalDraftPageOrder
   /portals/{organizationDomain}/draft/resources:
     summary: Resources
     description: Public portal customization resources
@@ -3352,9 +3492,11 @@ paths:
                 example: &id026
                 - path: resources/file-a0a5db36-940e-447b-9100-05b166b2c084.jpg
               example: *id026
-      operationId: getPortalsByOrganizationdomainDraftResources
+      summary: List portal draft resources
+      operationId: listPortalDraftResources
     post:
-      operationId: createPortalsByOrganizationdomainDraftResources
+      summary: Create portal draft resource
+      operationId: createPortalDraftResource
       description: 'Creates a resource for the portal draft.
 
         The required multipart fields in the body are the path of the resource and the content type. Ex:
@@ -3393,13 +3535,15 @@ paths:
       responses:
         '204':
           description: Resource deleted
-      operationId: deletePortalsByOrganizationdomainDraftResourcesByResourceid
+      summary: Delete portal draft resource
+      operationId: deletePortalDraftResource
     get:
       description: Gets portals resource
       responses:
         '200':
           description: Retrieved file as a binary content
-      operationId: getPortalsByOrganizationdomainDraftResourcesByResourceid
+      summary: Get portal draft resource
+      operationId: getPortalDraftResource
   /portals/{organizationDomain}/pages/{pagePath}*:
     summary: Page
     description: A single portal page identified by a "pagePath"
@@ -3433,7 +3577,8 @@ paths:
               examples:
                 Page:
                   $ref: examples/pages.yaml#/Page
-      operationId: getPortalsByOrganizationdomainPagesPagepath
+      summary: Get portal page
+      operationId: getPortalPage
   /users/me/queries:
     summary: Queries
     description: Saved searches queries that belong to an user
@@ -3454,7 +3599,8 @@ paths:
               examples:
                 SearchQueries:
                   $ref: examples/search-queries.yaml#/SearchQueries
-      operationId: getUsersMeQueries
+      summary: List my queries
+      operationId: listMyQueries
     post:
       description: Creates a new query
       requestBody:
@@ -3477,7 +3623,8 @@ paths:
               examples:
                 SearchQuery:
                   $ref: examples/search-queries.yaml#/SearchQuery
-      operationId: createUsersMeQueries
+      summary: Create my query
+      operationId: createMyQuery
   /users/me/queries/{queryId}:
     summary: Query
     description: A single user saved search query identified by a "queryId"
@@ -3507,7 +3654,8 @@ paths:
                   - rest-api
                   search: salesforce
               example: *id028
-      operationId: patchUsersMeQueriesByQueryid
+      summary: Update my query
+      operationId: updateMyQuery
     delete:
       description: Deletes the query
       parameters:
@@ -3515,26 +3663,30 @@ paths:
       responses:
         '204':
           description: Saved search query deleted
-      operationId: deleteUsersMeQueriesByQueryid
+      summary: Delete my query
+      operationId: deleteMyQuery
   /featureFlags:
     get:
       responses:
         '200':
           description: Successful operation.
-      operationId: getFeatureflags
+      summary: List feature flags
+      operationId: listFeatureFlags
       description: Lists featureFlags.
   /graphql:
     get:
       responses:
         '200':
           description: Successful operation.
-      operationId: getGraphql
+      summary: Get GraphQL playground
+      operationId: getGraphqlPlayground
       description: Lists graphql.
     post:
       responses:
         '200':
           description: Successful operation.
-      operationId: postGraphql
+      summary: Execute GraphQL query
+      operationId: executeGraphqlQuery
       description: Creates graphql.
 components:
   securitySchemes:
@@ -3574,7 +3726,7 @@ components:
         example: asset-id
       x-origin:
       - api: urn:api:exchange-experience
-        operation: getAssetsSearch
+        operation: searchAssets
         description: GET `/assets/search`; use the asset search results from Exchange and extract`assetId` values.
         values: $[*].assetId
         labels: $[*].name
@@ -3607,7 +3759,7 @@ components:
         pattern: ^v{0,1}(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       x-origin:
       - api: urn:api:exchange-experience
-        operation: getAssetsSearch
+        operation: searchAssets
         description: GET `/assets/search`; use the asset search results from Exchange and extract `version` values.
         values: $.versions
         labels: $.name

--- a/apis/flex-gateway-manager/api.yaml
+++ b/apis/flex-gateway-manager/api.yaml
@@ -21,7 +21,8 @@ security:
 paths:
   /organizations/{organizationId}/usage/managed-gateways:
     get:
-      operationId: getOrganizationsByOrganizationidUsageManagedGateways
+      summary: Get managed gateway usage
+      operationId: getManagedGatewayUsage
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - name: size
@@ -66,7 +67,8 @@ paths:
       description: Retrieves a managed gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/runtime-configuration:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRuntimeConfiguration
+      summary: Get gateway runtime configuration
+      operationId: getGatewayRuntimeConfig
       description: Get the runtime configuration of a Managed or Self-Managed Omni Gateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -93,7 +95,8 @@ paths:
                 id: string
                 type: string
     put:
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRuntimeConfiguration
+      summary: Update gateway runtime configuration
+      operationId: updateGatewayRuntimeConfig
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -128,7 +131,8 @@ paths:
       description: Replaces a runtime configuration.
   /organizations/{organizationId}/environments/{environmentId}/gateways:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+      summary: List gateways
+      operationId: listGateways
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -187,7 +191,8 @@ paths:
                 type: string
       description: Retrieves a gateways.
     post:
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+      summary: Create gateway
+      operationId: createGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -220,7 +225,8 @@ paths:
       description: Creates a gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Get gateway by ID
+      operationId: getGatewayById
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -246,7 +252,8 @@ paths:
                 type: string
       description: Retrieves a gateways.
     put:
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Update gateway
+      operationId: updateGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -279,7 +286,8 @@ paths:
                 type: string
       description: Replaces a gateways.
     delete:
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayid
+      summary: Delete gateway
+      operationId: deleteGateway
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -300,7 +308,8 @@ paths:
       description: Deletes a gateways.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/registration:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidRegistration
+      summary: Get gateway registration
+      operationId: getGatewayRegistration
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -332,7 +341,8 @@ paths:
       description: Retrieves a registration.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/status:
     get:
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidStatus
+      summary: Get gateway status
+      operationId: getGatewayStatus
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -372,7 +382,8 @@ paths:
       description: Retrieves a status.
   /organizations/{organizationId}/environments/{environmentId}/gateways/{gatewayId}/desiredstatus:
     patch:
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidGatewaysByGatewayidDesiredstatus
+      summary: Update gateway desired status
+      operationId: updateGatewayDesiredStatus
       parameters:
       - $ref: '#/components/parameters/XOrigin_organizationId_Path'
       - $ref: '#/components/parameters/XOrigin_environmentId_Path'
@@ -486,7 +497,7 @@ components:
         format: uuid
       x-origin:
       - api: urn:api:flex-gateway-manager
-        operation: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidGateways
+        operation: listGateways
         description: GET `/organizations/{organizationId}/environments/{environmentId}/gateways` in this API; use `id` values as `gatewayId`.
         values: $.id
         labels: $.name

--- a/apis/metrics/api.yaml
+++ b/apis/metrics/api.yaml
@@ -21,6 +21,7 @@ security:
 paths:
   /metric_types:
     get:
+      summary: List supported metric types
       operationId: getMetricTypes
       description: Get a list of all supported metric names and descriptions.
       parameters:
@@ -90,7 +91,8 @@ paths:
           description: An internal error occurred in the server. This error sometimes indicates an issue with server-side code.
   "/metric_types/{metricTypeName}:describe":
     get:
-      operationId: getMetricTypesMetrictypenameDescribe
+      summary: Describe a metric type
+      operationId: describeMetricType
       description: Get the metric descriptor by a metric type name.
       parameters:
       - name: metricTypeName
@@ -198,7 +200,8 @@ paths:
           description: Exceeded service rate limit. Wait and try again.
         "500":
           description: An internal error occurred in the server. This error sometimes indicates an issue with server-side code.
-      operationId: createMetricsSearch
+      summary: Search metrics
+      operationId: searchMetrics
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/mule-agent-plugin/api.yaml
+++ b/apis/mule-agent-plugin/api.yaml
@@ -30,6 +30,7 @@ paths:
                     muleVersion: 3.9.2
                     agentVersion: 1.13.0
               example: {}
+      summary: Get agent status
       operationId: getAgent
     put:
       description: ' <p>Upgrades the Mule Agent plugin with the provided .jar file.</p> <p>Upgrading the Agent will only install the the jar passed in the request and won''t change any configuration</p> <p>Since v2.2.0 the configuration of Authentication Proxy and MCM endpoints was changed so in order to reconect the server further configuration would be needed</p>'
@@ -73,7 +74,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id003
-      operationId: updateAgent
+      summary: Upgrade Mule Agent plugin
+      operationId: upgradeAgent
   /agent/configuration:
     get:
       description: "Returns the full configuration of the Mule Agent. \n"
@@ -506,6 +508,7 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id004
+      summary: Get agent configuration
       operationId: getAgentConfiguration
   /agent/components:
     get:
@@ -641,7 +644,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id005
-      operationId: getAgentComponents
+      summary: List agent components
+      operationId: listAgentComponents
   /agent/{componentId}:
     get:
       description: "Returns a JSON representing the component's configuration. \n"
@@ -712,7 +716,8 @@ paths:
                     errorType: class java.util.NoSuchElementException
                     errorMessage: Component mule.agent.runtime.configuration.servicep does not exist.
               example: {}
-      operationId: getAgentByComponentid
+      summary: Get component configuration
+      operationId: getComponentById
     patch:
       description: 'Changes the configuration of the component by overriding the values of the properties passed
 
@@ -814,7 +819,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id013
-      operationId: patchAgentByComponentid
+      summary: Patch component configuration
+      operationId: patchComponent
     put:
       description: 'Changes the configuration of the component by overriding the full configuration with the
 
@@ -928,7 +934,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id021
-      operationId: updateAgentByComponentid
+      summary: Update component configuration
+      operationId: updateComponent
   /agent/{componentId}/enable:
     put:
       description: 'Enables a service.
@@ -1010,7 +1017,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id027
-      operationId: updateAgentByComponentidEnable
+      summary: Enable component
+      operationId: enableComponent
   /agent/{componentId}/disable:
     put:
       description: 'Disables a service.
@@ -1092,7 +1100,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id033
-      operationId: updateAgentByComponentidDisable
+      summary: Disable component
+      operationId: disableComponent
   /agent/{componentId}/{applicationName}:
     put:
       description: 'Completely changes the configuration of the service by overriding the configuration provided in the agent descriptor with the properties passed in the JSON. If the body is not sent in the request the service will respond with the current information.
@@ -1195,7 +1204,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id039
-      operationId: updateAgentByComponentidByApplicationname
+      summary: Update component config for application
+      operationId: updateComponentForApp
     patch:
       description: 'Partially changes the configuration of the service for a given application by overriding the configuration provided in the agent descriptor with the properties passed in the JSON. If the body is not sent in the request the service will respond with the current information.
 
@@ -1297,7 +1307,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id045
-      operationId: patchAgentByComponentidByApplicationname
+      summary: Patch component config for application
+      operationId: patchComponentForApp
   /actions:
     put:
       description: 'Performs the action described by the request on the Runtime where the Mule Agent is running on.
@@ -1439,7 +1450,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id051
-      operationId: updateActions
+      summary: Perform runtime action
+      operationId: performAction
   /domains:
     get:
       description: 'Returns all existing domains in Mule.
@@ -1502,7 +1514,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id052
-      operationId: getDomains
+      summary: List domains
+      operationId: listDomains
   /domains/{domainName}:
     get:
       description: 'Returns all the details of the domain requested.
@@ -1643,7 +1656,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id056
-      operationId: getDomainsByDomainname
+      summary: Get domain details
+      operationId: getDomain
     put:
       description: 'Deploys or redeploys a domain in Mule
 
@@ -1749,7 +1763,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id062
-      operationId: updateDomainsByDomainname
+      summary: Deploy or redeploy domain
+      operationId: deployDomain
     delete:
       description: 'Undeploys a domain from Mule.
 
@@ -1905,7 +1920,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id068
-      operationId: deleteDomainsByDomainname
+      summary: Undeploy domain
+      operationId: undeployDomain
   /domains/{domainName}/restart:
     put:
       description: 'Restarts a domain from Mule.
@@ -2062,7 +2078,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id074
-      operationId: updateDomainsByDomainnameRestart
+      summary: Restart domain
+      operationId: restartDomain
   /applications:
     get:
       description: 'Returns all existing applications in Mule.
@@ -2110,7 +2127,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id075
-      operationId: getApplications
+      summary: List applications
+      operationId: listApplications
   /applications/{applicationName}:
     get:
       description: 'Gets a particular application.
@@ -2193,7 +2211,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id079
-      operationId: getApplicationsByApplicationname
+      summary: Get application details
+      operationId: getApplication
     put:
       description: 'Redeploys/creates an application to Mule using the name and file passed in the POST body.
 
@@ -2313,7 +2332,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id082
-      operationId: updateApplicationsByApplicationname
+      summary: Deploy or redeploy application
+      operationId: deployApplication
     delete:
       description: 'Undeploys an application from Mule.
 
@@ -2370,7 +2390,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id085
-      operationId: deleteApplicationsByApplicationname
+      summary: Undeploy application
+      operationId: undeployApplication
   /applications/{applicationName}/stop:
     put:
       description: 'Stops an application.
@@ -2445,7 +2466,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id088
-      operationId: updateApplicationsByApplicationnameStop
+      summary: Stop application
+      operationId: stopApplication
   /applications/{applicationName}/start:
     put:
       description: 'Starts an application.
@@ -2520,7 +2542,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id091
-      operationId: updateApplicationsByApplicationnameStart
+      summary: Start application
+      operationId: startApplication
   /applications/{applicationName}/restart:
     put:
       description: 'Retarts an application.
@@ -2578,7 +2601,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id094
-      operationId: updateApplicationsByApplicationnameRestart
+      summary: Restart application
+      operationId: restartApplication
   /applications/{applicationName}/flows:
     get:
       description: 'Gets application flows.
@@ -2634,7 +2658,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id097
-      operationId: getApplicationsByApplicationnameFlows
+      summary: List application flows
+      operationId: listApplicationFlows
   /applications/{applicationName}/flows/{flowName}/stop:
     put:
       description: 'Stop an application flow.
@@ -2687,7 +2712,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id099
-      operationId: updateApplicationsByApplicationnameFlowsByFlownameStop
+      summary: Stop application flow
+      operationId: stopApplicationFlow
   /applications/{applicationName}/flows/{flowName}/start:
     put:
       description: 'Start an application flow.
@@ -2740,7 +2766,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id101
-      operationId: updateApplicationsByApplicationnameFlowsByFlownameStart
+      summary: Start application flow
+      operationId: startApplicationFlow
   /clusters:
     get:
       description: 'Retrieves the clustering information of this Mule instance.
@@ -2816,7 +2843,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id105
-      operationId: getClusters
+      summary: Get cluster info
+      operationId: getClusterInfo
     post:
       description: 'Adds this Mule instance to a cluster with the information provided in the request.
 
@@ -2875,7 +2903,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id107
-      operationId: createClusters
+      summary: Join cluster
+      operationId: joinCluster
     delete:
       description: 'Removes this Mule instance from the cluster it belongs to.
 
@@ -2903,7 +2932,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id109
-      operationId: deleteClusters
+      summary: Leave cluster
+      operationId: leaveCluster
   /clusters/members:
     get:
       description: 'Retrieves the members of the cluster this Mule instance belongs to.
@@ -2945,7 +2975,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id111
-      operationId: getClustersMembers
+      summary: List cluster members
+      operationId: listClusterMembers
   /healthcheck/applications/{applicationName}/ready:
     get:
       description: Health Check Endpoint to validate if an application is running or not.
@@ -2972,7 +3003,8 @@ paths:
                     errorType: errorType
                     errorMessage: 'Not ready. Status: [CREATED | INITIALISED | STARTED | STOPPED | DEPLOYMENT_FAILED | DESTROYED]'
               example: {}
-      operationId: getHealthcheckApplicationsByApplicationnameReady
+      summary: Check application readiness
+      operationId: checkApplicationReady
   /logging/domains/{domainName}/{scope}:
     get:
       description: "Retrieves the current log level that has the domain for a package scope. \n"
@@ -3040,7 +3072,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id114
-      operationId: getLoggingDomainsByDomainnameByScope
+      summary: Get domain log level
+      operationId: getDomainLogLevel
     post:
       description: 'Sets the log level on a package scope for the domain passed on the request.
 
@@ -3135,7 +3168,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id120
-      operationId: createLoggingDomainsByDomainnameByScope
+      summary: Set domain log level
+      operationId: setDomainLogLevel
   /logging/applications/{appName}/{packageScope}:
     get:
       description: 'Retrieves the current log level of a package scope in an application.
@@ -3204,7 +3238,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id124
-      operationId: getLoggingApplicationsByAppnameByPackagescope
+      summary: Get application log level
+      operationId: getApplicationLogLevel
     post:
       description: 'Sets the log level on a package scope for the application passed on the request.
 
@@ -3268,7 +3303,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id128
-      operationId: createLoggingApplicationsByAppnameByPackagescope
+      summary: Set application log level
+      operationId: setApplicationLogLevel
   /monitoring:
     get:
       description: 'Retrieves all the beans currently being tracked by the monitoring service. Not available on PCE.
@@ -3517,7 +3553,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id130
-      operationId: getMonitoring
+      summary: List monitored beans
+      operationId: listMonitoredBeans
     post:
       description: 'Adds a list of beans to those currently being tracked the monitoring service. Not available on PCE.
 
@@ -3592,7 +3629,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id134
-      operationId: createMonitoring
+      summary: Add monitored beans
+      operationId: addMonitoredBeans
     delete:
       description: 'Removes a list of beans of those currently being tracked the monitoring service. The beans to delete that are send in the json body must be identicaly the same as the registered ones. Not available on PCE.
 
@@ -3673,7 +3711,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id138
-      operationId: deleteMonitoring
+      summary: Remove monitored beans
+      operationId: removeMonitoredBeans
   /properties:
     get:
       description: 'Retrieves the server properties that are currently being set by the Mule Agent server properties.
@@ -3719,7 +3758,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id140
-      operationId: getProperties
+      summary: List server properties
+      operationId: listProperties
     post:
       description: 'Sets the given properties in the ${mule_home}/conf/wrapper.conf file.
 
@@ -3833,7 +3873,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id146
-      operationId: createProperties
+      summary: Set server properties
+      operationId: setProperties
   /properties/{propertyName}:
     get:
       description: 'Retrieves the property with the given name from the ${mule_home}/conf/wrapper.conf file.
@@ -3938,7 +3979,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id154
-      operationId: getPropertiesByPropertyname
+      summary: Get server property
+      operationId: getProperty
     put:
       description: 'Sets the given property in ${mule_home}/conf/wrapper.conf file.
 
@@ -4053,7 +4095,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id162
-      operationId: updatePropertiesByPropertyname
+      summary: Set server property
+      operationId: setProperty
     delete:
       description: 'Removes the property located in ${mule_home}/conf/wrapper.conf file.
 
@@ -4137,7 +4180,8 @@ paths:
                   errorType: errorType
                   errorMessage: Error Message
               example: *id170
-      operationId: deletePropertiesByPropertyname
+      summary: Delete server property
+      operationId: deleteProperty
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/object-store-v2-stats/api.yaml
+++ b/apis/object-store-v2-stats/api.yaml
@@ -109,7 +109,8 @@ paths:
               example: *id001
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationid
+      summary: Get organization request counts
+      operationId: getOrganizationRequestCounts
   /organizations/{organizationId}/environments:
     get:
       description: Get list of environments with data for a specific queried time frame. This api will also return list of deleted environments. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -152,7 +153,8 @@ paths:
               example: *id002
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironments
+      summary: List organization environments
+      operationId: listOrganizationEnvironments
   /organizations/{organizationId}/environments/{environmentId}:
     get:
       description: Get list of request counts. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -244,7 +246,8 @@ paths:
               example: *id003
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentid
+      summary: Get environment request counts
+      operationId: getEnvironmentRequestCounts
   /organizations/{organizationId}/environments/{environmentId}/regions:
     get:
       description: Get list of regions with data for a specific queried time frame. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -288,7 +291,8 @@ paths:
               example: *id004
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegions
+      summary: List environment regions
+      operationId: listEnvironmentRegions
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}:
     get:
       description: Get list of request count per region. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -381,7 +385,8 @@ paths:
               example: *id005
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionid
+      summary: Get region request counts
+      operationId: getRegionRequestCounts
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/stores:
     get:
       description: Get list of stores with data for a specific queried time frame. This api will also return list of deleted stores. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -427,7 +432,8 @@ paths:
               example: *id006
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidStores
+      summary: List region stores
+      operationId: listRegionStores
   /organizations/{organizationId}/environments/{environmentId}/regions/{regionId}/stores/{storeId}:
     get:
       description: Get list of request count per store. If you are using connected app, "Store Metrics Viewer" scope is needed. For query timeframes and retention refer to [OSv2 documentation](https://docs.mulesoft.com/object-store/osv2-apis#osv2-usage-limits)
@@ -531,7 +537,8 @@ paths:
               example: *id007
         '400':
           description: If invalid query parameters or exceeds the limits documented above.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidRegionsByRegionidStoresByStoreid
+      summary: Get store request counts
+      operationId: getStoreRequestCounts
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/object-store-v2/api.yaml
+++ b/apis/object-store-v2/api.yaml
@@ -65,7 +65,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStores
+      summary: List object stores
+      operationId: listStores
   /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}:
     description: Manage an object store.
     get:
@@ -95,7 +96,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreid
+      summary: Get object store
+      operationId: getStore
     put:
       description: Create an object store. If you are using connected app, either of "Manage Stores / Manage Store Data" scopes  are needed.
       parameters:
@@ -113,7 +115,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreid
+      summary: Create object store
+      operationId: createStore
     patch:
       description: Modify object store attributes. If you are using connected app, either of "Manage Stores / Manage Store Data" scopes  are needed.
       parameters:
@@ -131,7 +134,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreid
+      summary: Update object store
+      operationId: updateStore
     delete:
       description: Delete the object store. If you are using connected app, either of "Manage Stores / Manage Store Data" scopes  are needed.
       parameters:
@@ -149,7 +153,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreid
+      summary: Delete object store
+      operationId: deleteStore
   /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions:
     description: Get list of keys in an object store
     get:
@@ -191,7 +196,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitions
+      summary: List object store partitions
+      operationId: listStorePartitions
   /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions/{partitionId}:
     description: Change object store values
     head:
@@ -214,7 +220,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: headOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionid
+      summary: Check partition existence
+      operationId: checkPartitionExists
     get:
       description: Retrieve the values stored for the given key. If you are using connected app, you need "Manage Store Data" scope.
       parameters:
@@ -271,7 +278,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionid
+      summary: Retrieve values for a partition
+      operationId: getPartitionValues
     delete:
       description: Remove the object and all the values in the contained list. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -301,7 +309,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionid
+      summary: Delete partition and its values
+      operationId: deletePartition
   /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions/{partitionId}/keys:
     get:
       description: Retrieve the given object. If you are using connected app, "Manage Store Data" scope is needed.
@@ -328,7 +337,8 @@ paths:
           description: 'There has been an unexpected error performing this request.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeys
+      summary: List keys in a partition
+      operationId: listPartitionKeys
   /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions/{partitionId}/keys/{keyId}:
     description: Create, modify, or delete an object.
     get:
@@ -357,7 +367,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyid
+      summary: Retrieve object by key
+      operationId: getObject
     head:
       description: Check if the object exists. "Manage Store Data" scope is needed.
       parameters:
@@ -388,7 +399,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: headOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyid
+      summary: Check if object exists
+      operationId: checkObjectExists
     put:
       description: Create/Modify the given object. Total object size must be 10MB or less, and metadata must be 4KB or less. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -428,7 +440,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyid
+      summary: Create or modify object
+      operationId: upsertObject
     post:
       description: Alter the object in a non-idempotent fashion. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -452,7 +465,8 @@ paths:
           description: 'There has been an unexpected error performing this request.
 
             '
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyid
+      summary: Alter object non-idempotently
+      operationId: alterObject
     delete:
       description: Remove the object with the given ID. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -483,7 +497,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyid
+      summary: Delete object by key
+      operationId: deleteObject
   ? /organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions/{partitionId}/keys/{keyId}/confirmations/{confirmationId}
   : description: Change operation settings. If you are using connected app, "Manage Store Data" scope is needed.
     post:
@@ -513,7 +528,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyidConfirmationsByConfirmationid
+      summary: Acknowledge object operation
+      operationId: ackObjectOperation
     patch:
       description: Extend the operation's time to live. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -549,7 +565,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyidConfirmationsByConfirmationid
+      summary: Extend operation time to live
+      operationId: extendOperationTtl
     delete:
       description: Nack the operation. If you are using connected app, "Manage Store Data" scope is needed.
       parameters:
@@ -577,7 +594,8 @@ paths:
           description: 'This request is not implemented on this service.
 
             '
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeysByKeyidConfirmationsByConfirmationid
+      summary: Reject object operation
+      operationId: nackObjectOperation
   /organizations/{organizationId}/regions:
     description: Get list of object store regions
     get:
@@ -599,7 +617,8 @@ paths:
                   name: Mars West (Oxia Palus)
                   url: http://object-store.mars-west-1.cloudhub.com
               example: *id005
-      operationId: getOrganizationsByOrganizationidRegions
+      summary: List available object store regions
+      operationId: listRegions
 components:
   securitySchemes:
     bearerAuth:
@@ -619,7 +638,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:object-store-v2
-        operation: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStores
+        operation: listStores
         description: GET `/organizations/{organizationId}/environments/{environmentId}/stores` in this API; use `id` values as `storeId`.
         values: $.id
         labels: $.name
@@ -632,7 +651,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:object-store-v2
-        operation: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitions
+        operation: listStorePartitions
         description: GET `/organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions` in this API; use `id` values as `partitionId`.
         values: $.id
         labels: $.name
@@ -645,7 +664,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:object-store-v2
-        operation: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidStoresByStoreidPartitionsByPartitionidKeys
+        operation: listPartitionKeys
         description: GET `/organizations/{organizationId}/environments/{environmentId}/stores/{storeId}/partitions/{partitionId}/keys` in this API; use `id` values as `keyId`.
         values: $.id
       description: The key ID to identify the target resource.

--- a/apis/partner-manager-v2-tracking/api.yaml
+++ b/apis/partner-manager-v2-tracking/api.yaml
@@ -830,7 +830,8 @@ paths:
               example: {}
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissions
+      summary: List transmissions
+      operationId: listTransmissions
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/replay:
     description: The collection of replay
     post:
@@ -882,7 +883,8 @@ paths:
                 message: Operation completed successfully.
       security:
       - oauth_2_0: []
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsReplay
+      summary: Replay multiple transmissions
+      operationId: replayTransmissions
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/{transmissionId}:
     description: The collection of transmissions
     get:
@@ -1009,7 +1011,8 @@ paths:
               example: {}
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionid
+      summary: Get transmission by ID
+      operationId: getTransmissionById
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/{transmissionId}/reviews:
     description: Get an entity representing a review
     get:
@@ -1112,7 +1115,8 @@ paths:
                   message: string
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionidReviews
+      summary: List transmission reviews
+      operationId: listTransmissionReviews
     post:
       description: Create a new review
       parameters:
@@ -1180,7 +1184,8 @@ paths:
                   message: string
       security:
       - oauth_2_0: []
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionidReviews
+      summary: Create transmission review
+      operationId: createTransmissionReview
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/{transmissionId}/reviews/{reviewId}:
     description: Get an entity representing a review
     put:
@@ -1253,7 +1258,8 @@ paths:
                   message: string
       security:
       - oauth_2_0: []
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionidReviewsByReviewid
+      summary: Update transmission review
+      operationId: updateTransmissionReview
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/{transmissionId}/summaries:
     description: The collection of summaries
     get:
@@ -1320,7 +1326,8 @@ paths:
               example: {}
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionidSummaries
+      summary: List transmission summaries
+      operationId: listTransmissionSummaries
   /organizations/{organizationId}/environments/{envId}/activity/transmissions/{transmissionId}/replays:
     description: Get an entity representing a replay
     post:
@@ -1394,7 +1401,8 @@ paths:
                   message: string
       security:
       - oauth_2_0: []
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvidActivityTransmissionsByTransmissionidReplays
+      summary: Replay transmission
+      operationId: replayTransmission
   /organizations/{organizationId}/environments/{envId}/activity/messages:
     description: The collection of messages
     get:
@@ -1682,7 +1690,8 @@ paths:
               example: {}
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityMessages
+      summary: List messages
+      operationId: listMessages
   /organizations/{organizationId}/environments/{envId}/activity/messages/{messageId}:
     description: Get an entity representing a message
     get:
@@ -1865,7 +1874,8 @@ paths:
                   message: string
       security:
       - oauth_2_0: []
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidActivityMessagesByMessageid
+      summary: Get message by ID
+      operationId: getMessageById
   /organizations/{organizationId}/environments/{envId}/contents:
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -1890,7 +1900,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvidContentsByContentid
+      summary: Get content by ID
+      operationId: getContentById
       description: Retrieves a contents.
 components:
   requestBodies:

--- a/apis/proxies-xapi/api.yaml
+++ b/apis/proxies-xapi/api.yaml
@@ -32,7 +32,8 @@ paths:
           default: 3.8.0
           type: string
         description: The gatewayVersion query parameter.
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidProxy
+      summary: Get proxy
+      operationId: getProxy
     parameters:
     - name: environmentApiId
       in: path
@@ -56,7 +57,8 @@ paths:
               type: object
         required: false
         description: The active data to create.
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidActive
+      summary: Activate proxy
+      operationId: activateProxy
       description: Creates a active.
     parameters:
     - name: environmentApiId
@@ -79,7 +81,8 @@ paths:
               schema:
                 example: ./responses/deployments.json
               example: ./responses/deployments.json
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+      summary: List proxy deployments
+      operationId: listProxyDeployments
       description: Retrieves a deployments.
     post:
       responses:
@@ -98,7 +101,8 @@ paths:
               $ref: ./requests/inbound-deployment-body.json
         required: true
         description: The deployments data to create.
-      operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+      summary: Create proxy deployment
+      operationId: createProxyDeployment
       description: Creates a deployments.
     parameters:
     - name: environmentApiId
@@ -122,7 +126,8 @@ paths:
                 example: ./responses/deployment.json
               example: ./responses/deployment.json
       description: Returns a deployment (And sync it with deployment targets)
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeploymentsByProxydeploymentid
+      summary: Get proxy deployment by ID
+      operationId: getProxyDeploymentById
     put:
       responses:
         '201':
@@ -135,7 +140,8 @@ paths:
               $ref: ./requests/inbound-deployment-body.json
         required: true
         description: The deployments data to update.
-      operationId: updateOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeploymentsByProxydeploymentid
+      summary: Replace proxy deployment
+      operationId: replaceProxyDeployment
       description: Replaces a deployments.
     patch:
       responses:
@@ -154,7 +160,8 @@ paths:
               type: object
         required: true
         description: The deployments data to update.
-      operationId: patchOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeploymentsByProxydeploymentid
+      summary: Patch proxy deployment
+      operationId: patchProxyDeployment
       description: Updates a deployments.
     parameters:
     - name: proxyDeploymentId
@@ -191,7 +198,8 @@ paths:
                 example: ./responses/deploymentStatus.json
               example: ./responses/deploymentStatus.json
       description: Retrieves the deployment details of a version (And sync it with deployment targets).
-      operationId: getOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeploymentsByProxydeploymentidStatus
+      summary: Get proxy deployment status
+      operationId: getProxyDeploymentStatus
     parameters:
     - name: proxyDeploymentId
       in: path
@@ -218,7 +226,8 @@ paths:
           description: Successful operation.
       parameters:
       - $ref: '#/components/parameters/XOrigin_environmentId_Query'
-      operationId: getOrganizationsByOrganizationidDeploymentTargets
+      summary: List deployment targets
+      operationId: listDeploymentTargets
       description: Retrieves a deployment targets.
     parameters:
     - $ref: '#/components/parameters/XOrigin_organizationId_Path'
@@ -237,7 +246,8 @@ paths:
           - redeployment
           - rollback
         description: The operation query parameter.
-      operationId: getOrganizationsByOrganizationidTargetsByTargetidRuntimesMuleVersions
+      summary: List Mule runtime versions
+      operationId: listMuleRuntimeVersions
       description: Retrieves a versions.
     parameters:
     - name: targetId
@@ -254,7 +264,8 @@ paths:
           description: Successful operation.
       parameters:
       - $ref: '#/components/parameters/XOrigin_environmentId_Query'
-      operationId: getOrganizationsByOrganizationidProvidersByProvideridRuntimeFabricDeploymentTargets
+      summary: List Runtime Fabric deployment targets
+      operationId: listRuntimeFabricTargets
       description: Retrieves a runtime fabric deployment targets.
     parameters:
     - name: providerId
@@ -276,7 +287,8 @@ paths:
         schema:
           type: boolean
         description: The returnAllTargets query parameter.
-      operationId: getOrganizationsByOrganizationidProvidersByProvideridCloudhub2DeploymentTargets
+      summary: List CloudHub 2.0 deployment targets
+      operationId: listCloudHub2DeploymentTargets
       description: Retrieves a cloudhub2 deployment targets.
     parameters:
     - name: providerId
@@ -291,7 +303,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: getChDomainsByDomainname
+      summary: Get CH domain by name
+      operationId: getChDomain
       description: Retrieves a ch domains.
     parameters:
     - name: domainName
@@ -310,6 +323,7 @@ paths:
               schema:
                 example: ./responses/echo.json
               example: ./responses/echo.json
+      summary: Get echo response
       operationId: getStatusEcho
       description: Lists echo.
   /status/version:
@@ -323,6 +337,7 @@ paths:
                 example: ./responses/version.json
               example: ./responses/version.json
       description: Retrieves the date and commit of the deployed version.
+      summary: Get service version
       operationId: getStatusVersion
 components:
   schemas: {}

--- a/apis/runtime-fabric/api.yaml
+++ b/apis/runtime-fabric/api.yaml
@@ -1000,7 +1000,6 @@ paths:
       operationId: testExternalLogForwarding
   /organizations/{organizationId}/fabrics/events:
     get:
-      summary: List cluster events
       description: 'Retrieve the cluster events across the Runtime Fabrics in the
         organization.
 

--- a/apis/runtime-fabric/api.yaml
+++ b/apis/runtime-fabric/api.yaml
@@ -139,7 +139,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidFabrics
+      summary: List Runtime Fabrics
+      operationId: listFabrics
     post:
       description: Runtime Fabric register endpoint
       parameters:
@@ -222,7 +223,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidFabrics
+      summary: Register a Runtime Fabric
+      operationId: registerFabric
   /organizations/{organizationId}/fabrics/{fabricId}:
     description: Get an entity representing a fabric
     delete:
@@ -239,7 +241,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidFabricsByFabricid
+      summary: Delete Runtime Fabric
+      operationId: deleteFabric
       description: Deletes a fabrics.
     get:
       description: 'Get the fabric
@@ -518,7 +521,8 @@ paths:
               schema: {}
               example:
                 message: Operation completed successfully.
-      operationId: getOrganizationsByOrganizationidFabricsByFabricid
+      summary: Get Runtime Fabric by ID
+      operationId: getFabric
     patch:
       description: Update existing fabric
       parameters:
@@ -799,7 +803,8 @@ paths:
                         largestBlock: 12847
                     activationToken: fe01cd5a-89a1-11e7-bb31-be2e44b06b34
               example: {}
-      operationId: patchOrganizationsByOrganizationidFabricsByFabricid
+      summary: Update Runtime Fabric
+      operationId: updateFabric
   /organizations/{organizationId}/fabrics/{fabricId}/logforwarding:
     get:
       description: Get the Log forwarding config information.
@@ -841,7 +846,8 @@ paths:
                   forwardLogs:
                     id: string
                     type: string
-      operationId: getOrganizationsByOrganizationidFabricsByFabricidLogforwarding
+      summary: Get log forwarding configuration
+      operationId: getFabricLogForwarding
     patch:
       description: Update the Anypoint Log forwarding config
       parameters:
@@ -889,7 +895,8 @@ paths:
                   forwardLogs:
                     id: string
                     type: string
-      operationId: patchOrganizationsByOrganizationidFabricsByFabricidLogforwarding
+      summary: Update log forwarding configuration
+      operationId: updateFabricLogForwarding
     delete:
       description: Deletes the External and Anypoint Monitoring log forwarding.
       parameters:
@@ -898,7 +905,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidFabricsByFabricidLogforwarding
+      summary: Delete log forwarding configuration
+      operationId: deleteFabricLogForwarding
   /organizations/{organizationId}/fabrics/{fabricId}/logforwarding/external:
     patch:
       description: Configure the External log forwarding
@@ -953,7 +961,8 @@ paths:
                 forwardLogs:
                   id: string
                   type: string
-      operationId: patchOrganizationsByOrganizationidFabricsByFabricidLogforwardingExternal
+      summary: Configure external log forwarding
+      operationId: updateExternalLogForwarding
     delete:
       description: Deletes the External log forwarding configuration
       parameters:
@@ -962,7 +971,8 @@ paths:
       responses:
         '204':
           description: Operation completed successfully with no content returned.
-      operationId: deleteOrganizationsByOrganizationidFabricsByFabricidLogforwardingExternal
+      summary: Delete external log forwarding
+      operationId: deleteExternalLogForwarding
   /organizations/{organizationId}/fabrics/{fabricId}/logforwarding/external/test:
     post:
       description: 'Lets the user send test message to validate the end to end connectivity.
@@ -986,7 +996,8 @@ paths:
               example:
                 messageRef: string
                 rtfName: string
-      operationId: createOrganizationsByOrganizationidFabricsByFabricidLogforwardingExternalTest
+      summary: Test external log forwarding delivery
+      operationId: testExternalLogForwarding
   /organizations/{organizationId}/fabrics/events:
     get:
       summary: List cluster events
@@ -1017,6 +1028,7 @@ paths:
                 createdAt: 1573599617.0
                 updatedAt: 1573599618.0
                 resolvedAt: 1573599618.0
+      summary: List Runtime Fabric cluster events
       operationId: listFabricEvents
   /organizations/{organizationId}/fabrics/{fabricId}/health:
     get:
@@ -1091,7 +1103,8 @@ paths:
                   failedProbes:
                   - id: string
                     type: string
-      operationId: getOrganizationsByOrganizationidFabricsByFabricidHealth
+      summary: Get Runtime Fabric health
+      operationId: getFabricHealth
   /organizations/{organizationId}/fabrics/{fabricId}/oidcIssuers:
     get:
       summary: Get OIDC issuers
@@ -1368,7 +1381,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: getOrganizationsByOrganizationidGroups
+      summary: List fabric groups
+      operationId: listFabricGroups
   /organizations/{organizationId}/groups/{groupId}:
     get:
       parameters:
@@ -1388,7 +1402,8 @@ paths:
                 associations:
                 - id: string
                   type: string
-      operationId: getOrganizationsByOrganizationidGroupsByGroupid
+      summary: Get fabric group by ID
+      operationId: getFabricGroup
       description: Retrieves a groups.
   /organizations/{organizationId}/groups/{groupId}/associations:
     description: The collection of associations
@@ -1454,7 +1469,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: getOrganizationsByOrganizationidGroupsByGroupidAssociations
+      summary: List environment associations
+      operationId: listGroupAssociations
     post:
       description: Create a new association
       parameters:
@@ -1513,7 +1529,8 @@ paths:
                 errors:
                 - code: string
                   message: string
-      operationId: createOrganizationsByOrganizationidGroupsByGroupidAssociations
+      summary: Create environment association
+      operationId: createAssociation
   /organizations/{organizationId}/groups/{groupId}/associations/{associationId}:
     get:
       parameters:
@@ -1540,7 +1557,8 @@ paths:
                 organizationId: string
                 deploymentStatus: string
                 errorMessage: string
-      operationId: getOrganizationsByOrganizationidGroupsByGroupidAssociationsByAssociationid
+      summary: Get environment association by ID
+      operationId: getAssociation
       description: Retrieves a associations.
     patch:
       description: Update an existing environment association.
@@ -1575,7 +1593,8 @@ paths:
                 organizationId: string
                 deploymentStatus: string
                 errorMessage: string
-      operationId: patchOrganizationsByOrganizationidGroupsByGroupidAssociationsByAssociationid
+      summary: Update environment association
+      operationId: updateAssociation
     delete:
       parameters:
       - $ref: '#/components/parameters/XOrigin_fabricOrganizationId_Path'
@@ -1589,7 +1608,8 @@ paths:
       responses:
         '200':
           description: Successful operation.
-      operationId: deleteOrganizationsByOrganizationidGroupsByGroupidAssociationsByAssociationid
+      summary: Delete environment association
+      operationId: deleteAssociation
       description: Deletes a associations.
   /organizations/{organizationId}:
     delete:
@@ -1600,7 +1620,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '429':
           description: Too many requests. Rate limit exceeded.
-      operationId: deleteOrganizationsByOrganizationid
+      summary: Delete organization Runtime Fabric data
+      operationId: deleteOrganization
       description: Deletes a organizations.
   /organizations/{organizationId}/environments/{environmentId}:
     delete:
@@ -1623,7 +1644,8 @@ paths:
           description: Operation completed successfully with no content returned.
         '429':
           description: Too many requests. Rate limit exceeded.
-      operationId: deleteOrganizationsByOrganizationidEnvironmentsByEnvid
+      summary: Delete environment
+      operationId: deleteEnvironment
       description: Deletes a environments.
   /organizations/{organizationId}/imageregistrycredential:
     get:
@@ -1643,7 +1665,8 @@ paths:
                 password: string
                 endpoint: string
                 passwordExpirationTimestamp: 0.0
-      operationId: getOrganizationsByOrganizationidImageregistrycredential
+      summary: Get image registry credential
+      operationId: getImageRegistryCredential
   /organizations/{organizationId}/imageRegistryProperties:
     get:
       summary: Get image registry properties
@@ -1751,7 +1774,8 @@ paths:
               example:
               - id: string
                 type: string
-      operationId: getRuntimes
+      summary: List supported Mule runtime versions
+      operationId: listRuntimes
   /runtimes/{name}:
     get:
       description: 'Retrieve a single name
@@ -1778,7 +1802,8 @@ paths:
                 endOfSupportDate: 0.0
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getRuntimesByName
+      summary: Get Mule runtime by name
+      operationId: getRuntime
   /runtimes/{name}/tags:
     get:
       description: 'Retrieves tags for a name
@@ -1806,7 +1831,8 @@ paths:
                 type: string
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getRuntimesByNameTags
+      summary: List tags for a runtime
+      operationId: listRuntimeTags
   /runtimes/{name}/tags/{tagId}:
     get:
       description: 'Retrieve a single name for a name
@@ -1842,7 +1868,8 @@ paths:
                 gracePeriodDays: 0.0
         '404':
           description: Not found. The requested resource does not exist.
-      operationId: getRuntimesByNameTagsByTagid
+      summary: Get runtime tag by ID
+      operationId: getRuntimeTag
   /downloads:
     get:
       description: List the available downloads
@@ -1881,6 +1908,7 @@ paths:
                 rtfctl:
                   id: string
                   type: string
+      summary: List available downloads
       operationId: getDownloads
   /download: {}
   /download/scripts: {}
@@ -1895,6 +1923,7 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
+      summary: Download latest installer scripts
       operationId: getDownloadScriptsLatest
   /download/installer: {}
   /download/installer/latest:
@@ -1908,6 +1937,7 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
+      summary: Download latest installer package
       operationId: getDownloadInstallerLatest
   /download/installer/latest/url:
     get:
@@ -1927,6 +1957,7 @@ paths:
                     type: string
               example:
                 url: string
+      summary: Get pre-signed installer URL
       operationId: getDownloadInstallerLatestUrl
   /download/agent: {}
   /download/agent/latest:
@@ -1940,6 +1971,7 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
+      summary: Download latest agent helm chart
       operationId: getDownloadAgentLatest
   /download/rtfctl: {}
   /download/rtfctl/latest:
@@ -1953,6 +1985,7 @@ paths:
             application/octet-stream:
               schema: {}
               example: (binary data)
+      summary: Download latest rtfctl binary
       operationId: getDownloadRtfctlLatest
 components:
   securitySchemes:
@@ -3265,7 +3298,7 @@ components:
         type: string
       x-origin:
       - api: urn:api:runtime-fabric
-        operation: getOrganizationsByOrganizationidFabrics
+        operation: listFabrics
         description: GET `/organizations/{organizationId}/fabrics` in this API; use `[].id` values as `fabricId`.
         values: $[*].id
         labels: $[*].name

--- a/apis/tokenization-creation-and-mgmt/api.yaml
+++ b/apis/tokenization-creation-and-mgmt/api.yaml
@@ -149,7 +149,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createFormats
+      summary: Create tokenization format
+      operationId: createFormat
     get:
       description: Get a list of formats.
       parameters:
@@ -285,6 +286,7 @@ paths:
                 - code: 0
                   field: string
                   message: string
+      summary: List tokenization formats
       operationId: getFormats
   /formats/{formatId}:
     description: Get an entity representing a format
@@ -388,7 +390,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getFormatsByFormatid
+      summary: Get tokenization format
+      operationId: getFormatById
     put:
       parameters:
       - name: formatId
@@ -496,7 +499,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateFormatsByFormatid
+      summary: Update tokenization format
+      operationId: updateFormatById
       description: Replaces a formats.
     delete:
       parameters:
@@ -566,7 +570,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteFormatsByFormatid
+      summary: Delete tokenization format
+      operationId: deleteFormatById
       description: Deletes a formats.
   /services:
     description: The collection of services
@@ -646,6 +651,7 @@ paths:
                 - code: 0
                   field: string
                   message: string
+      summary: List tokenization services
       operationId: getServices
   /environments/{envId}:
     parameters:
@@ -810,7 +816,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: createEnvironmentsByEnvidServices
+      summary: Create tokenization service
+      operationId: createService
     get:
       description: Get a list of services.
       parameters:
@@ -1033,7 +1040,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidServices
+      summary: List services in environment
+      operationId: getEnvironmentServices
   /environments/{envId}/services/{serviceId}:
     description: Get an entity representing a service
     get:
@@ -1177,7 +1185,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidServicesByServiceid
+      summary: Get service by ID
+      operationId: getServiceById
     patch:
       description: To perform rekey of a VDP table associated with a service.
       parameters:
@@ -1311,7 +1320,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: patchEnvironmentsByEnvidServicesByServiceid
+      summary: Rekey service VDP table
+      operationId: rekeyService
     put:
       parameters:
       - name: desiredStatus
@@ -1505,7 +1515,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: updateEnvironmentsByEnvidServicesByServiceid
+      summary: Update tokenization service
+      operationId: updateService
       description: Replaces a services.
     delete:
       parameters:
@@ -1576,7 +1587,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: deleteEnvironmentsByEnvidServicesByServiceid
+      summary: Delete tokenization service
+      operationId: deleteService
       description: Deletes a services.
   /environments/{envId}/deployments:
     get:
@@ -1722,7 +1734,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeployments
+      summary: List tokenization deployments
+      operationId: listDeployments
   /environments/{envId}/deployments/{deploymentId}:
     description: 'Access detailed operations of a particular deployment.
 
@@ -1847,7 +1860,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeploymentsByDeploymentid
+      summary: Get deployment by ID
+      operationId: getDeploymentById
   /environments/{envId}/deployments/{deploymentId}/specs:
     description: Get an entity representing a spec
     get:
@@ -1954,7 +1968,8 @@ paths:
                 - code: 0
                   field: string
                   message: string
-      operationId: getEnvironmentsByEnvidDeploymentsByDeploymentidSpecs
+      summary: List deployment specs
+      operationId: listDeploymentSpecs
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/usage/api.yaml
+++ b/apis/usage/api.yaml
@@ -199,7 +199,8 @@ paths:
           description: Too Many Requests. Rate limit exceeded.
         "500":
           description: Internal Server Error. An unexpected error occurred.
-      operationId: getMetersDescribe
+      summary: Describe all meters
+      operationId: describeMeters
   "/meters/{meter-name}:describe":
     get:
       description: Get particular meter description from usage api
@@ -295,7 +296,8 @@ paths:
           description: Too Many Requests. Rate limit exceeded.
         "500":
           description: Internal Server Error. An unexpected error occurred.
-      operationId: getMetersMeterNameDescribe
+      summary: Describe a specific meter
+      operationId: describeMeter
   /meters:search:
     post:
       description: Search meters from usage api
@@ -344,7 +346,8 @@ paths:
           description: Too Many Requests. Rate limit exceeded.
         "500":
           description: Internal Server Error. An unexpected error occurred.
-      operationId: createMetersSearch
+      summary: Search meters
+      operationId: searchMeters
 components:
   securitySchemes:
     bearerAuth:

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -87,7 +87,7 @@ Retrieve all API instances in the selected environment. Each entry represents a 
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -180,7 +180,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -87,7 +87,7 @@ Retrieve all API instances in the selected environment. Each entry represents a 
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -114,7 +114,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `version`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID from Step 1
@@ -165,7 +165,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults. For example, Omni Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults. For example, Omni Gateway uses `credentialsOriginHasHttpBasicAuthenticationHeader` while the generic template uses `credentialsOrigin`.
 
 ## Step 5: Apply Policy to API Instance
 
@@ -180,7 +180,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -237,15 +237,15 @@ After completing all steps, verify the policy is properly applied:
 
 ## Next Steps
 
-1. **Verify the policy** — List applied policies with `listOrganizationsEnvironmentsApisPolicies` to confirm it's active and correctly configured.
+1. **Verify the policy** — List applied policies with `listApiPolicies` to confirm it's active and correctly configured.
 
 2. **Test the enforcement** — Send requests to the API and verify the policy behaves as expected (e.g., unauthorized requests are rejected, rate limits are enforced).
 
-3. **Adjust configuration** — Use `patchOrganizationsEnvironmentsApisPolicy` to update configuration without removing the policy.
+3. **Adjust configuration** — Use `updateApiPolicy` to update configuration without removing the policy.
 
-4. **Apply additional policies** — Repeat this workflow to layer multiple policies (e.g., add rate limiting on top of OAuth2). Use `updateOrganizationsEnvironmentsApisPoliciesBulk` to control execution order.
+4. **Apply additional policies** — Repeat this workflow to layer multiple policies (e.g., add rate limiting on top of OAuth2). Use `reorderApiPolicies` to control execution order.
 
-5. **Consider automated policies** — If you want this policy applied to all APIs in the organization automatically, explore `createOrganizationsAutomatedpolicies`.
+5. **Consider automated policies** — If you want this policy applied to all APIs in the organization automatically, explore `createAutomatedPolicy`.
 
 ## Troubleshooting
 
@@ -270,7 +270,7 @@ After completing all steps, verify the policy is properly applied:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint
@@ -302,7 +302,7 @@ After completing all steps, verify the policy is properly applied:
 **Solutions:**
 - Pass both `apiInstanceId` and `environmentId` to filter for compatible templates
 - Remove filters to see all templates, then check compatibility manually
-- For custom policies, verify the template is published via `listOrganizationsCustompolicytemplates`
+- For custom policies, verify the template is published via `listCustomPolicyTemplates`
 
 ## Related Jobs
 

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -324,7 +324,7 @@ Deploys the API instance to the selected Omni Gateway target. This uses the Prox
 
 ```yaml
 api: urn:api:proxies-xapi
-operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+operationId: createProxyDeployment
 inputs:
   organizationId:
     from:

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -114,7 +114,7 @@ Publishes your agent specification to Exchange as a reusable asset. This makes i
 
 ```yaml
 api: urn:api:exchange-experience
-operationId: createAssets
+operationId: uploadAsset
 inputs:
   organizationId:
     from:
@@ -160,7 +160,7 @@ Search Exchange for agent assets. This search is not scoped to a specific organi
 
 ```yaml
 api: urn:api:exchange-experience
-operationId: getAssetsSearch
+operationId: searchAssets
 inputs:
   types:
     value: "agent"

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your agent Exchange asset. Th
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists agent instances in the selected environment by filtering with `family=agen
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -490,7 +490,7 @@ Apply the selected policy to your agent instance with the appropriate configurat
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-agent/SKILL.md
+++ b/skills/secure-agent/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your agent Exchange asset. Th
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists agent instances in the selected environment by filtering with `family=agen
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -423,7 +423,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -475,7 +475,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 9: Apply Policy to Instance
 
@@ -490,7 +490,7 @@ Apply the selected policy to your agent instance with the appropriate configurat
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -622,7 +622,7 @@ Your agent is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -223,7 +223,7 @@ Creates a managed API instance in API Manager from your Exchange asset. This cre
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -350,7 +350,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -402,7 +402,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 7: Apply Policy to API Instance
 
@@ -417,7 +417,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -552,7 +552,7 @@ Your API is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -223,7 +223,7 @@ Creates a managed API instance in API Manager from your Exchange asset. This cre
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -417,7 +417,7 @@ Apply the selected policy to your API instance with the appropriate configuratio
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -108,7 +108,7 @@ Publishes your API specification to Exchange as a reusable asset. This makes it 
 
 ```yaml
 api: urn:api:exchange-experience
-operationId: createAssets
+operationId: uploadAsset
 inputs:
   organizationId:
     from:

--- a/skills/secure-api/SKILL.md
+++ b/skills/secure-api/SKILL.md
@@ -286,7 +286,7 @@ Deploys the API instance to the selected Omni Gateway target. This uses the Prox
 
 ```yaml
 api: urn:api:proxies-xapi
-operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+operationId: createProxyDeployment
 inputs:
   organizationId:
     from:

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -324,7 +324,7 @@ Deploys the API instance to the selected Omni Gateway target. This uses the Prox
 
 ```yaml
 api: urn:api:proxies-xapi
-operationId: createOrganizationsByOrganizationidEnvironmentsByEnvironmentidApisByEnvironmentapiidDeployments
+operationId: createProxyDeployment
 inputs:
   organizationId:
     from:

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -114,7 +114,7 @@ Publishes your MCP server specification to Exchange as a reusable asset. This ma
 
 ```yaml
 api: urn:api:exchange-experience
-operationId: createAssets
+operationId: uploadAsset
 inputs:
   organizationId:
     from:
@@ -160,7 +160,7 @@ Search Exchange for MCP server assets. This search is not scoped to a specific o
 
 ```yaml
 api: urn:api:exchange-experience
-operationId: getAssetsSearch
+operationId: searchAssets
 inputs:
   types:
     value: "mcp"

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your MCP server Exchange asse
 
 ```yaml
 api: urn:api:api-manager
-operationId: createApi
+operationId: createApiInstance
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists MCP server instances in the selected environment by filtering with `family
 
 ```yaml
 api: urn:api:api-manager
-operationId: listApis
+operationId: listApiInstances
 inputs:
   organizationId:
     from:
@@ -490,7 +490,7 @@ Apply the selected policy to your MCP server instance with the appropriate confi
 
 ```yaml
 api: urn:api:api-manager
-operationId: applyApiPolicy
+operationId: applyApiInstancePolicy
 inputs:
   organizationId:
     from:

--- a/skills/secure-mcp-server/SKILL.md
+++ b/skills/secure-mcp-server/SKILL.md
@@ -261,7 +261,7 @@ Creates a managed API instance in API Manager from your MCP server Exchange asse
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApis
+operationId: createApi
 inputs:
   organizationId:
     from:
@@ -395,7 +395,7 @@ Lists MCP server instances in the selected environment by filtering with `family
 
 ```yaml
 api: urn:api:api-manager
-operationId: listOrganizationsEnvironmentsApis
+operationId: listApis
 inputs:
   organizationId:
     from:
@@ -423,7 +423,7 @@ outputs:
 
 List all available policy templates from Exchange for your organization. This endpoint returns the full Exchange coordinates (`groupId`, `assetId`, `assetVersion`) and gateway-compatible configuration for each template — these are required when applying a policy.
 
-**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listOrganizationsPolicytemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
+**Important:** Use the `api-portal-xapi` endpoint (`getExchangePolicyTemplates`) instead of the generic `listPolicyTemplates` endpoint. The generic endpoint does not return Exchange coordinates or gateway-specific configuration property names, which are required for the apply step.
 
 **What you'll need:**
 - Organization ID
@@ -475,7 +475,7 @@ outputs:
 
 **Common issues:**
 - **Empty list**: Pass `apiInstanceId` and `environmentId` to get templates compatible with your gateway type. Without these filters, some templates may not appear.
-- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listOrganizationsPolicytemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
+- **Wrong config property names**: Always use the configuration from this endpoint — the generic `listPolicyTemplates` endpoint may return different (non-gateway-compatible) property names and defaults.
 
 ## Step 9: Apply Policy to API Instance
 
@@ -490,7 +490,7 @@ Apply the selected policy to your MCP server instance with the appropriate confi
 
 ```yaml
 api: urn:api:api-manager
-operationId: createOrganizationsEnvironmentsApisPolicies
+operationId: applyApiPolicy
 inputs:
   organizationId:
     from:
@@ -622,7 +622,7 @@ Your MCP server is now protected with:
 **Symptoms:** `"The policy to be created is missing at least one of the following properties related to the policy template: 'groupId', 'assetId', 'assetVersion'."`
 
 **Possible causes:**
-- Used the generic `listOrganizationsPolicytemplates` endpoint which does not return Exchange coordinates
+- Used the generic `listPolicyTemplates` endpoint which does not return Exchange coordinates
 
 **Solutions:**
 - Use `getExchangePolicyTemplates` from `api-portal-xapi` instead — this returns the full Exchange coordinates needed by the apply endpoint


### PR DESCRIPTION
## Summary

Consolidates the operation ID and summary cleanups from the related API specification PRs into a single change set.

- Renames verbose, path-derived `operationId` values to concise, resource-focused camelCase names.
- Adds or normalizes operation `summary` fields using imperative language without trailing periods.
- Updates affected internal `x-origin` operation references.
- Updates JTBD skill references that depend on renamed operations.
- Resolves the Runtime Fabric consolidation conflict while preserving the existing endpoint structure.

## Scope

Updates 25 API specifications:

- Access Management
- AMC Application Manager
- Anypoint Monitoring Archive
- Anypoint MQ Broker and Stats
- Anypoint Security Policies
- API Manager, API Platform, and API Portal XAPI
- ARM Monitoring Query and ARM REST Services
- Citizen Platform Experience
- CloudHub and CloudHub 2.0
- Exchange Experience
- Flex Gateway Manager
- Metrics
- Mule Agent Plugin
- Object Store v2 and Stats
- Partner Manager Tracking
- Proxies XAPI
- Runtime Fabric
- Tokenization Management
- Usage