### PR TITLE
@W-23941113: publish Universal policy tools on the Platform MCP catalog

### DIFF
--- a/mcps/mulesoft-platform/enrichment.yaml
+++ b/mcps/mulesoft-platform/enrichment.yaml
@@ -11,6 +11,12 @@ parameters:
   instance_id:
       x-origin:
         $ref: ../../fragments/anypoint_fragment.yaml#/components/parameters/environmentApiId_Path/x-origin
+  instance_ids:
+      x-origin:
+        $ref: ../../fragments/anypoint_fragment.yaml#/components/parameters/environmentApiId_Path/x-origin
+  policy_id:
+    x-origin:
+      $ref: ../../fragments/anypoint_fragment.yaml#/components/parameters/policyId_Path/x-origin
   group_id:
     x-origin:
       $ref: ../../fragments/anypoint_fragment.yaml#/components/parameters/groupId_Path/x-origin

--- a/mcps/mulesoft-platform/exchange.json
+++ b/mcps/mulesoft-platform/exchange.json
@@ -1,14 +1,16 @@
 {
-  "main": "mcp.yaml",
+  "main": "server.json",
   "name": "MuleSoft Platform MCP Server",
   "organizationId": "8bfc8bbf-5508-419e-aadc-77dfe18a8172",
   "groupId": "f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform",
   "assetId": "mulesoft-platform",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "apiVersion": "v2",
   "classifier": "mcp-metadata",
   "dependencies": [],
-  "tags": ["MuleSoft Platform"],
+  "tags": [
+    "MuleSoft Platform"
+  ],
   "originalFormatVersion": "3.0",
   "install": {
     "docs_url": "https://docs.mulesoft.com/mulesoft-mcp-server/using-mulesoft-platform-mcp-server"

--- a/mcps/mulesoft-platform/server.json
+++ b/mcps/mulesoft-platform/server.json
@@ -88,6 +88,13 @@
           "uri": "ui://asset-instance/policy-selector.html"
         },
         {
+          "description": "Interactive login panel for MuleSoft Platform authentication",
+          "mimeType": "text/html;profile=mcp-app",
+          "name": "anypoint-login-ui",
+          "title": "MuleSoft Platform Login",
+          "uri": "ui://auth/login-v2.html"
+        },
+        {
           "description": "Interactive HTML UI for browsing and selecting business groups",
           "mimeType": "text/html;profile=mcp-app",
           "name": "anypoint-business-group-selector-ui",
@@ -6959,6 +6966,71 @@
         {
           "annotations": {
             "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Authenticate with MuleSoft Platform. MUST be called before any other tool. Call WITHOUT arguments to display the interactive login panel where the user enters their credentials. Do NOT ask the user for username/password in the chat.",
+          "inputSchema": {
+            "properties": {
+              "password": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Password"
+              },
+              "username": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Username"
+              }
+            },
+            "title": "loginArguments",
+            "type": "object"
+          },
+          "meta": {
+            "ui": {
+              "resourceUri": "ui://auth/login-v2.html"
+            },
+            "ui/resourceUri": "ui://auth/login-v2.html"
+          },
+          "name": "login",
+          "title": "Login to MuleSoft Platform"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": null,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Clear the stored authentication token.",
+          "inputSchema": {
+            "properties": {},
+            "title": "logoutArguments",
+            "type": "object"
+          },
+          "name": "logout",
+          "title": "Logout from MuleSoft Platform"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
             "idempotentHint": null,
             "openWorldHint": true,
             "readOnlyHint": false,
@@ -9498,8 +9570,8 @@
         }
       ],
       "totals": {
-        "resources": 29,
-        "tools": 120
+        "resources": 30,
+        "tools": 122
       }
     }
   },

--- a/mcps/mulesoft-platform/server.json
+++ b/mcps/mulesoft-platform/server.json
@@ -88,13 +88,6 @@
           "uri": "ui://asset-instance/policy-selector.html"
         },
         {
-          "description": "Interactive login panel for MuleSoft Platform authentication",
-          "mimeType": "text/html;profile=mcp-app",
-          "name": "anypoint-login-ui",
-          "title": "MuleSoft Platform Login",
-          "uri": "ui://auth/login-v2.html"
-        },
-        {
           "description": "Interactive HTML UI for browsing and selecting business groups",
           "mimeType": "text/html;profile=mcp-app",
           "name": "anypoint-business-group-selector-ui",
@@ -216,9 +209,159 @@
       ],
       "tools": [
         {
-          "description": "Apply the selected policy to the target asset instance using the provided configuration data. For non-MuleSoft providers, pass provider and gateway_id; policy_template_id is the plugin name for Kong or the template ID for Apigee.",
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to add one or more existing platform users to an Anypoint Team. Write operation (idempotent — re-adding a member is a no-op). `user_ids` are platform user IDs, NOT emails — resolve emails to IDs with `find_user_by_email` first. `membership_type` is 'member' (default) or 'maintainer' and applies to every user in the call. Returns a per-user outcome so a partial failure reports which ids succeeded. Use for prompts like 'add these users to the Payments team', 'make user X a maintainer of team Y'. Example: add_members_to_team(team_id=<team_id>, user_ids=[<user_id>]).",
+          "inputSchema": {
+            "properties": {
+              "membership_type": {
+                "default": "member",
+                "description": "Role in the team for every added user: 'member' (default) or 'maintainer'.",
+                "title": "Membership Type",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID owning the team. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              },
+              "team_id": {
+                "default": "",
+                "description": "team_id of the team to add members to.",
+                "title": "Team Id",
+                "type": "string"
+              },
+              "user_ids": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Platform user IDs (NOT emails) to add; 1-100 per call. Resolve emails to IDs with find_user_by_email first.",
+                "title": "User Ids"
+              }
+            },
+            "title": "add_members_to_teamArguments",
+            "type": "object"
+          },
+          "name": "add_members_to_team",
+          "title": "Add Members to Team"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Server-side rollup that absorbs the agent→model loop. Picks the top-N agents by request volume (``fetch_monitoring_drill_down(entity_type='agents')``), calls ``view_agent_details`` per agent (capped at ``top_n``, default 10, hard cap 20), aggregates their model configurations and returns a comparison. Use this for: 'which models are used the most across agents?', 'which models are underutilized or unused?', 'which agents use which LLM?'. Args: organization_id (required), top_n (default 10), agents (optional list of agent ids — if supplied, skips the top-N discovery and just walks these). Returns: ``{summary, agents: [{agent_id, name, model: {...}, model_id, model_provider}], model_distribution: {model_id: count}, errors: [...]}``.",
+          "inputSchema": {
+            "properties": {
+              "agents": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Agents"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "top_n": {
+                "default": 10,
+                "title": "Top N",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "organization_id"
+            ],
+            "title": "agents_with_modelsArguments",
+            "type": "object"
+          },
+          "name": "agents_with_models",
+          "title": "Sample top agents and report their model configuration"
+        },
+        {
+          "description": "Apply the selected policy to a SINGLE target asset instance using the provided configuration data. This is the tool for a provider-NATIVE policy (a Kong plugin name or an Apigee template ID, as selected via prepare_policy_creation) — those are NOT canonical templates and can only be applied one instance at a time, so loop this tool per instance if a native policy targets several. It is also the right choice for a single MuleSoft/Anypoint instance when you need fine per-instance control (order, pointcut, disabled). ONLY for a CANONICAL (Universal) policy — one returned by 'list_universal_policies' — that must be applied to MORE THAN ONE API instance at once, or across instances spanning different providers (mulesoft/anypoint, kong, apigee, azure, aws), prefer 'apply_universal_policy' instead: it fans the canonical template out across every instance in one call and creates the native policy on each provider's control plane. Do NOT route a native plugin/template id to 'apply_universal_policy' — it only accepts canonical template names. For a non-MuleSoft external gateway (provider='kong'/'apigee'/'azure'), set provider and pass the numeric api_instance_id plus the template's Exchange coordinates via asset (group_id + asset_id + asset_version, from get_policy_template_form) — the policy is applied through the Anypoint API Manager Universal API (gateway_id is not used on this path). injection_point is optional; omit it to let APIM default it from the template. This routing is gated per organization; a closed gate returns a structured error.",
           "inputSchema": {
             "$defs": {
+              "PolicyApplyAssetRef": {
+                "description": "Optional Exchange asset coordinates for a policy template.\n\nCarrying these as a single bundle keeps ``apply_policy_to_instance``\nunder the architectural parameter cap while preserving the\n``group_id`` / ``asset_id`` / ``asset_version`` triple that callers\nmust keep in sync.",
+                "properties": {
+                  "asset_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Asset Id"
+                  },
+                  "asset_version": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Asset Version"
+                  },
+                  "group_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Group Id"
+                  }
+                },
+                "title": "PolicyApplyAssetRef",
+                "type": "object"
+              },
               "PolicyConfigurationData": {
                 "additionalProperties": true,
                 "description": "Open-shape configuration object passed to API Manager when applying a policy.\n\nThe exact key set is policy-template-specific (e.g. rate-limiting uses\n``rateLimits``; OAuth2 uses ``tokenUrl``). ``extra='allow'`` preserves\ntemplate-defined keys; clients can still receive a structured JSON schema\nin the tool spec instead of an unconstrained ``dict``.",
@@ -237,32 +380,21 @@
             "properties": {
               "api_instance_id": {
                 "default": "",
+                "description": "Numeric API Manager instance ID of the target instance.",
                 "title": "Api Instance Id",
                 "type": "string"
               },
-              "asset_id": {
+              "asset": {
                 "anyOf": [
                   {
-                    "type": "string"
+                    "$ref": "#/$defs/PolicyApplyAssetRef"
                   },
                   {
                     "type": "null"
                   }
                 ],
                 "default": null,
-                "title": "Asset Id"
-              },
-              "asset_version": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Asset Version"
+                "description": "Exchange coordinates of the policy template (group_id / asset_id / asset_version) from get_policy_template_form. Required on the external-gateway Universal API path."
               },
               "configuration_data": {
                 "anyOf": [
@@ -273,7 +405,8 @@
                     "type": "null"
                   }
                 ],
-                "default": null
+                "default": null,
+                "description": "Policy configuration matching the template schema from get_policy_template_form. Validated by APIM against the template."
               },
               "disabled": {
                 "anyOf": [
@@ -285,10 +418,12 @@
                   }
                 ],
                 "default": null,
+                "description": "Apply the policy in a disabled state. Omit to apply it enabled.",
                 "title": "Disabled"
               },
               "environment_id": {
                 "default": "",
+                "description": "Anypoint environment ID. Optional on the external-gateway (Universal API) path, where api_instance_id alone identifies the instance.",
                 "title": "Environment Id",
                 "type": "string"
               },
@@ -302,9 +437,10 @@
                   }
                 ],
                 "default": null,
+                "description": "Gateway ID. Not used on the external-gateway Universal API path.",
                 "title": "Gateway Id"
               },
-              "group_id": {
+              "injection_point": {
                 "anyOf": [
                   {
                     "type": "string"
@@ -314,7 +450,8 @@
                   }
                 ],
                 "default": null,
-                "title": "Group Id"
+                "description": "Optional injection point. Omit to let APIM default it from the template.",
+                "title": "Injection Point"
               },
               "label": {
                 "anyOf": [
@@ -326,6 +463,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Optional human-readable label for the applied policy.",
                 "title": "Label"
               },
               "order": {
@@ -338,9 +476,11 @@
                   }
                 ],
                 "default": null,
+                "description": "Explicit position of the policy in the chain. Omit to let APIM assign the next order.",
                 "title": "Order"
               },
               "organization_id": {
+                "description": "Anypoint organization (business group) ID that owns the instance.",
                 "title": "Organization Id",
                 "type": "string"
               },
@@ -353,7 +493,8 @@
                     "type": "null"
                   }
                 ],
-                "default": null
+                "default": null,
+                "description": "Optional pointcut (method / URI) scoping for the policy."
               },
               "policy_template_id": {
                 "anyOf": [
@@ -365,6 +506,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Policy template ID being applied.",
                 "title": "Policy Template Id"
               },
               "provider": {
@@ -377,6 +519,7 @@
                   }
                 ],
                 "default": null,
+                "description": "External gateway provider: 'kong', 'apigee', or 'azure'. Set for a non-MuleSoft gateway to apply through the APIM Universal API. Omit for MuleSoft.",
                 "title": "Provider"
               }
             },
@@ -394,6 +537,119 @@
           },
           "name": "apply_policy_to_instance",
           "title": "Apply Policy To Asset Instance"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Apply a Universal (canonical) policy to one or more API instances across any provider in one call — each instance gets a native policy created on its own provider's control plane. This is the REQUIRED path whenever the policy targets MORE THAN ONE API instance (e.g. 'apply CORS to these 3 APIs') or the instances span different providers (mulesoft/anypoint, kong, apigee, azure, aws): pass every instance id in one call rather than looping 'apply_policy_to_instance'. No environment id is needed or accepted (non-MuleSoft instances have none). Only for a SINGLE MuleSoft/Anypoint instance that needs finer per-instance control (order, pointcut, disabled) should you prefer 'apply_policy_to_instance' instead.",
+          "inputSchema": {
+            "$defs": {
+              "PolicyConfigurationData": {
+                "additionalProperties": true,
+                "description": "Open-shape configuration object passed to API Manager when applying a policy.\n\nThe exact key set is policy-template-specific (e.g. rate-limiting uses\n``rateLimits``; OAuth2 uses ``tokenUrl``). ``extra='allow'`` preserves\ntemplate-defined keys; clients can still receive a structured JSON schema\nin the tool spec instead of an unconstrained ``dict``.",
+                "properties": {},
+                "title": "PolicyConfigurationData",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "configuration": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/PolicyConfigurationData"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Policy configuration values, keyed per the template's configuration schema."
+              },
+              "instance_ids": {
+                "description": "API instance ids to apply the policy to, across any provider (mulesoft/anypoint, kong, apigee, azure, aws). At least one required. For a single MuleSoft/Anypoint instance, prefer 'apply_policy_to_instance' instead — it targets one instance with fuller per-instance controls (order, pointcut, disabled).",
+                "items": {
+                  "type": "string"
+                },
+                "title": "Instance Ids",
+                "type": "array"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization id. Defaults to the session's current organization.",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "policy_name": {
+                "description": "Kebab-case canonical policy template name to apply, e.g. 'rate-limiting'.",
+                "title": "Policy Name",
+                "type": "string"
+              }
+            },
+            "required": [
+              "policy_name",
+              "instance_ids"
+            ],
+            "title": "apply_universal_policyArguments",
+            "type": "object"
+          },
+          "name": "apply_universal_policy",
+          "title": "Apply Universal Policy"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Fetch applied + automated policies for up to N instances of a given API in one call, aggregate them, and return a per-instance + cross-instance summary. Replaces the agent-driven pattern of looping ``view_api_instance_policies`` per instance — that loop burst the rate-limited Anypoint policy endpoint into 502s (W-22750961 #34, 18 calls all failed). Sampling order: production env first, then sandbox, then design, then any remaining environments. Stops sampling on the first 5xx and reports what it captured. Use this for: 'what gaps exist in policy coverage across instances?', 'compare policy coverage between production and staging', 'which instances are missing rate limiting?', 'audit policies for this API'. Args: organization_id (active BG), asset_id (the API's asset id), max_instances (default 3, max 8). Returns: ``{summary, instances: [{instance_id, environment_name, policy_count, applied: [...], automated: [...]}], comparison: {policy_names_in_all, policy_names_missing_anywhere}, errors: [{instance_id, error}]}``. Example: audit_api_policies(organization_id=<bg>, asset_id=<api>).",
+          "inputSchema": {
+            "properties": {
+              "asset_id": {
+                "title": "Asset Id",
+                "type": "string"
+              },
+              "instances": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Instances"
+              },
+              "max_instances": {
+                "default": 3,
+                "title": "Max Instances",
+                "type": "integer"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "asset_id"
+            ],
+            "title": "audit_api_policiesArguments",
+            "type": "object"
+          },
+          "name": "audit_api_policies",
+          "title": "Audit API policies across instances"
         },
         {
           "annotations": {
@@ -591,6 +847,155 @@
         {
           "annotations": {
             "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Verify whether a SINGLE named secret exists and return its non-sensitive metadata (name, type, expiration, last-modified) — never the secret value. USE THIS for 'does secret X exist?'. Provide secret_name alone and it reports which group(s) the secret lives in; add secret_group_name ONLY when the user explicitly names a group; or pass secret_group_id + secret_id UUIDs. A secret name may contain '/' (e.g. 'byov-test/api-key') — pass it whole as secret_name; never split it into group/secret on a slash. Use list_secret_refs to enumerate everything, or search_secrets for partial-name matches across groups.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "secret_group_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "UUID of the secret group. Use secret_group_name instead when chaining from list_secret_refs output.",
+                "title": "Secret Group Id"
+              },
+              "secret_group_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "OPTIONAL human-readable name of the secret group (as returned by list_secret_refs in 'secretGroupName'). Add it ONLY when the user explicitly names a group; omit it to search every group for secret_name. Do NOT derive a group by splitting a secret name on '/' — secret names can contain slashes (see secret_name).",
+                "title": "Secret Group Name"
+              },
+              "secret_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "UUID of the secret. Use secret_name instead when chaining from list_secret_refs output.",
+                "title": "Secret Id"
+              },
+              "secret_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the secret to check (as returned by list_secret_refs in 'name'). This is the primary input — provide it alone to find which group(s) the secret lives in, or with secret_group_name to check one specific group. IMPORTANT: a secret name MAY CONTAIN '/' (e.g. 'byov-test/api-key'). Pass the whole name here verbatim — never split it into secret_group_name + secret_name on a slash.",
+                "title": "Secret Name"
+              }
+            },
+            "title": "check_secretArguments",
+            "type": "object"
+          },
+          "name": "check_secret",
+          "title": "Check One Secret Exists"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Run ``find_assets`` (facets mode) against each of the supplied business-group ids and return a side-by-side comparison (totalHits + byType breakdown per BG). Use this for 'compare service maturity between business units', 'which BG has the most APIs?', 'breakdown by BG'. The agent should call ``list_business_groups`` first to discover the ids; this tool fans out at most ``max_groups`` (default 3, hard cap 8) of them. Returns: ``{groups: [{business_group_id, total_hits, byType: {...}}], cross_group: {leader_by_total, type_distribution_diff}}``. Example: compare_business_groups(business_group_ids=['<bg1>', '<bg2>', '<bg3>']).",
+          "inputSchema": {
+            "properties": {
+              "business_group_ids": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "title": "Business Group Ids"
+              },
+              "max_groups": {
+                "default": 3,
+                "title": "Max Groups",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "business_group_ids"
+            ],
+            "title": "compare_business_groupsArguments",
+            "type": "object"
+          },
+          "name": "compare_business_groups",
+          "title": "Compare service breakdown across business groups"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
             "idempotentHint": false,
             "openWorldHint": true,
             "readOnlyHint": false,
@@ -753,6 +1158,80 @@
         },
         {
           "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to create a new Anypoint **business group** (a sub-organization) under a parent. Write operation. Creates a CHILD of `parent_organization_id` (the session org by default) — the org's true root is the pre-existing master org, which this does not create. The new business group has NO resource quota (zero vCores etc.); grant quota and permissions in the Anypoint UI afterward. The owner is always the authenticated caller (not selectable). Use for prompts like 'create a business group called Payments', 'add a child org under X'. Example: create_business_group(name=Payments).",
+          "inputSchema": {
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name for the new business group.",
+                "title": "Name",
+                "type": "string"
+              },
+              "parent_organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Parent business-group ID under which to create the new child business group. Resolves from the active session when omitted (creates a child of the current org).",
+                "title": "Parent Organization Id"
+              }
+            },
+            "title": "create_business_groupArguments",
+            "type": "object"
+          },
+          "name": "create_business_group",
+          "title": "Create Business Group"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to create an Anypoint **connected app** with a client_credentials grant — a machine / CI-CD credential that mints Anypoint access tokens from a client id + client secret. Write operation. For security the generated **client secret is NOT returned** (it would land in the transcript); the result gives the client id and a deep link to the Connected Apps page where the owner copies the secret and assigns scopes. The app is created UNSCOPED — grant business-group / environment access there (or via a follow-up tool) before it can be used. Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'create a connected app for our CI pipeline', 'set up a machine credential to deploy from GitHub Actions'. Example: create_connected_app(name=CI/CD deploy).",
+          "inputSchema": {
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Display name for the new connected app (e.g. 'CI/CD deploy'). Used to locate it afterward on the Connected Apps page.",
+                "title": "Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID to create the connected app in. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "create_connected_appArguments",
+            "type": "object"
+          },
+          "name": "create_connected_app",
+          "title": "Create Connected App"
+        },
+        {
+          "annotations": {
             "destructiveHint": null,
             "idempotentHint": false,
             "openWorldHint": true,
@@ -907,6 +1386,590 @@
           },
           "name": "create_control",
           "title": "Create Control"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to create a new Anypoint **environment** (sandbox or production) in a business group. Write operation. `environment_type` must be 'sandbox' or 'production'. Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'create a sandbox environment called QA', 'add a production environment to org X'. Example: create_environment(name=QA, environment_type=sandbox).",
+          "inputSchema": {
+            "properties": {
+              "environment_type": {
+                "default": "sandbox",
+                "description": "Environment type: 'sandbox' or 'production'.",
+                "title": "Environment Type",
+                "type": "string"
+              },
+              "name": {
+                "default": "",
+                "description": "Name for the new environment (alphanumeric, 2-65 characters).",
+                "title": "Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization / business-group ID to create the environment in. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "create_environmentArguments",
+            "type": "object"
+          },
+          "name": "create_environment",
+          "title": "Create Environment"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Create and deploy a Model Proxy (LLM proxy) in Anypoint: creates the Exchange asset then deploys via API Manager. This is the chat equivalent of the two-step 'Create a Model Proxy' wizard, and the fields map 1:1 onto it.\nStep 1 'Configure Gateway' — where the proxy is hosted: name (required), base_path (required), port (required, default 8081), and target_id (required). Copy target_id from the exact `id` field of a deployable row returned by `list_model_proxy_gateway_targets`. A gateway target name is never a valid target_id; when only the name is known, call that lookup, match the row by name, and pass its `id`. The server reads that row's authoritative name and inserts targetName into the deployment payload. description is optional. Resolve environment_id with `list_omni_gateway_environments`, then the gateway target with `list_model_proxy_gateway_targets` — do not ask the user for raw IDs, and do not source the target from `list_omni_gateway_targets` (different service, ids the deploy call rejects).\nStep 2 'Configure Routing Strategy' — where traffic goes. Two modes, matching the wizard. routing_strategy is required: the user must explicitly choose `model-based` or `semantic` after Step 1; never omit, default, or infer this field. `model-based` needs one or more typed `routes` entries with provider + model + upstream_url + that provider's wizard extras (`authFields` / `configFields` from `list_model_proxy_providers`). Call `list_model_proxy_providers` first (omit `provider`) and pick provider/`model` from that wizard catalog (bare `models[].value`). `semantic` needs a `semantic_service_config_id` from `list_model_proxy_semantic_routing` and that row's topicMode. advanced / select: each route's `prompt_topic_ids` from that service's topics. basic / create: each route's `prompt_topic` `{name, utterances}` (created on the fly, same POST as the UI modal) — an empty topics list is not a blocker. Also collect the rest of that wizard step from `wizardFields`: fallback card (`fallback_threshold` default 0.5, `fallback_route`, `fallback_model`), prompt guard (`deny_topic_ids_json` or `deny_topics_json` `{name, utterances}`), and optional semantic cache (`semantic_cache_config_id`). Optional: input_format.\nThe Omni Gateway target is NOT an LLM provider or upstream URL — upstreams belong in `routes`. For every new route, first ask the user to choose Dynamic or From Vault; set `credential_source` to `dataweave` or `from_vault` from that explicit choice. Dynamic uses `api_key_selector`, or both AWS selector fields for Bedrock. From Vault requires `list_model_proxy_vault_secret_groups` then `list_model_proxy_vault_secrets`; show names, retain ids internally, and put the selected ids in the matching typed `*_vault_ref` field. Never construct or accept a URN. The backend constructs key_mode, selectors, and vault keys. Literal API/AWS keys are rejected. There are no tag or runtime-constraint fields; do not ask for any field not listed here.\nNever construct a route from this description, provider defaults, lookup output, prior proxies, or reasonable guesses. A lookup result only supplies choices; it does not authorize choosing one. The gateway target, routing strategy, and every route's provider, model, upstream URL, credential source and source-specific fields, and optional settings must be explicitly confirmed by the user. If any required choice is missing, ask for it and do not call create_model_proxy.",
+          "inputSchema": {
+            "$defs": {
+              "LlmProxyCreateRouteInput": {
+                "additionalProperties": false,
+                "description": "One create-time route, using Dynamic or From Vault credentials.",
+                "properties": {
+                  "api_key_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "DataWeave expression locating the API key in the inbound request, for example #[attributes.headers['X-API-KEY']]. Required for a new non-Bedrock route; an existing update route may omit it when upstream_ids are preserved.",
+                    "title": "Api Key Selector"
+                  },
+                  "api_key_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "OpenAI/Gemini/Azure/NVIDIA/Anthropic only: selected API-key secret from the Model Proxy vault lookup tools"
+                  },
+                  "api_version": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Azure OpenAI API version (optional in the wizard)",
+                    "title": "Api Version"
+                  },
+                  "aws_access_key_id_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: DataWeave expression locating the AWS access key id; required with the secret selector on a new route",
+                    "title": "Aws Access Key Id Selector"
+                  },
+                  "aws_access_key_id_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: selected AWS access-key-id secret"
+                  },
+                  "aws_region": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock AWS region; defaults to us-east-1",
+                    "title": "Aws Region"
+                  },
+                  "aws_secret_access_key_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: DataWeave expression locating the AWS secret access key; required with the access-key selector on a new route",
+                    "title": "Aws Secret Access Key Selector"
+                  },
+                  "aws_secret_access_key_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: selected AWS secret-access-key secret"
+                  },
+                  "aws_session_token_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: optional selected AWS session-token secret"
+                  },
+                  "credential_source": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "dataweave",
+                          "from_vault"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Required for a new route: dataweave or from_vault. Existing update routes may omit it when upstream_ids are preserved. Never use static keys.",
+                    "title": "Credential Source"
+                  },
+                  "deployment_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Azure OpenAI deployment id (optional in the wizard)",
+                    "title": "Deployment Id"
+                  },
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Optional route label; defaults positionally to Route A, Route B, and so on",
+                    "title": "Label"
+                  },
+                  "model": {
+                    "description": "Bare model value returned for that provider; never a catalog UUID",
+                    "minLength": 1,
+                    "title": "Model",
+                    "type": "string"
+                  },
+                  "prompt_topic": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/PromptTopicInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Basic semantic service: topic to create and assign to this route"
+                  },
+                  "prompt_topic_ids": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Advanced semantic service: existing topic ids assigned to this route",
+                    "title": "Prompt Topic Ids"
+                  },
+                  "provider": {
+                    "description": "Provider id returned by list_model_proxy_providers",
+                    "enum": [
+                      "openai",
+                      "gemini",
+                      "azure",
+                      "bedrock",
+                      "nvidia",
+                      "anthropic"
+                    ],
+                    "title": "Provider",
+                    "type": "string"
+                  },
+                  "rule_headers": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Optional request-routing headers; never put credentials here",
+                    "title": "Rule Headers"
+                  },
+                  "upstream_url": {
+                    "description": "Destination URL; use the provider's defaultUrl unless the wizard requires one",
+                    "minLength": 1,
+                    "title": "Upstream Url",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "provider",
+                  "model",
+                  "upstream_url"
+                ],
+                "title": "LlmProxyCreateRouteInput",
+                "type": "object"
+              },
+              "PromptTopicInput": {
+                "additionalProperties": false,
+                "description": "Inline topic authored by the basic semantic-routing wizard.",
+                "properties": {
+                  "name": {
+                    "description": "Prompt-topic display name",
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "utterances": {
+                    "description": "Representative prompts, separated by newlines",
+                    "minLength": 1,
+                    "title": "Utterances",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "utterances"
+                ],
+                "title": "PromptTopicInput",
+                "type": "object"
+              },
+              "VaultSecretRefInput": {
+                "additionalProperties": false,
+                "description": "Opaque CSM selection returned by the Model Proxy vault lookup tools.",
+                "properties": {
+                  "secret_group_id": {
+                    "description": "Internal group id copied from list_model_proxy_vault_secret_groups; never ask the user to type it",
+                    "title": "Secret Group Id",
+                    "type": "string"
+                  },
+                  "secret_id": {
+                    "description": "Internal secret id copied from list_model_proxy_vault_secrets; never ask the user to type it",
+                    "title": "Secret Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secret_group_id",
+                  "secret_id"
+                ],
+                "title": "VaultSecretRefInput",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "base_path": {
+                "description": "Gateway base path, e.g. /my-proxy",
+                "title": "Base Path",
+                "type": "string"
+              },
+              "deny_topic_ids_json": {
+                "default": "",
+                "description": "Optional JSON array or comma list of prompt-guard topic ids (wizard Advanced options deny list). Advanced services: pick unused catalog ids from list_model_proxy_semantic_routing denyTopics.",
+                "title": "Deny Topic Ids Json",
+                "type": "string"
+              },
+              "deny_topics_json": {
+                "default": "",
+                "description": "Optional JSON array of {name, utterances} prompt-guard topics to create on save (wizard prompt-guard modal, usedForDenyList). Use on basic semantic services the same way as prompt_topic.",
+                "title": "Deny Topics Json",
+                "type": "string"
+              },
+              "description": {
+                "default": "",
+                "description": "Optional proxy description",
+                "title": "Description",
+                "type": "string"
+              },
+              "environment_id": {
+                "description": "Anypoint environment ID",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "fallback_model": {
+                "default": "",
+                "description": "Optional fallback model",
+                "title": "Fallback Model",
+                "type": "string"
+              },
+              "fallback_route": {
+                "default": "",
+                "description": "Optional. Must equal one route's exact `label` from the route list — or, if that route left `label` unset, the positional default 'Route A' / 'Route B' / 'Route C' (by index). NOT a provider name or semantic topic name — the gateway resolves this against route labels, not providers or topics.",
+                "title": "Fallback Route",
+                "type": "string"
+              },
+              "fallback_threshold": {
+                "default": -1.0,
+                "description": "Optional semantic fallback threshold; use -1 to omit",
+                "title": "Fallback Threshold",
+                "type": "number"
+              },
+              "input_format": {
+                "default": "openai",
+                "description": "openai | anthropic | gemini (default openai)",
+                "title": "Input Format",
+                "type": "string"
+              },
+              "name": {
+                "description": "Display name; slugified to Exchange assetId",
+                "title": "Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "port": {
+                "default": 8081,
+                "description": "Gateway listener port; default 8081",
+                "title": "Port",
+                "type": "integer"
+              },
+              "routes": {
+                "description": "Typed route fields matching the wizard. Set credential_source to dataweave and supply the provider selector field(s), or set it to from_vault and supply selections returned by the Model Proxy vault lookup tools. The server constructs the wire credential shape; literal API keys and caller-built URNs are rejected.",
+                "items": {
+                  "$ref": "#/$defs/LlmProxyCreateRouteInput"
+                },
+                "maxItems": 50,
+                "minItems": 1,
+                "title": "Routes",
+                "type": "array"
+              },
+              "routing_strategy": {
+                "description": "Required explicit routing choice: model-based or semantic. Do not omit or infer it; ask the user to choose after Step 1.",
+                "title": "Routing Strategy",
+                "type": "string"
+              },
+              "semantic_cache_config_id": {
+                "default": "",
+                "description": "Optional semantic cache config ID",
+                "title": "Semantic Cache Config Id",
+                "type": "string"
+              },
+              "semantic_service_config_id": {
+                "default": "",
+                "description": "Required when routing_strategy=semantic: a service `id` from `list_model_proxy_semantic_routing`. Use that row's topicMode: select = prompt_topic_ids; create = prompt_topic {name, utterances} on each route. Leave empty for model-based.",
+                "title": "Semantic Service Config Id",
+                "type": "string"
+              },
+              "target_id": {
+                "description": "Gateway target ID that will host this proxy — NOT an LLM provider or upstream URL. Copy the exact `id` field from a deployable row returned by `list_model_proxy_gateway_targets`. A gateway target name is never a valid target_id; if only its name is known, call that lookup, match the row by name, and pass the row's `id`. Never ask the user to paste an ID, never invent one, and never take it from `list_omni_gateway_targets` (different Anypoint service, ids this deploy call rejects).",
+                "title": "Target Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "environment_id",
+              "name",
+              "base_path",
+              "target_id",
+              "routes",
+              "routing_strategy"
+            ],
+            "title": "create_model_proxyArguments",
+            "type": "object"
+          },
+          "name": "create_model_proxy",
+          "title": "Create Model Proxy"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Create a Model Wallet in an Anypoint organization + environment. A Model Wallet scopes a caller (required_claims) to LLM Proxies and carries token/spend budgets. The wallet is scoped to ALL proxies automatically (there is no proxy picker yet), so proxy scope is not a parameter. environment_id is OPTIONAL: omit it to auto-select the environment the create UI would use (a production environment if the org has one, else the first available; design-time environments are ignored), so you need not know the env id. Pass an explicit environment_id only to override that default. required_claims is REQUIRED and must contain at least one 'claim:value' string using a COLON separator (NOT '='), e.g. 'group:managers' or 'iss:https://login.example.com'; each claim must include a value (the upstream rejects a claim with no value). budgets is REQUIRED — a wallet with no budget is unbounded and will be rejected; provide at least one budget, each with provider, metric (spend|tokens), period (daily|weekly|monthly), and limit. model is OPTIONAL: omit it for a provider-wide ('Any model') budget that caps every model under the provider (the usual case for a token budget), or pass a bare model id (e.g. 'claude-fable-5', no provider prefix) to cap one model. A 'spend' budget is only allowed with a concrete model that has a price configured in the Models catalog (an 'Any model' spend cap isn't priceable) — for an all-models cap use metric='tokens'. Example (provider-wide token cap, env auto-selected): create_model_wallet(organization_id=<org_id>, name='Team A', required_claims=['group:managers'], budgets=[{'provider':'anthropic','metric':'tokens','period':'monthly','limit':100000}]). Add 'model':'claude-fable-5' to that budget to cap a single model instead.",
+          "inputSchema": {
+            "$defs": {
+              "BudgetInput": {
+                "description": "One budget line for a wallet, in the FE domain vocabulary.\n\nMirrors the FE ``Budget`` shape (``services/model-wallets.ts``); the write\nbuilder translates it to the v2 wire limit (``resource``/``timeWindow``/\ncolon-joined ``provider:modelId``). ``model`` is OPTIONAL: a budget with no\nmodel is a valid provider-wide (\"Any model\") cap, exactly as the FE\n``Budget`` allows. Omitting it emits a limit with no ``modelId``.",
+                "properties": {
+                  "limit": {
+                    "description": "The cap value in the chosen metric.",
+                    "title": "Limit",
+                    "type": "number"
+                  },
+                  "metric": {
+                    "description": "Cap unit: 'spend' (dollars) or 'tokens'.",
+                    "enum": [
+                      "spend",
+                      "tokens"
+                    ],
+                    "title": "Metric",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bare model id, e.g. 'claude-fable-5' (no provider prefix). Omit for a provider-wide ('Any model') budget that caps every model under the provider.",
+                    "title": "Model"
+                  },
+                  "period": {
+                    "description": "Reset window.",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly"
+                    ],
+                    "title": "Period",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "Model provider, e.g. 'anthropic'.",
+                    "title": "Provider",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "provider",
+                  "metric",
+                  "period",
+                  "limit"
+                ],
+                "title": "BudgetInput",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "budgets": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "$ref": "#/$defs/BudgetInput"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Budgets"
+              },
+              "description": {
+                "default": "",
+                "title": "Description",
+                "type": "string"
+              },
+              "environment_id": {
+                "default": "",
+                "description": "Anypoint environment ID to create the wallet in. OPTIONAL — omit it (or pass an empty string) to auto-select the environment the create UI would use: a production environment if the organization has one, otherwise the first available (design-time environments are ignored). Pass an explicit id only to override that default.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "name": {
+                "title": "Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "required_claims": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Required Claims"
+              }
+            },
+            "required": [
+              "organization_id",
+              "name"
+            ],
+            "title": "create_model_walletArguments",
+            "type": "object"
+          },
+          "name": "create_model_wallet",
+          "title": "Create Model Wallet"
         },
         {
           "annotations": {
@@ -1257,10 +2320,10 @@
             "destructiveHint": null,
             "idempotentHint": false,
             "openWorldHint": true,
-            "readOnlyHint": true,
+            "readOnlyHint": false,
             "title": null
           },
-          "description": "Launch the scanner creation wizard to configure and create a new agent scanner. The wizard will guide you through provider selection, authentication, and configuration. On success, returns the created scanner details including scannerId. Pass organization_id when calling this tool. Call WITHOUT name/provider to display the interactive wizard.",
+          "description": "Create a new agent scanner. Internally validates connectivity before persisting the configuration. Parameters: provider (targetSystemType), platform (specific platform within a provider group, e.g. 'bedrock-agents'), schedule with unit (day/week/month) and at (0-23 UTC hour). Returns the created scanner details including scannerId on success, or a connection_failed status if credentials are invalid. Call WITHOUT name/provider to display the interactive wizard.",
           "inputSchema": {
             "$defs": {
               "ScannerAuthFields": {
@@ -1314,72 +2377,34 @@
                 "title": "ScannerNotifications",
                 "type": "object"
               },
-              "ScannerSchedule": {
-                "additionalProperties": true,
-                "description": "Scanner run schedule built by the wizard UI (``app.js``).\n\nMatches the legacy Anypoint scanner schedule JSON: ``{interval, unit,\nat, on, syncReview}``. All values are strings because the upstream API\npersists them as strings.",
+              "ScannerScheduleInput": {
+                "additionalProperties": false,
+                "description": "Strict wizard schedule input — only day/week/month with validated hour.",
                 "properties": {
                   "at": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "At"
-                  },
-                  "interval": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Interval"
-                  },
-                  "on": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "On"
+                    "default": "7",
+                    "title": "At",
+                    "type": "string"
                   },
                   "syncReview": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ],
-                    "default": null,
-                    "title": "Syncreview"
+                    "default": "ask-for-review",
+                    "title": "Syncreview",
+                    "type": "string"
                   },
                   "unit": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "enum": [
+                      "day",
+                      "week",
+                      "month"
                     ],
-                    "default": null,
-                    "title": "Unit"
+                    "title": "Unit",
+                    "type": "string"
                   }
                 },
-                "title": "ScannerSchedule",
+                "required": [
+                  "unit"
+                ],
+                "title": "ScannerScheduleInput",
                 "type": "object"
               }
             },
@@ -1497,6 +2522,18 @@
                 "default": null,
                 "title": "Owner Id"
               },
+              "platform": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Platform"
+              },
               "provider": {
                 "anyOf": [
                   {
@@ -1512,7 +2549,7 @@
               "schedule": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/ScannerSchedule"
+                    "$ref": "#/$defs/ScannerScheduleInput"
                   },
                   {
                     "type": "null"
@@ -1532,6 +2569,55 @@
           },
           "name": "create_scanner",
           "title": "Create Agent Scanner"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to create a new Anypoint **Team** (the platform identity construct — NOT the Microsoft Teams messaging channel). Write operation. `parent_team_id` is REQUIRED: to create a top-level team, first call `list_teams` to find the root team (the one with no parent) and pass its `team_id`. `team_type` is 'internal' (default), 'external', 'private', 'shared', or 'legacy'. Use for prompts like 'create a team called Payments under the root team', 'add a private team X'. Example: create_team(team_name=Payments, parent_team_id=<root_team_id>).",
+          "inputSchema": {
+            "properties": {
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID to create the team in. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              },
+              "parent_team_id": {
+                "default": "",
+                "description": "team_id of the parent team. REQUIRED — the API has no root default. To create a top-level team, first call list_teams and pass the root team's id (the team with no parent).",
+                "title": "Parent Team Id",
+                "type": "string"
+              },
+              "team_name": {
+                "default": "",
+                "description": "Name for the new team (unique within the organization).",
+                "title": "Team Name",
+                "type": "string"
+              },
+              "team_type": {
+                "default": "internal",
+                "description": "Team type: 'internal' (default), 'external', 'private', 'shared', or 'legacy'.",
+                "title": "Team Type",
+                "type": "string"
+              }
+            },
+            "title": "create_teamArguments",
+            "type": "object"
+          },
+          "name": "create_team",
+          "title": "Create Team"
         },
         {
           "annotations": {
@@ -1621,6 +2707,536 @@
         },
         {
           "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Delete one Model Wallet by id in an Anypoint organization + environment. Destructive and irreversible. version is REQUIRED: read the wallet's current version with fetch_model_wallet_details and pass it — it is sent as the upstream optimistic-concurrency If-Match header, and a missing version is rejected (there is no force-delete path). environment_id is OPTIONAL: omit it to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). When acting on a wallet from fetch_model_wallets, pass that wallet's environmentId — a wallet can live in ANY environment, and auto-select resolves only one, so a delete could target the wrong environment or not find the wallet. Example (env from the fetch_model_wallets row): delete_model_wallet(organization_id=<org_id>, model_wallet_id=<id>, environment_id=<env_id>, version=<n>).",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "default": "",
+                "description": "Anypoint environment ID the wallet lives in. OPTIONAL — omit it to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). Pass an explicit id only to override that default.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "model_wallet_id": {
+                "title": "Model Wallet Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Version"
+              }
+            },
+            "required": [
+              "organization_id",
+              "model_wallet_id"
+            ],
+            "title": "delete_model_walletArguments",
+            "type": "object"
+          },
+          "name": "delete_model_wallet",
+          "title": "Delete Model Wallet"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Answer 'what do I need to connect/onboard this vault?' in up to three steps. (1) No arguments: list every supported provider. (2) provider ONLY (e.g. 'azure_key_vault'): list the auth methods that provider supports so the user can choose one — use this for 'create an azure vault integration' before asking for any fields. (3) provider + auth_method: get the COMPLETE onboarding checklist — always-required inputs (name, provider, auth_method, vault_url), required/optional raw_secrets and connection_config fields, and optional inputs (description, sync_interval_minutes). Common provider phrasings are accepted (e.g. 'aws', 'aws secret manager'). Use before onboard_vault so you know exactly what to collect, and before edit_integration to see valid attributes.",
+          "inputSchema": {
+            "properties": {
+              "auth_method": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Authentication method to describe (e.g. 'azure_sp_secret'). Pair with provider to get that combination's full onboarding checklist. Omit it (giving only provider) to first list the provider's available auth methods.",
+                "title": "Auth Method"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Vault provider to describe ('aws_secrets_manager', 'azure_key_vault', 'hashicorp_vault'; common phrasings like 'aws' or 'azure' are normalized). Provide provider ALONE (no auth_method) to list the authentication methods that provider supports so the user can choose one. Omit both to list every provider.",
+                "title": "Provider"
+              }
+            },
+            "title": "describe_vault_auth_schemaArguments",
+            "type": "object"
+          },
+          "name": "describe_vault_auth_schema",
+          "title": "Describe Vault Onboarding Requirements"
+        },
+        {
+          "description": "Edit the configuration of an already-applied native policy on an external gateway instance (Kong / Apigee / Azure) via the Anypoint API Manager Universal API. The numeric api_instance_id identifies the instance on this path (no environment_id or gateway_id is needed). Pass provider, api_instance_id, the policy_id and the policy's Exchange coordinates (asset: group_id / asset_id / asset_version) from view_api_instance_policies, plus the new configuration_data. configuration_data REPLACES the existing configuration wholesale — send the full merged object, not a delta: read the current configurationData from view_api_instance_policies immediately before and merge your change into it, or the keys you omit are dropped. A policy whose readOnly flag is true cannot be edited. Writes are asynchronous (accepted with HTTP 202); poll list_instance_policy_operations for the terminal COMPLETED / FAILED state. This routing is gated per organization; a closed gate returns a structured error.",
+          "inputSchema": {
+            "$defs": {
+              "PolicyApplyAssetRef": {
+                "description": "Optional Exchange asset coordinates for a policy template.\n\nCarrying these as a single bundle keeps ``apply_policy_to_instance``\nunder the architectural parameter cap while preserving the\n``group_id`` / ``asset_id`` / ``asset_version`` triple that callers\nmust keep in sync.",
+                "properties": {
+                  "asset_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Asset Id"
+                  },
+                  "asset_version": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Asset Version"
+                  },
+                  "group_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Group Id"
+                  }
+                },
+                "title": "PolicyApplyAssetRef",
+                "type": "object"
+              },
+              "PolicyConfigurationData": {
+                "additionalProperties": true,
+                "description": "Open-shape configuration object passed to API Manager when applying a policy.\n\nThe exact key set is policy-template-specific (e.g. rate-limiting uses\n``rateLimits``; OAuth2 uses ``tokenUrl``). ``extra='allow'`` preserves\ntemplate-defined keys; clients can still receive a structured JSON schema\nin the tool spec instead of an unconstrained ``dict``.",
+                "properties": {},
+                "title": "PolicyConfigurationData",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "api_instance_id": {
+                "default": "",
+                "description": "Numeric API Manager instance ID of the external gateway instance.",
+                "title": "Api Instance Id",
+                "type": "string"
+              },
+              "asset": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/PolicyApplyAssetRef"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Exchange coordinates of the applied policy template (group_id / asset_id / asset_version). Required for edits."
+              },
+              "configuration_data": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/PolicyConfigurationData"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "New configuration for the policy. Replaces the existing configuration; validated by APIM against the template's schema."
+              },
+              "organization_id": {
+                "description": "Anypoint organization (business group) ID that owns the instance.",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "policy_id": {
+                "default": "",
+                "description": "ID of the applied policy to edit (the policyId from view_api_instance_policies).",
+                "title": "Policy Id",
+                "type": "string"
+              },
+              "provider": {
+                "default": "",
+                "description": "External gateway provider: 'kong', 'apigee', or 'azure'. Required — this tool edits native provider policies through the APIM Universal API.",
+                "title": "Provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id"
+            ],
+            "title": "edit_applied_policyArguments",
+            "type": "object"
+          },
+          "name": "edit_applied_policy",
+          "title": "Edit Applied Policy"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Modify an existing vault integration's configuration. The current optimistic-lock version is read automatically by describing the integration first (callers do NOT supply a version). Provider, auth method, name and vault URL are immutable. For managed integrations the editable attributes are description, raw_secrets and connection_config; for reference-based integrations they are description, sync_enabled and credential_refs. Supplying an attribute that is not valid for the integration type is rejected with the list of valid attributes. Edited managed credentials are validated against the auth schema and connection-tested before saving; the save is ABORTED unless the vault is reachable AND the credential grants all required permissions (list, describe, get-value). If a reachable vault is missing permissions the edit is refused and 'missingPermissions' in the response says which to grant.",
+          "inputSchema": {
+            "properties": {
+              "connection_config": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Non-secret connection configuration, keyed by the auth schema's config-field key (e.g. 'azure.spSecret.clientId', 'azure.spSecret.tenantId'). Provide the required config fields for the chosen provider/auth_method.",
+                "title": "Connection Config"
+              },
+              "credential_refs": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "ADVANCED — most callers should use raw_secrets instead. Credential references for the REFERENCE-based flow (pointers to secrets already stored in Anypoint, NOT raw values): an object with 'secretRefs' (map of field key -> {secretGroupId, secretId, secretType}) and optional 'connectionConfig'. onboard_vault does NOT accept this — it is only for editing or connectivity-testing an existing reference-based integration. Do NOT combine with raw_secrets.",
+                "title": "Credential Refs"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Optional human-readable description (max 512 chars).",
+                "title": "Description"
+              },
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "integration_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "UUID of the vault integration. Use integration_name instead when you only know the display name.",
+                "title": "Integration Id"
+              },
+              "integration_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the vault integration (as shown by onboard_vault). Provide this OR integration_id — not both.",
+                "title": "Integration Name"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "raw_secrets": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "DEFAULT / RECOMMENDED way to supply credentials: the raw secret credential VALUES for the managed flow, keyed by the auth schema's secret-field key (the field 'key' from describe_vault_auth_schema, e.g. 'azure.spSecret.clientSecret'). This is the credential input for onboarding a vault. Never echoed back. Provide exactly the required secret fields for the chosen provider/auth_method. Do NOT also send credential_refs — they are two different, mutually-exclusive flows.",
+                "title": "Raw Secrets"
+              },
+              "sync_enabled": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Enable/disable automatic sync (reference-based integrations only); omit to leave unchanged.",
+                "title": "Sync Enabled"
+              }
+            },
+            "title": "edit_integrationArguments",
+            "type": "object"
+          },
+          "name": "edit_integration",
+          "title": "Edit Vault Integration"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Edit an existing Model Wallet by id in an Anypoint organization + environment. Partial update: pass only the fields to change — an omitted field is left as-is upstream (a rename can send just name). required_claims are flat 'claim' or 'claim:value' strings; each budget needs provider, metric (spend|tokens), period (daily|weekly|monthly), and limit. model is OPTIONAL: omit it for a provider-wide ('Any model') budget that caps every model under the provider (the usual case for a token budget), or pass a bare model id (e.g. 'claude-fable-5', no provider prefix) to cap one model. A 'spend' budget requires a concrete model that has a price configured in the Models catalog (an 'Any model' spend cap isn't priceable) — for an all-models cap use metric='tokens'. version is REQUIRED: read the wallet's current version with fetch_model_wallet_details and pass it — it is sent as the upstream optimistic-concurrency If-Match header, and a missing version is rejected so an edit can't clobber a concurrent change. environment_id is OPTIONAL: omit it to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). When acting on a wallet from fetch_model_wallets, pass that wallet's environmentId — a wallet can live in ANY environment, and auto-select resolves only one, so an edit could target the wrong environment or not find the wallet. Example (env from the fetch_model_wallets row): edit_model_wallet(organization_id=<org_id>, model_wallet_id=<id>, environment_id=<env_id>, version=<n>, name='Renamed').",
+          "inputSchema": {
+            "$defs": {
+              "BudgetInput": {
+                "description": "One budget line for a wallet, in the FE domain vocabulary.\n\nMirrors the FE ``Budget`` shape (``services/model-wallets.ts``); the write\nbuilder translates it to the v2 wire limit (``resource``/``timeWindow``/\ncolon-joined ``provider:modelId``). ``model`` is OPTIONAL: a budget with no\nmodel is a valid provider-wide (\"Any model\") cap, exactly as the FE\n``Budget`` allows. Omitting it emits a limit with no ``modelId``.",
+                "properties": {
+                  "limit": {
+                    "description": "The cap value in the chosen metric.",
+                    "title": "Limit",
+                    "type": "number"
+                  },
+                  "metric": {
+                    "description": "Cap unit: 'spend' (dollars) or 'tokens'.",
+                    "enum": [
+                      "spend",
+                      "tokens"
+                    ],
+                    "title": "Metric",
+                    "type": "string"
+                  },
+                  "model": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bare model id, e.g. 'claude-fable-5' (no provider prefix). Omit for a provider-wide ('Any model') budget that caps every model under the provider.",
+                    "title": "Model"
+                  },
+                  "period": {
+                    "description": "Reset window.",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly"
+                    ],
+                    "title": "Period",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "Model provider, e.g. 'anthropic'.",
+                    "title": "Provider",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "provider",
+                  "metric",
+                  "period",
+                  "limit"
+                ],
+                "title": "BudgetInput",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "budgets": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "$ref": "#/$defs/BudgetInput"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Budgets"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Description"
+              },
+              "environment_id": {
+                "default": "",
+                "description": "Anypoint environment ID the wallet lives in. OPTIONAL — omit it to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). Pass an explicit id only to override that default.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "model_wallet_id": {
+                "title": "Model Wallet Id",
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Name"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "required_claims": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Required Claims"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Version"
+              }
+            },
+            "required": [
+              "organization_id",
+              "model_wallet_id"
+            ],
+            "title": "edit_model_walletArguments",
+            "type": "object"
+          },
+          "name": "edit_model_wallet",
+          "title": "Edit Model Wallet"
+        },
+        {
+          "annotations": {
             "destructiveHint": null,
             "idempotentHint": true,
             "openWorldHint": true,
@@ -1706,6 +3322,44 @@
         {
           "annotations": {
             "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to get org-wide managed LLM usage for the Budget dashboard: totalSpend plus by-provider and by-wallet breakdowns. ALWAYS read displayUnit before quoting amounts: 'dollars' means the LLM-proxy Model Library has at least one priced model (idle priced models still show dollars, which may be $0); 'tokens' is total tokens because no catalog model has a Model Library rate — never call token totals dollars. When displayUnit is dollars, also read excludedUnpricedModelCount and excludedTokens: if count > 0 those tokens are not in the dollar total (catalog-unpriced usage) and must not be quoted as full spend. Unattributed proxy spend (no wallet id) is omitted from by-wallet only; totalSpend and byProvider include it. Answers questions like 'how much are we spending on LLMs?', 'which provider costs the most?', 'top spending wallets?'. When Budget Management is not enabled for the org, the tool returns a non-error 'not enabled' empty-state — do NOT report that as $0 spend. When the spend source is unreachable, degraded=true and the summary says unavailable — also not $0. Supports time_range values: 1h, 6h, 24h, 7d, 30d (default 7d). Pass environment_id (Anypoint environment UUID) when known so by-key labels resolve to wallet names and catalog rates can price dollars. Omit rather than inventing one; missing env leaves raw wallet ids and returns tokens (not dollars) without degraded. organization_id is accepted only as an alias or a business group the Bearer belongs to, never as the authorization decision. Example: fetch_budget_usage(organization_id=<org_id>, time_range='7d', environment_id=<env_id>). For per-agent dollar spend, use fetch_cost_instances(category='agent'). For per-instance MCP token usage, use fetch_cost_instances. For org-wide MCP token KPIs (not Budgets), use fetch_cost_overview.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "default": "",
+                "description": "Optional Anypoint environment UUID. When present, by-key labels resolve to wallet names (clientKeyId → clientKeyName) and dollars use Model Library rates. Omit rather than inventing one; missing env leaves raw wallet ids and reports token counts (no catalog), not a false $0.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "description": "Anypoint organization ID. Spend is bound to the authenticated caller; a model-supplied organization_id is accepted only as an alias or a business group the Bearer belongs to, never as the authorization decision.",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "time_range": {
+                "default": "7d",
+                "description": "Time window for spend aggregation. One of 1h, 6h, 24h, 7d, 30d. Default 7d.",
+                "title": "Time Range",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id"
+            ],
+            "title": "fetch_budget_usageArguments",
+            "type": "object"
+          },
+          "name": "fetch_budget_usage",
+          "title": "Fetch Budget Usage"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true,
@@ -1748,9 +3402,19 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool to get token usage and response time timeseries for a single MCP server instance. Returns time-bucketed data points with totalTokens, tokenDelta, and avgResponseTimeMs per bucket. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Example: fetch_cost_instance_timeseries(organization_id=<org_id>, instance_id=<instance_id>, time_range='7d'). For org-wide overview, use fetch_cost_overview instead.",
+          "description": "Use this tool to chart a single instance over time. category selects the scope (defaults to 'mcp'). category='mcp': an MCP server instance — instance_id is the API Manager instance id; buckets carry totalTokens, tokenDelta, and avgResponseTimeMs. category='agent': a single AGENT (LLM proxy) — instance_id is the agent's id (agentId / llmProxyId from fetch_cost_instances(category='agent')); buckets carry the agent's LLM-proxy token counts and avgResponseTimeMs. The agent series is token-denominated — it carries NO per-bucket dollars (for agent dollar spend/savings totals use fetch_cost_instances(category='agent')). This is the only tool that returns an agent timeseries — fetch_cost_instances(category='agent') gives the agent table but no per-agent chart. Always pass a real instance_id from fetch_cost_instances (mcp or agent scope); never invent one. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Example (mcp): fetch_cost_instance_timeseries(organization_id=<org_id>, instance_id=<instance_id>, time_range='7d'). Example (agent): fetch_cost_instance_timeseries(organization_id=<org_id>, instance_id=<agentId>, time_range='7d', category='agent'). For the org-wide overview, use fetch_cost_overview instead.",
           "inputSchema": {
             "properties": {
+              "category": {
+                "default": "mcp",
+                "description": "Scope of the series. 'mcp' (default): MCP-server instance — instance_id is the API Manager instance id. 'agent': agent / LLM-proxy scope — instance_id is the agent's api.instance.id (== agentId / llmProxyId from fetch_cost_instances(category='agent')).",
+                "enum": [
+                  "mcp",
+                  "agent"
+                ],
+                "title": "Category",
+                "type": "string"
+              },
               "instance_id": {
                 "title": "Instance Id",
                 "type": "string"
@@ -1783,9 +3447,19 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool to get per-instance token usage with optimization coverage. Each instance includes totalTokens, tokenDelta (tokens saved), avgResponseTimeMs, toolsListTokens, toolsCallTokens, environmentId, organizationId, appliedPolicies, appliedCostPolicyIds, unappliedCostPolicyIds, and optimizationCoverage (0-1). Response also includes a policyTemplates lookup (templateId -> name, description). Use filter_unoptimized=true to find instances with unapplied cost policies. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Use top_n to limit results (default 10, max 50). Use sort_by to change ordering (totalTokens, tokenDelta, avgResponseTimeMs, totalCalls, tokensPerCall). To optimize a specific instance, use the unappliedCostPolicyIds list with prepare_policy_creation(asset_id=<assetId>, policy_name_hint=<policy_id>). Example: fetch_cost_instances(organization_id=<org_id>, time_range='30d', filter_unoptimized=true).",
+          "description": "Use this tool to get per-instance usage. category selects the scope (defaults to 'mcp'). category='mcp': per-MCP-server-instance token usage with optimization coverage. Each instance includes totalTokens, tokenDelta (tokens saved), avgResponseTimeMs, toolsListTokens, toolsCallTokens, environmentId, organizationId, appliedPolicies, appliedCostPolicyIds, unappliedCostPolicyIds, and optimizationCoverage (0-1). Response also includes a policyTemplates lookup (templateId -> name, description). Use filter_unoptimized=true to find instances with unapplied cost policies. Use sort_by to change ordering (totalTokens, tokenDelta, avgResponseTimeMs, totalCalls, tokensPerCall). To optimize a specific instance, use the unappliedCostPolicyIds list with prepare_policy_creation(asset_id=<assetId>, policy_name_hint=<policy_id>). category='agent': per-agent LLM-proxy spend and savings in DOLLARS (not token estimates). Each agent includes agentId, agentName, managedType (managed if connected to an LLM proxy, else unmanaged), llmProxyId, spend (cost $), saved / potentialSavings ($), and a usage block (totalTokens, totalCalls, tokensPerCall, avgResponseTimeMs). Dollar figures depend on cost data being available for the org (response carries costDataAvailable); when false, spend/saved are zeroed placeholders, NOT real dollars — do NOT report that $0 as real spend, tell the user to Configure Costs. potentialSavings is always 0.0 (no per-agent rate source). sort_by / filter_unoptimized do not apply to the agent scope. Answers 'how much are my agents spending?', 'which agents saved the most?'. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Use top_n to limit results (default 10, max 50). Example (mcp): fetch_cost_instances(organization_id=<org_id>, time_range='30d', filter_unoptimized=true). Example (agent): fetch_cost_instances(organization_id=<org_id>, time_range='30d', category='agent').",
           "inputSchema": {
             "properties": {
+              "category": {
+                "default": "mcp",
+                "description": "Scope of the listing. 'mcp' (default): per-MCP-server-instance token usage and optimization coverage. 'agent': per-agent LLM-proxy usage with spend/savings in dollars (dollars shown only when cost data is available for the org).",
+                "enum": [
+                  "mcp",
+                  "agent"
+                ],
+                "title": "Category",
+                "type": "string"
+              },
               "filter_unoptimized": {
                 "default": false,
                 "title": "Filter Unoptimized",
@@ -1828,9 +3502,19 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool to get a ranked list of MCP server instances that should be optimized, mirroring the 'Recommended Optimizations' card on the Cost Management page. Filters to active instances (usage in window) that have at least one unapplied cost policy, projects token savings from Exchange tool metadata using the same rate analyzers as the UI, and returns the top N by projected savings. Each recommendation includes instanceId, instanceName, serverName, assetId, environment, totalTokens, projectedTokensSaved, projectedSavingsPercent, unappliedCostPolicyIds, and perPolicyProjections (policyId, policyName, rate 0-1, tokensSaved). Supports time_range values: 1h, 6h, 24h, 7d, 30d. top_n defaults to 3, max 10. Answers questions like 'what should I optimize next?', 'biggest token savings opportunities?', 'where is the most waste?'. Follow up with prepare_policy_creation(asset_id=<assetId>, policy_name_hint=<policyId>) to apply a policy. Example: fetch_cost_optimization_recommendations(organization_id=<org_id>, time_range='30d', top_n=3).",
+          "description": "Use this tool to get a ranked list of instances that should be optimized, mirroring the 'Recommended Optimizations' card on the Cost Management page. Filters to active instances (usage in window) that have at least one unapplied cost policy, projects token savings from Exchange tool metadata using the same rate analyzers as the UI, and returns the top N by projected savings. Each recommendation includes instanceId, instanceName, serverName, assetId, environment, totalTokens, projectedTokensSaved, projectedSavingsPercent, unappliedCostPolicyIds, and perPolicyProjections (policyId, policyName, rate 0-1, tokensSaved). category='mcp' (default) ranks MCP-server instances. category='agent' scopes to agents / LLM proxies, but agent optimization needs an upstream per-proxy cost-policy/rate source that is not yet emitted (W-23371138): it returns an empty list today (no fabricated agent savings) and lights up automatically once that source lands. Do NOT invent agent recommendations. Supports time_range values: 1h, 6h, 24h, 7d, 30d. top_n defaults to 3, max 10. Answers questions like 'what should I optimize next?', 'biggest token savings opportunities?', 'where is the most waste?'. Follow up with prepare_policy_creation(asset_id=<assetId>, policy_name_hint=<policyId>) to apply a policy. Example: fetch_cost_optimization_recommendations(organization_id=<org_id>, time_range='30d', top_n=3).",
           "inputSchema": {
             "properties": {
+              "category": {
+                "default": "mcp",
+                "description": "Scope to rank. 'mcp' (default): MCP-server instances ranked by projected token savings from unapplied cost policies — the 'Recommended Optimizations' card. 'agent': agent / LLM-proxy scope. Agent optimization is proxy-scoped and depends on an upstream per-proxy cost-policy/rate source that is not yet emitted (W-23371138), so this returns an empty list today (no fabricated savings) and populates automatically once that source lands — never invent agent recommendations.",
+                "enum": [
+                  "mcp",
+                  "agent"
+                ],
+                "title": "Category",
+                "type": "string"
+              },
               "organization_id": {
                 "title": "Organization Id",
                 "type": "string"
@@ -1868,7 +3552,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool to get org-wide token usage KPIs for MCP servers: total tokens, saved tokens (from optimization policies), and total tool calls. Optionally includes token usage timeseries. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Use include_timeseries=true for chart data (increases response size). Example: fetch_cost_overview(organization_id=<org_id>, time_range='30d'). For per-instance breakdown, use fetch_cost_instances instead.",
+          "description": "Use this tool for the org-wide cost summary: MCP-server token KPIs (total tokens, saved tokens from optimization policies, total tool calls) PLUS org-wide agent dollar cards (totalManagedSpend, agentAmountSaved). The dollar cards are populated only when cost data is available for the org (costDataAvailable=true); when false they are absent — do NOT report $0 as real spend. agentPotentialSavings is always 0.0 (no per-agent rate source) and is not a spend figure. Optionally includes token usage timeseries. Supports time_range values: 1h, 6h, 24h, 7d, 30d. Use include_timeseries=true for chart data (increases response size). Example: fetch_cost_overview(organization_id=<org_id>, time_range='30d'). For a per-MCP-instance token breakdown, use fetch_cost_instances. For per-agent dollar spend/savings, use fetch_cost_instances(category='agent').",
           "inputSchema": {
             "properties": {
               "include_timeseries": {
@@ -2163,28 +3847,131 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool to rank services or instances contributing to a specific performance metric (availability, reliability, avgLatency, requestVolume, errorRate, policyViolations). Powers the Performance view's drill-down drawer and answers questions like \"which services are driving errors?\" or \"rank instances by latency\". Filter by entity_type (apis/agents/mcp-servers/llms), service_id (narrow to one service's instances), instance_id (single instance), environments list, or providers list. Free-text `search` matches service/instance/environment names. Returns MetricContributorRow[] plus pagination metadata (totalRows, offset, pageSize). Example: fetch_monitoring_drill_down(metric='errorRate', time_range='24h'). Example: fetch_monitoring_drill_down(metric='avgLatency', entity_type='apis', sort_dir='desc').",
+          "description": "Get one Model Wallet by id in an Anypoint organization + environment. Returns modelWalletId, name, clientId, requiredClaims, budgets (each with model, metric, period, and limit), and version. environment_id is OPTIONAL: omit it to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). When acting on a wallet from fetch_model_wallets, pass that wallet's environmentId — a wallet can live in ANY environment, and auto-select resolves only one, so it may not find the wallet. Read-only. Example (env from the fetch_model_wallets row): fetch_model_wallet_details(organization_id=<org_id>, model_wallet_id=<id>, environment_id=<env_id>). For the full list, use fetch_model_wallets.",
           "inputSchema": {
             "properties": {
-              "entity_type": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Entity Type"
+              "environment_id": {
+                "default": "",
+                "description": "Anypoint environment ID the wallet lives in. OPTIONAL — omit it (or pass an empty string) to auto-select the environment the UI would use (a production environment if the org has one, else the first available; design-time environments are ignored). Pass an explicit id only to override that default.",
+                "title": "Environment Id",
+                "type": "string"
               },
+              "model_wallet_id": {
+                "title": "Model Wallet Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "model_wallet_id"
+            ],
+            "title": "fetch_model_wallet_detailsArguments",
+            "type": "object"
+          },
+          "name": "fetch_model_wallet_details",
+          "title": "Fetch Model Wallet Details"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the Model Wallets in an Anypoint organization, across EVERY environment in the org. A Model Wallet scopes a caller (clientId + requiredClaims) to a set of LLM Proxies and carries its token/spend budgets. This tool takes NO environment parameter — it always spans all environments and each returned wallet carries the environmentId (and environmentName) it lives in. To answer about a single environment, filter the returned wallets by their environmentId; do NOT assume the session's active environment is the only one. Each returned wallet includes modelWalletId, name, clientId, requiredClaims, budgets, version, and environmentId. Pass an optional 'search' substring to filter by name or clientId (case-insensitive), the same as the catalog page's search box; omit it to list all. Read-only. Example: fetch_model_wallets(organization_id=<org_id>). Example (name filter): fetch_model_wallets(organization_id=<org_id>, search='team a'). For one wallet's full detail, use fetch_model_wallet_details (pass the wallet's environmentId from these results).",
+          "inputSchema": {
+            "properties": {
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "search": {
+                "default": "",
+                "description": "Optional case-insensitive substring to filter the returned wallets by name or clientId (same as the catalog page's search box). Blank returns all wallets.",
+                "title": "Search",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id"
+            ],
+            "title": "fetch_model_walletsArguments",
+            "type": "object"
+          },
+          "name": "fetch_model_wallets",
+          "title": "Fetch Model Wallets"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to rank services or instances contributing to a specific performance metric (availability, reliability, avgLatency, requestVolume, errorRate, policyViolations, taskResolution, qualityScore, latencyMs, agentMethod, failureReason). Powers the Performance view's drill-down drawer and answers questions like \"which services are driving errors?\", \"rank instances by latency\", or \"which agents have the highest quality score / most resolved tasks?\". The taskResolution and qualityScore metrics surface agent quality: taskResolution ranks by resolved-task volume, and qualityScore ranks by the task-count-weighted mean quality score. The latencyMs metric ranks by agent-execution latency (the mulesoft.agent.latency.ms signal, request-weighted at the service level) distinct from avgLatency's gateway p99. The agentMethod and failureReason metrics rank by total event count and each row carries a category breakdown array (agentMethodBreakdown / failureReasonBreakdown, each entry {label, count} sorted count-descending): agentMethod breaks down invocations by mulesoft.agent.method, failureReason breaks down failures by mulesoft.agent.failure.reason. Filter by entity_type (apis/agents/mcp-servers/llms), service_id (narrow to one service's instances), instance_id (single instance), environments list, or providers list. Free-text `search` matches service/instance/environment names. Returns MetricContributorRow[] plus pagination metadata (totalRows, offset, pageSize). Example: fetch_monitoring_drill_down(metric='errorRate', time_range='24h'). Example: fetch_monitoring_drill_down(metric='avgLatency', entity_type='apis', sort_dir='desc'). Example: fetch_monitoring_drill_down(metric='qualityScore', entity_type='agents', sort_dir='desc'). Example: fetch_monitoring_drill_down(metric='latencyMs', entity_type='agents', sort_dir='desc'). Example: fetch_monitoring_drill_down(metric='agentMethod', entity_type='agents'). Example: fetch_monitoring_drill_down(metric='failureReason', entity_type='agents').",
+          "inputSchema": {
+            "$defs": {
+              "DrillDownScope": {
+                "description": "Optional scope filters for ``fetch_monitoring_drill_down``.\n\nBundled to keep the agent-facing wrapper under the 13-arg cap while\npreserving the legacy entity/service/instance filter trio.",
+                "properties": {
+                  "entity_type": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Entity Type"
+                  },
+                  "instance_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Instance Id"
+                  },
+                  "service_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Service Id"
+                  }
+                },
+                "title": "DrillDownScope",
+                "type": "object"
+              }
+            },
+            "properties": {
               "environment": {
-                "default": "sandbox",
+                "default": "unknown",
                 "title": "Environment",
                 "type": "string"
               },
               "environments": {
                 "anyOf": [
+                  {
+                    "type": "string"
+                  },
                   {
                     "items": {
                       "type": "string"
@@ -2198,18 +3985,6 @@
                 "default": null,
                 "title": "Environments"
               },
-              "instance_id": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Instance Id"
-              },
               "limit": {
                 "default": 25,
                 "title": "Limit",
@@ -2222,7 +3997,12 @@
                   "avgLatency",
                   "requestVolume",
                   "errorRate",
-                  "policyViolations"
+                  "policyViolations",
+                  "taskResolution",
+                  "qualityScore",
+                  "latencyMs",
+                  "agentMethod",
+                  "failureReason"
                 ],
                 "title": "Metric",
                 "type": "string"
@@ -2247,6 +4027,9 @@
               "providers": {
                 "anyOf": [
                   {
+                    "type": "string"
+                  },
+                  {
                     "items": {
                       "type": "string"
                     },
@@ -2259,22 +4042,21 @@
                 "default": null,
                 "title": "Providers"
               },
-              "search": {
-                "default": "",
-                "title": "Search",
-                "type": "string"
-              },
-              "service_id": {
+              "scope": {
                 "anyOf": [
                   {
-                    "type": "string"
+                    "$ref": "#/$defs/DrillDownScope"
                   },
                   {
                     "type": "null"
                   }
                 ],
-                "default": null,
-                "title": "Service Id"
+                "default": null
+              },
+              "search": {
+                "default": "",
+                "title": "Search",
+                "type": "string"
               },
               "sort_dir": {
                 "default": "desc",
@@ -2341,7 +4123,7 @@
                 "title": "Asset Version"
               },
               "environment": {
-                "default": "sandbox",
+                "default": "unknown",
                 "title": "Environment",
                 "type": "string"
               },
@@ -2389,7 +4171,7 @@
           "inputSchema": {
             "properties": {
               "environment": {
-                "default": "sandbox",
+                "default": "unknown",
                 "title": "Environment",
                 "type": "string"
               },
@@ -2437,7 +4219,44 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool when you need aggregate counts/buckets for summaries, dashboards, or filter panels, not full service-row hydration. Prefer this tool over fetch_services when the user asks 'how many', 'breakdown by type/status/provider', or other distribution insights. Fetches facet aggregates for exactly one required business_group_id. Supports either text query (q) OR typed filtering/aggregates; when q is provided, do not send filters or aggregates. Canonical typed values are api classifiers (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) plus agent and mcp, and common aliases are normalized before filtering. Canonical provider values include: mulesoft, kong, apigee, aws, azure, openai, anthropic, aws-bedrock, google-vertex, agentforce, microsoft-copilot, godaddy-ans, langsmith, mistral, meta. filters MUST be a JSON object, never a Lucene-style string. Supported filter fields: providerIn (list of canonical provider strings), statusIn, apiCategoryIn, environmentTypeIn, complianceStatusIn, hasInstances (bool), hasActiveInstance (bool). Example (typed facets): fetch_service_facets(business_group_id=<business_group_id>, asset_types=[<asset_type>, ...], aggregates={'totalHits': True, 'byType': True, 'byProvider': True}). Example (query facets): fetch_service_facets(business_group_id=<business_group_id>, q=<search_query>). Returns structured payload with aggregates, total, and query context metadata. If the user then asks for specific assets, follow with fetch_services.",
+          "description": "Return the full ruleset payload for one source_ruleset_key (rules, severities, source asset id/version, profile name). Pair with search_repository_knowledge: each match's metadata.rulesetKey is the argument to pass back here. Use when the user asks for 'full ruleset details', 'list every rule in <ruleset>', or 'what does the X ruleset check'.",
+          "inputSchema": {
+            "properties": {
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Organization Id"
+              },
+              "source_ruleset_key": {
+                "title": "Source Ruleset Key",
+                "type": "string"
+              }
+            },
+            "required": [
+              "source_ruleset_key"
+            ],
+            "title": "fetch_ruleset_detailsArguments",
+            "type": "object"
+          },
+          "name": "fetch_ruleset_details",
+          "title": "Fetch Ruleset Details"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool when you need aggregate counts/buckets for summaries, dashboards, or filter panels, not full service-row hydration. Prefer this tool over fetch_services when the user asks 'how many', 'breakdown by type/status/provider', or other distribution insights. Fetches facet aggregates for exactly one required business_group_id. Supports either text query (q) OR typed filtering/aggregates; when q is provided, do not send filters or aggregates. Canonical typed values are api classifiers (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) plus agent and mcp, and common aliases are normalized before filtering. Canonical provider values include: mulesoft, kong, apigee, aws, azure, openai, anthropic, aws-bedrock, google-vertex, agentforce, microsoft-copilot, godaddy-ans, langsmith, mistral, meta. filters MUST be a JSON object, never a Lucene-style string. Supported filter fields: providerIn (list of canonical provider strings), statusIn, apiCategoryIn, environmentTypeIn, complianceStatusIn, tagsIn (list of exact Exchange tags, ANDed with the other filters), hasInstances (bool), hasActiveInstance (bool). Example (typed facets): fetch_service_facets(business_group_id=<business_group_id>, asset_types=[<asset_type>, ...], aggregates={'totalHits': True, 'byType': True, 'byProvider': True}). Example (query facets): fetch_service_facets(business_group_id=<business_group_id>, q=<search_query>). Returns structured payload with aggregates, total, and query context metadata. If the user then asks for specific assets, follow with fetch_services.",
           "inputSchema": {
             "$defs": {
               "AssetSearchAggregatesRequest": {
@@ -2554,6 +4373,18 @@
                     "default": null,
                     "title": "Hasactiveversion"
                   },
+                  "hasGovernance": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Hasgovernance"
+                  },
                   "hasInstances": {
                     "anyOf": [
                       {
@@ -2565,6 +4396,21 @@
                     ],
                     "default": null,
                     "title": "Hasinstances"
+                  },
+                  "provenanceIn": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Provenancein"
                   },
                   "providerIn": {
                     "anyOf": [
@@ -2580,6 +4426,21 @@
                     ],
                     "default": null,
                     "title": "Providerin"
+                  },
+                  "providerLabelHints": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Providerlabelhints"
                   },
                   "providerTupleIn": {
                     "anyOf": [
@@ -2610,6 +4471,21 @@
                     ],
                     "default": null,
                     "title": "Statusin"
+                  },
+                  "tagsIn": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Tagsin"
                   }
                 },
                 "title": "AssetSearchFilters",
@@ -2696,7 +4572,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool when you need concrete service rows (for example asset IDs/names, detail selection, or navigation affordances). Prefer this tool over fetch_service_facets when the user asks 'which assets' or requests item-level results. Fetches lightweight services for exactly one required business_group_id. Searches the user's business group AND the MuleSoft public catalog overlay for agent / mcp / llm asset types — public providers like GoDaddy ANS, Salesforce Agentforce, LangSmith, Microsoft Copilot, OpenAI, Anthropic, AWS Bedrock surface here. API asset types (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) are user-org-only by design — the public overlay carries no API rows, so APIs are not affected. Supports either text query (q) OR typed filtering/aggregates; when q is provided, do not send filters or aggregates. Canonical typed values are api classifiers (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) plus agent and mcp. The tool normalizes common aliases/plurals (for example api/apis, rest, openapi, asyncapi, agents, mcp-servers) to canonical values before filtering. Returns structured payload with services, assets (alias), total, and optional aggregates. Service rows include a provider field. Canonical provider values include: mulesoft, kong, apigee, aws, azure, openai, anthropic, aws-bedrock, google-vertex, agentforce, microsoft-copilot, godaddy-ans, langsmith, mistral, meta. If you only need counts/buckets (no row hydration), use fetch_service_facets instead. filters MUST be a JSON object, never a Lucene-style string. Supported filter fields: providerIn (list of canonical provider strings), statusIn, apiCategoryIn, environmentTypeIn, complianceStatusIn, hasInstances (bool), hasActiveInstance (bool). Example (typed rows): fetch_services(business_group_id=<business_group_id>, asset_types=[<asset_type>, ...], size=<n>). Example (provider-filtered): fetch_services(business_group_id=<business_group_id>, asset_types=['agent'], filters={'providerIn': ['godaddy-ans']}, size=50). Example (text search): fetch_services(business_group_id=<business_group_id>, q=<search_query>, size=<n>). Service rows include affordances and links for downstream navigation/actions. IMPORTANT: Do NOT paginate through all results by calling this tool multiple times with different offsets. Use the first page of results to synthesize your answer. Only call again with different filters if the first result set is clearly irrelevant to the user's question.",
+          "description": "Use this tool when you need concrete service rows (for example asset IDs/names, detail selection, or navigation affordances). Prefer this tool over fetch_service_facets when the user asks 'which assets' or requests item-level results. Fetches lightweight services for exactly one required business_group_id. Searches the user's business group AND the MuleSoft public catalog overlay for agent / mcp / llm asset types — public providers like GoDaddy ANS, Salesforce Agentforce, LangSmith, Microsoft Copilot, OpenAI, Anthropic, AWS Bedrock surface here. API asset types (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) are user-org-only by design — the public overlay carries no API rows, so APIs are not affected. Supports either text query (q) OR typed filtering/aggregates; when q is provided, do not send filters or aggregates. Canonical typed values are api classifiers (rest-api, http-api, graphql, soap-api, grpc-api, evented-api) plus agent and mcp. The tool normalizes common aliases/plurals (for example api/apis, rest, openapi, asyncapi, agents, mcp-servers) to canonical values before filtering. Returns structured payload with services, assets (alias), total, and optional aggregates. Service rows include a provider field. Canonical provider values include: mulesoft, kong, apigee, aws, azure, openai, anthropic, aws-bedrock, google-vertex, agentforce, microsoft-copilot, godaddy-ans, langsmith, mistral, meta. If you only need counts/buckets (no row hydration), use fetch_service_facets instead. filters MUST be a JSON object, never a Lucene-style string. Supported filter fields: providerIn (list of canonical provider strings), statusIn, apiCategoryIn, environmentTypeIn, complianceStatusIn, tagsIn (list of exact Exchange tags, ANDed with the other filters — use this to scope to tagged assets, e.g. finance), hasInstances (bool), hasActiveInstance (bool). Example (typed rows): fetch_services(business_group_id=<business_group_id>, asset_types=[<asset_type>, ...], size=<n>). Example (provider-filtered): fetch_services(business_group_id=<business_group_id>, asset_types=['agent'], filters={'providerIn': ['godaddy-ans']}, size=50). Example (tag-filtered): fetch_services(business_group_id=<business_group_id>, filters={'tagsIn': ['finance']}, size=50). Example (text search): fetch_services(business_group_id=<business_group_id>, q=<search_query>, size=<n>). Service rows include affordances and links for downstream navigation/actions. IMPORTANT: Do NOT paginate through all results by calling this tool multiple times with different offsets. Use the first page of results to synthesize your answer. Only call again with different filters if the first result set is clearly irrelevant to the user's question.",
           "inputSchema": {
             "$defs": {
               "AssetSearchAggregatesRequest": {
@@ -2813,6 +4689,18 @@
                     "default": null,
                     "title": "Hasactiveversion"
                   },
+                  "hasGovernance": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Hasgovernance"
+                  },
                   "hasInstances": {
                     "anyOf": [
                       {
@@ -2824,6 +4712,21 @@
                     ],
                     "default": null,
                     "title": "Hasinstances"
+                  },
+                  "provenanceIn": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Provenancein"
                   },
                   "providerIn": {
                     "anyOf": [
@@ -2839,6 +4742,21 @@
                     ],
                     "default": null,
                     "title": "Providerin"
+                  },
+                  "providerLabelHints": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Providerlabelhints"
                   },
                   "providerTupleIn": {
                     "anyOf": [
@@ -2869,6 +4787,21 @@
                     ],
                     "default": null,
                     "title": "Statusin"
+                  },
+                  "tagsIn": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "title": "Tagsin"
                   }
                 },
                 "title": "AssetSearchFilters",
@@ -2925,6 +4858,16 @@
                 "title": "Include Affordances",
                 "type": "boolean"
               },
+              "include_public": {
+                "default": true,
+                "title": "Include Public",
+                "type": "boolean"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
               "q": {
                 "anyOf": [
                   {
@@ -2941,6 +4884,11 @@
                 "default": 20,
                 "title": "Size",
                 "type": "integer"
+              },
+              "stable_full_window": {
+                "default": false,
+                "title": "Stable Full Window",
+                "type": "boolean"
               }
             },
             "required": [
@@ -2951,6 +4899,220 @@
           },
           "name": "fetch_services",
           "title": "Fetch Services"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "🔍 Discover assets in your portfolio + the public catalog.\n\nUse this tool for any of:\n  ✓ 'find [thing]' / 'search for [thing]' / 'discover [thing]'\n  ✓ 'do you have [thing]?' / 'is there a [thing]?'\n  ✓ 'show me [thing]' / 'list [thing]' / 'what [things] exist?'\n  ✓ Data catalog discovery ('show my data assets', 'find Informatica sources')\n  ✓ '[type] for [capability]' (e.g. 'APIs for payments', 'agents for invoices')\n  ✓ 'similar to [thing]' / 'alternatives to [thing]'\n  ✓ Resolving a user-supplied display name or slug to an asset id\n    before navigating or fetching detail.\n\nInternally runs semantic (concept / synonym) and lexical (literal slug /\nshort query / id-token) discovery in parallel and merges. One call covers\nliteral pastes ('pet-store-api'), partial names ('Pet Store'), single\ntokens ('store'), and conceptual queries ('flight booking').\n\nSEARCH DISCIPLINE (prefer one natural-language call):\n  Semantic + lexical search already handles slug / hyphen / spacing variants,\n  so a natural phrase like 'batch processing agent' already matches — slugging\n  the same intent into 'batch-processing' or 'batch processing' and re-calling\n  rarely surfaces anything new. Aim for ~3 calls at most, with at least one\n  using ASSET_TYPE=\"\" (no filter). Empty results usually mean nothing matched;\n  slug/spacing rewrites of the same intent seldom help — though rephrasing for\n  a genuinely different angle (e.g. a broader or analytical query) is fine.\n\nReturns userOrgAssets (your portfolio) + publicOrgAssets (MuleSoft public\ncatalog), each ranked by relevance.\n\nUSER_QUERY parameter (always pass it):\n  The user's verbatim, untrimmed message. Used only to tell a single named\n  lookup ('the NTO Recommendations API' → collapse the card to that asset)\n  from a set/category ('all finance APIs', 'APIs similar to Stripe' → keep\n  the whole set). Never sent to the search backend; pass even when you also\n  trim QUERY down to the key search terms.\n\nASSET_TYPE parameter (optional):\n  Leave empty (\"\") to search ALL types (recommended for discovery).\n  Pass when the user clearly names ONE kind:\n    'api' / 'apis' → expands to 'rest-api', 'http-api', 'graphql', 'soap-api', 'grpc-api', 'evented-api' (EXCLUDES 'mcp', 'agent', 'llm', 'model', 'vector-database', 'gateway')\n    'mcp', 'agent', 'llm' for those kinds\n    'data' for Informatica/CDGC data assets and catalog sources\n\nAPPLIED POLICIES (INCLUDE_APPLIED_POLICIES + POLICY_NAME_FILTER):\n  Set INCLUDE_APPLIED_POLICIES=true to answer 'which of my APIs have / are\n  missing policy X?' in ONE call. Each of your portfolio results then also\n  carries the policies currently APPLIED to its managed instances (MuleSoft\n  and external Kong/Apigee/Azure). Pass POLICY_NAME_FILTER='rate-limiting'\n  (name or substring) to report the found/missing split directly — do NOT\n  loop view_api_instance_policies over every hit. For the apply flow key on\n  policyCoverage ('all'/'partial'/'none'/'unknown') + instancesMissingPolicy\n  (the instances still lacking it), NOT hasPolicy alone: hasPolicy is\n  any-instance, so a partially-protected API reads True and would be skipped.\n  Off by default; the fan-out is bounded (top matched APIs, production-first\n  instances) and the meta block says what was capped.\n\nDO NOT USE FOR:\n  ✗ Performance metrics (use fetch_monitoring_*)\n  ✗ Cost analysis (use fetch_cost_*)\n  ✗ Governance findings / conformance reports (use fetch_governance_*) — but\n    for APPLIED policies across a set of APIs, use INCLUDE_APPLIED_POLICIES\n    above rather than calling view_api_instance_policies per asset.\n  ✗ Applied policies for ONE already-known instance (use view_api_instance_policies)\n  ✗ Already-selected asset details (use asset-specific tools)\n  ✗ Typed catalog listings (use fetch_services)\n  ✗ Catalog facets / aggregates (use fetch_service_facets)\n",
+          "inputSchema": {
+            "properties": {
+              "asset_type": {
+                "default": "",
+                "title": "Asset Type",
+                "type": "string"
+              },
+              "for_policy_application": {
+                "default": false,
+                "title": "For Policy Application",
+                "type": "boolean"
+              },
+              "include_applied_policies": {
+                "default": false,
+                "title": "Include Applied Policies",
+                "type": "boolean"
+              },
+              "max_results": {
+                "default": 20,
+                "title": "Max Results",
+                "type": "integer"
+              },
+              "policy_name_filter": {
+                "default": "",
+                "title": "Policy Name Filter",
+                "type": "string"
+              },
+              "query": {
+                "title": "Query",
+                "type": "string"
+              },
+              "user_query": {
+                "default": "",
+                "title": "User Query",
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "title": "find_assetsArguments",
+            "type": "object"
+          },
+          "name": "find_assets",
+          "title": "Find Assets"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Single ``find_assets`` call with synonym expansion done server-side, so the agent doesn't loop across rephrasings. Use this when the user describes a capability and the literal phrasing might not match the asset's name (e.g. 'LLMs for code generation' → also search 'code completion', 'codegen'). Args: query (required), asset_type (optional: agent / rest-api / mcp / llm), max_synonyms (default 3, cap 6). Returns the standard ``find_assets`` envelope plus a ``query_attempts`` list showing which synonyms were tried.",
+          "inputSchema": {
+            "properties": {
+              "asset_type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Asset Type"
+              },
+              "max_synonyms": {
+                "default": 3,
+                "title": "Max Synonyms",
+                "type": "integer"
+              },
+              "query": {
+                "title": "Query",
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "title": "find_assets_expandedArguments",
+            "type": "object"
+          },
+          "name": "find_assets_expanded",
+          "title": "Asset discovery with server-side synonym expansion"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to check whether a person is already a platform user in an organization, by their exact email address. Returns only users whose email matches exactly (case-insensitive) — an idempotency check before inviting someone. Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'is jane@acme.com already a user?', 'find the user with email X', 'does this person already have access?'. Example: find_user_by_email(email=jane@acme.com).",
+          "inputSchema": {
+            "properties": {
+              "email": {
+                "default": "",
+                "description": "Exact email address of the platform user to find.",
+                "title": "Email",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID to search within. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "find_user_by_emailArguments",
+            "type": "object"
+          },
+          "name": "find_user_by_email",
+          "title": "Find User by Email"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Get instance-rooted Context Catalog lineage. Downstream supports Agent, MCP, and API roots; upstream supports MCP and API roots. If instance_id is omitted, returns deployed instance options with their owning asset versions so the user can choose; it never selects implicitly. Empty results use stable reasonCode values: ASSET_NOT_FOUND, ASSET_VERSION_NOT_FOUND, NO_INSTANCES, or LINEAGE_NOT_FOUND. Otherwise reuse the selected option's requestArguments exactly; they contain the matching instance_id and asset_version. Treat status and connections as authoritative: CONNECTS_TO is runtime evidence and ROUTES_TO is design-time evidence. Technical ASSET nodes, IMPLEMENTATION_OF edges, and RESOLVES_TO edges are omitted.",
+          "inputSchema": {
+            "properties": {
+              "asset": {
+                "title": "Asset",
+                "type": "string"
+              },
+              "asset_type": {
+                "enum": [
+                  "agent",
+                  "mcp",
+                  "api"
+                ],
+                "title": "Asset Type",
+                "type": "string"
+              },
+              "asset_version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Asset Version"
+              },
+              "direction": {
+                "enum": [
+                  "upstream",
+                  "downstream"
+                ],
+                "title": "Direction",
+                "type": "string"
+              },
+              "instance_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Instance Id"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Organization Id"
+              }
+            },
+            "required": [
+              "asset",
+              "asset_type",
+              "direction"
+            ],
+            "title": "get_asset_lineageArguments",
+            "type": "object"
+          },
+          "name": "get_asset_lineage",
+          "title": "Get Asset Lineage"
         },
         {
           "annotations": {
@@ -2982,6 +5144,97 @@
           },
           "name": "get_business_group",
           "title": "Get Business Group"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Show hierarchy, classifications, glossary terms, and the explicit PII state for ONE data asset or catalog source, never the full catalog — use `find_assets(asset_type=\"data\")` first to list/find data sources. Returns source → database → schema → table → column structure, column classifications and glossary terms, aggregate governance summaries, and PII state.",
+          "inputSchema": {
+            "properties": {
+              "asset": {
+                "title": "Asset",
+                "type": "string"
+              },
+              "asset_version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Asset Version"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Organization Id"
+              }
+            },
+            "required": [
+              "asset"
+            ],
+            "title": "get_data_asset_classificationArguments",
+            "type": "object"
+          },
+          "name": "get_data_asset_classification",
+          "title": "Get Data Asset Classification"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Read an existing Model Proxy's FULL current configuration — not just the route list: also routingStrategy, semanticServiceConfigId, fallbackRoute/fallbackModel/fallbackThreshold, denyTopicIds, and semanticCacheConfigId. This is the ONLY tool that returns that full snapshot, and calling it is MANDATORY, in the SAME turn, immediately BEFORE every single `update_model_proxy` call — even if a snapshot from an earlier turn in this conversation looks current or you already called it once this session, re-fetch anyway. `update_model_proxy` REPLACES the whole route list AND every semantic field wholesale, so adding or editing one route without a fresh copy of the full current set silently drops the others (and their `upstream_ids` / `prompt_topic_ids` / semantic config). Prefer `asset_id` from `list_llms` and omit `environment_id` — the tool walks every env. Do NOT reuse the environment_id from a prior create (`list_omni_gateway_environments`); that 404s GET .../upstreams when the proxy lives elsewhere. Each route comes back with its `upstream_ids`, which `update_model_proxy` needs to update a route in place instead of recreating it. Credentials are never returned; an unchanged route keeps its stored key when you resend it. Semantic proxies also return routingStrategy, semanticServiceConfigId, fallbackRoute / fallbackModel / fallbackThreshold, denyTopicIds, and semanticCacheConfigId — resend those on update so they are not cleared.",
+          "inputSchema": {
+            "properties": {
+              "api_instance_id": {
+                "default": "",
+                "description": "API Manager instance ID (preferred when known)",
+                "title": "Api Instance Id",
+                "type": "string"
+              },
+              "asset_id": {
+                "default": "",
+                "description": "Exchange asset ID; resolved when api_instance_id is empty",
+                "title": "Asset Id",
+                "type": "string"
+              },
+              "environment_id": {
+                "default": "",
+                "description": "Optional. The proxy's own environment `id` from `list_llms`. Do NOT reuse the env from a prior create (`list_omni_gateway_environments`). Prefer omitting this and passing `asset_id` so the tool walks environments.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "title": "get_llm_proxy_routesArguments",
+            "type": "object"
+          },
+          "name": "get_llm_proxy_routes",
+          "title": "Get LLM Proxy Routes"
         },
         {
           "annotations": {
@@ -3022,6 +5275,23 @@
           },
           "name": "get_mcp_server_state",
           "title": "Get MCP Server State"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to view the current user's own profile / personal settings. Read-only. Returns the caller's identity (username, email, name) and the business groups they belong to. Sensitive fields (phone, last-login, IdP linkage) and permission grants are deliberately omitted — this does NOT report roles or permissions. Use for prompts like 'show my profile', 'what's my email on file?', 'which business groups am I in?'. Example: get_my_profile().",
+          "inputSchema": {
+            "properties": {},
+            "title": "get_my_profileArguments",
+            "type": "object"
+          },
+          "name": "get_my_profile",
+          "title": "Get My Profile"
         },
         {
           "annotations": {
@@ -3127,11 +5397,44 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Load one policy template detail, including configuration schema, to dynamically render the creation form. Use this immediately after the user selects a policy in prepare_policy_creation. For non-MuleSoft providers, pass provider and gateway_id alongside template_id.",
+          "description": "Check the status of an asynchronous policy operation. Pass the 'operationId' a policy apply returned — from 'apply_universal_policy' (the canonical fan-out across providers) or from a single-instance native apply (e.g. Kong/Apigee), which also runs asynchronously via the same Temporal operation flow — to see whether it is RUNNING, COMPLETED, or FAILED (with the failure reason). Poll this after an async apply to confirm the policy actually landed on the provider.",
+          "inputSchema": {
+            "properties": {
+              "operation_id": {
+                "description": "The operation id a policy apply returned in its 'operationId' field — from 'apply_universal_policy', or from a single-instance native apply. It's a Temporal workflow id of the form 'v1~external-policy.<org>.universal.<policy>.<uuid>~<run>'.",
+                "title": "Operation Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization id. Defaults to the session's current organization.",
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "operation_id"
+            ],
+            "title": "get_policy_operation_statusArguments",
+            "type": "object"
+          },
+          "name": "get_policy_operation_status",
+          "title": "Get Policy Operation Status"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Load one policy template detail, including configuration schema, to dynamically render the creation form. Use this immediately after the user selects a policy in prepare_policy_creation. For a non-MuleSoft external gateway (provider='kong'/'apigee'/'azure'), set provider and pass the template's Exchange coordinates (group_id + asset_id + asset_version, from prepare_policy_creation) so the editable schema is read through the Anypoint API Manager Universal API (gateway_id is not used on this path). This tool also serves the EDIT flow: to read the configuration schema of a policy that is ALREADY applied, pass the Exchange coordinates (group_id + asset_id + asset_version) returned by view_api_instance_policies — the policy does not need to be un-applied first.",
           "inputSchema": {
             "properties": {
               "api_instance_id": {
                 "default": "",
+                "description": "Numeric API Manager instance ID of the target instance.",
                 "title": "Api Instance Id",
                 "type": "string"
               },
@@ -3145,6 +5448,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Exchange asset ID of the policy template.",
                 "title": "Asset Id"
               },
               "asset_version": {
@@ -3157,10 +5461,12 @@
                   }
                 ],
                 "default": null,
+                "description": "Exchange asset version of the policy template. For the EDIT flow, use the asset_version returned by view_api_instance_policies.",
                 "title": "Asset Version"
               },
               "direction": {
                 "default": "inbound",
+                "description": "Policy direction: 'inbound' or 'outbound'.",
                 "enum": [
                   "inbound",
                   "outbound"
@@ -3170,6 +5476,7 @@
               },
               "environment_id": {
                 "default": "",
+                "description": "Anypoint environment ID. Optional on the external-gateway (Universal API) path, where api_instance_id alone identifies the instance.",
                 "title": "Environment Id",
                 "type": "string"
               },
@@ -3183,6 +5490,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Gateway ID. Not used on the external-gateway Universal API path.",
                 "title": "Gateway Id"
               },
               "group_id": {
@@ -3195,9 +5503,11 @@
                   }
                 ],
                 "default": null,
+                "description": "Exchange group ID of the policy template. For the EDIT flow, use the group_id returned by view_api_instance_policies.",
                 "title": "Group Id"
               },
               "organization_id": {
+                "description": "Anypoint organization (business group) ID that owns the instance.",
                 "title": "Organization Id",
                 "type": "string"
               },
@@ -3211,6 +5521,7 @@
                   }
                 ],
                 "default": null,
+                "description": "External gateway provider: 'kong', 'apigee', or 'azure'. Set for a non-MuleSoft gateway to read the editable schema through the APIM Universal API. Omit for MuleSoft.",
                 "title": "Provider"
               },
               "template_id": {
@@ -3223,6 +5534,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Policy template ID selected in prepare_policy_creation.",
                 "title": "Template Id"
               }
             },
@@ -3249,7 +5561,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Poll the status of a provisioning or update job. Returns status (running/complete/failed), progress step, completed steps, result (MCP URL on success), and can_resume flag.",
+          "description": "Poll the status of a provisioning or update job. Returns status (running/complete/failed), progress step, result (MCP URL on success), and — on failure — a durable failure record (code, message, failed step, compensations run). A failed job is terminal: re-submit from the wizard to retry.",
           "inputSchema": {
             "properties": {
               "job_id": {
@@ -3281,14 +5593,59 @@
         {
           "annotations": {
             "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to get full details for a single semantic cache configuration, including embedding config (provider, model), vector DB config (provider, collection), object store config, similarity criteria, similarity threshold, TTL, and LLM-based cache eligibility settings. Requires organization_id, environment_id, and config_id. config_id accepts either the UUID or the config label (e.g. 'semantic-cache-16'); labels are resolved to IDs automatically. Example: get_semantic_cache_config_detail(organization_id=<org_id>, environment_id=<env_id>, config_id='semantic-cache-16').",
+          "inputSchema": {
+            "properties": {
+              "config_id": {
+                "title": "Config Id",
+                "type": "string"
+              },
+              "environment_id": {
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "environment_id",
+              "config_id"
+            ],
+            "title": "get_semantic_cache_config_detailArguments",
+            "type": "object"
+          },
+          "name": "get_semantic_cache_config_detail",
+          "title": "Get Semantic Cache Config Detail"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
             "idempotentHint": true,
             "openWorldHint": false,
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Return the catalog of SaaS systems available for MCP server provisioning. Each item includes tools, auth type, credential fields, and upstream config.",
+          "description": "Return the catalog of SaaS systems available for MCP server provisioning. Each item includes assetId, name, description, auth type, and a tool list (name + description). Paginated via offset/limit; check has_more/total to page through the full catalog. The upstream config and credential schema are resolved server-side at provision time from the assetId — you only need to pass assetId + selected tool names to provision_mcp_server.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 20,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
               "organization_id": {
                 "anyOf": [
                   {
@@ -3322,9 +5679,14 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "List agents registered in the MuleSoft Platform for a given organization. Presents an interactive UI for browsing, filtering, and selecting agents.",
+          "description": "List agents registered in the MuleSoft Platform for a given organization. Presents an interactive UI for browsing, filtering, and selecting agents. Paginated: pass offset/limit; if the response has hasMore=true, request the next page with the returned nextOffset. To find a specific agent by name or topic, prefer find_assets over paging through the whole list.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
               "name": {
                 "anyOf": [
                   {
@@ -3336,6 +5698,11 @@
                 ],
                 "default": null,
                 "title": "Name"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
               },
               "organization_id": {
                 "anyOf": [
@@ -3382,7 +5749,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "List APIs from the MuleSoft Platform catalog for a given organization. Presents an interactive UI for browsing, filtering, and selecting APIs.",
+          "description": "List APIs from the MuleSoft Platform catalog for a given organization. Presents an interactive UI for browsing, filtering, and selecting APIs. Paginated: pass offset/limit; if the response has has_more=true, request the next page with the returned next_offset. To find a specific API by name or topic, prefer find_assets over paging through the whole list.",
           "inputSchema": {
             "properties": {
               "api_category": {
@@ -3397,6 +5764,11 @@
                 "default": null,
                 "title": "Api Category"
               },
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
               "name": {
                 "anyOf": [
                   {
@@ -3408,6 +5780,11 @@
                 ],
                 "default": null,
                 "title": "Name"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
               },
               "organization_id": {
                 "anyOf": [
@@ -3454,9 +5831,14 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "List available business groups, optionally filtering by name.",
+          "description": "List available business groups, optionally filtering by name. Paginated: pass offset/limit; if the response has has_more=true, request the next page with the returned next_offset.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
               "name": {
                 "anyOf": [
                   {
@@ -3468,6 +5850,11 @@
                 ],
                 "default": null,
                 "title": "Name"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
               }
             },
             "title": "list_business_groupsArguments",
@@ -3490,9 +5877,112 @@
             "readOnlyHint": true,
             "title": null
           },
+          "description": "Use this tool to list an organization's Anypoint **connected apps**. Read-only. Returns each app's client id, name, grant types, and enabled flag — the client **secret is never included**. Set `mine=true` to return only the connected apps the current user owns. Optional `search` (by name) and `limit`/`offset` pagination (default limit 25, max 100). Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'list our connected apps', 'what connected apps do I own?'. Example: list_connected_apps(organization_id=<id>).",
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "default": 25,
+                "description": "Maximum connected apps to return (1-100, default 25).",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "mine": {
+                "default": false,
+                "description": "When true, return only the connected apps owned by the current session user (their own apps).",
+                "title": "Mine",
+                "type": "boolean"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Zero-based pagination offset (default 0).",
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID to list connected apps for. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              },
+              "search": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter to connected apps whose name matches this text.",
+                "title": "Search"
+              }
+            },
+            "title": "list_connected_appsArguments",
+            "type": "object"
+          },
+          "name": "list_connected_apps",
+          "title": "List Connected Apps"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to list the Anypoint environments in a business group, with each environment's type reliably resolved to sandbox / production / unknown (field `environmentType`). Read-only: it does NOT change the active-environment context (that is `select_active_environment`). Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'list the environments in my sandbox business group', 'which environments does org X have?', 'do I have a production environment?'. Example: list_environments(organization_id=<organization_id>).",
+          "inputSchema": {
+            "properties": {
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization / business-group ID whose environments to list. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "list_environmentsArguments",
+            "type": "object"
+          },
+          "name": "list_environments",
+          "title": "List Environments"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
           "description": "List governance strategies for an organization. Shows the same searchable and filterable table style as the main web app.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
               "organization_id": {
                 "anyOf": [
                   {
@@ -3538,7 +6028,146 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "List LLM models registered in the MuleSoft Platform for a given organization. Presents an interactive UI for browsing, filtering, and selecting LLMs.",
+          "description": "List the asynchronous policy operations (the Activity feed) for an external gateway instance (Kong / Apigee / Azure) via the Anypoint API Manager Universal API. Pass provider and the numeric api_instance_id. Because apply/edit/remove writes are processed asynchronously (accepted with HTTP 202), use this to check the terminal state of a recent write: each operation carries a type (APPLY / UPDATE / TOGGLE / REMOVE / CANONICAL_APPLY) and a status (RUNNING / COMPLETED / FAILED). FAILED operations are enriched with their error reason. Pass limit to cap the number of returned operations (newest first).",
+          "inputSchema": {
+            "properties": {
+              "api_instance_id": {
+                "default": "",
+                "description": "Numeric API Manager instance ID of the external gateway instance.",
+                "title": "Api Instance Id",
+                "type": "string"
+              },
+              "limit": {
+                "default": 0,
+                "description": "Max number of recent operations to return; 0 uses the service default (10). Capped at 50.",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "organization_id": {
+                "description": "Anypoint organization (business group) ID that owns the instance.",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "provider": {
+                "default": "",
+                "description": "External gateway provider: 'kong', 'apigee', or 'azure'. Required — reads native provider operations through the APIM Universal API.",
+                "title": "Provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id"
+            ],
+            "title": "list_instance_policy_operationsArguments",
+            "type": "object"
+          },
+          "name": "list_instance_policy_operations",
+          "title": "List Instance Policy Operations"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the secret references discovered (synced) by ONE specific vault integration (identified by integration_name or integration_id). Shows secret metadata (name, type, expiration) only — never values or internal group identifiers. Use list_secret_refs instead to list ALL secrets across every group in the environment.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "integration_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "UUID of the vault integration. Use integration_name instead when you only know the display name.",
+                "title": "Integration Id"
+              },
+              "integration_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the vault integration (as shown by onboard_vault). Provide this OR integration_id — not both.",
+                "title": "Integration Name"
+              },
+              "limit": {
+                "default": 50,
+                "description": "Maximum number of items to return in this page.",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Zero-based index of the first item to return (pagination).",
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "list_integration_secretsArguments",
+            "type": "object"
+          },
+          "name": "list_integration_secrets",
+          "title": "List Secrets Synced by One Integration"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List LLM models registered in the MuleSoft Platform for a given organization. Presents an interactive UI for browsing, filtering, and selecting LLMs. Paginated: pass offset/limit; if the response has has_more=true, request the next page with the returned next_offset.",
           "inputSchema": {
             "properties": {
               "category": {
@@ -3553,6 +6182,11 @@
                 "default": null,
                 "title": "Category"
               },
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
               "name": {
                 "anyOf": [
                   {
@@ -3564,6 +6198,11 @@
                 ],
                 "default": null,
                 "title": "Name"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
               },
               "organization_id": {
                 "anyOf": [
@@ -3613,6 +6252,11 @@
           "description": "List MCP servers registered in the MuleSoft Platform for a given organization. Presents an interactive UI for browsing, filtering, and selecting MCP servers.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 30,
+                "title": "Limit",
+                "type": "integer"
+              },
               "name": {
                 "anyOf": [
                   {
@@ -3624,6 +6268,11 @@
                 ],
                 "default": null,
                 "title": "Name"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
               },
               "organization_id": {
                 "title": "Organization Id",
@@ -3656,6 +6305,240 @@
           },
           "name": "list_mcp_servers",
           "title": "List MCP Servers"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the gateway targets a Model Proxy can be deployed onto, for one environment. This is the exact list the 'Create a Model Proxy' wizard shows, and the ONLY valid source of `target_id` for `create_model_proxy` (the server resolves the matching target name). Requires the environment's `id` from `list_omni_gateway_environments` — a display name such as 'Demo' fails as an authorization error that looks like a missing role but is not. Prefer a row with `deployable: true`; the wizard greys the others out. Do NOT use `list_omni_gateway_targets` for this — it reads a different Anypoint service whose ids the deploy call will not accept.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "description": "Anypoint environment ID — the opaque `id` from a `list_omni_gateway_environments` item, NOT the environment's display name. A name such as 'Demo' is rejected upstream as an authorization failure, which reads like a missing role but is not.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environment_id"
+            ],
+            "title": "list_model_proxy_gateway_targetsArguments",
+            "type": "object"
+          },
+          "name": "list_model_proxy_gateway_targets",
+          "title": "List Model Proxy Gateway Targets"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the LLM providers the 'Create a Model Proxy' wizard offers on step 2, plus each provider's current model dropdown (the same `GET .../modelproxies/models?provider=` call the UI makes per dropdown). Leave `provider` empty (default) to return all six wizard providers with their models — present every `id` together with that row's `models[].value` in the same reply. Call this before asking which provider or model to use; do not invent provider ids or public model names. Route `model` is the bare `models[].value` (e.g. gpt-4o, never a UUID or openai:gpt-4o). OpenAI, Gemini, Azure, and NVIDIA are dropdowns — an empty `models` list is not freeform. Only `freeformModel: true` (bedrock, anthropic) takes a typed model id. Pass `provider` only to refresh one dropdown. `defaultUrl` is the wizard's destination URL. Each row's `authFields` / `configFields` are the extra wizard inputs that appear after that provider is selected (Azure URL + optional deployment_id/api_version; Bedrock AWS keys + aws_region). This is NOT `list_llms` (existing proxies) and NOT `list_model_proxy_semantic_routing`.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "description": "Anypoint environment ID — the opaque `id` from `list_omni_gateway_environments`, not the display name.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "provider": {
+                "default": "",
+                "description": "Optional wizard provider id (openai, gemini, azure, bedrock, nvidia, anthropic). When set, returns only that dropdown — the same `?provider=` call the UI makes. Leave empty to list all six.",
+                "title": "Provider",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environment_id"
+            ],
+            "title": "list_model_proxy_providersArguments",
+            "type": "object"
+          },
+          "name": "list_model_proxy_providers",
+          "title": "List Model Proxy Providers"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Two-stage, paginated lookup matching the 'Create a Model Proxy' wizard. First call it without `semantic_service_config_id` to receive one page of semantic services; present their labels and stop for the user's choice. Use `pagination.next_offset` only when another page is needed. After selection, call it once with that returned row's exact `id` to receive only that service's topic page. Do not preload topics for every service and do not repeat the service-list call while the choice is unchanged. Each service has `serviceType` and `topicMode`. advanced / topicMode=select: pick existing topic `id`s as `prompt_topic_ids`; `usedForDenyList` rows are prompt-guard choices. basic / topicMode=create: the wizard's 'Create new topic' modal; no topic endpoint is called during lookup and an empty topic page is expected. Collect a topic name and sample utterances per route and pass `prompt_topic` `{name, utterances}` on `create_model_proxy` / `update_model_proxy`; those tools POST `/prompt-topics` like the UI. The selected-service result's `wizardFields` lists every other control on that wizard step: fallback card (`fallback_threshold` default 0.5, `fallback_route`, `fallback_model`), prompt guard (`deny_topic_ids_json` or `deny_topics_json` name+utterances; `denyTopics` is the usedForDenyList catalog), and semantic cache (`list_semantic_cache_configs` then `semantic_cache_config_id`). Never tell the user the environment has no topics so you cannot create the proxy. Pass a service `id` as `semantic_service_config_id`. Semantic routing needs at least two routes. This is NOT `list_semantic_cache_configs`.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "description": "Anypoint environment ID — the opaque `id` from `list_omni_gateway_environments`, not the display name.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "limit": {
+                "default": 10,
+                "description": "Maximum rows to return for this page (default 10, max 25).",
+                "maximum": 25,
+                "minimum": 1,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Zero-based offset. Pages semantic services when no service id is supplied; pages the selected service's topics otherwise.",
+                "minimum": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "semantic_service_config_id": {
+                "default": "",
+                "description": "Optional exact service `id` from a prior page returned by this tool. Leave empty to page through semantic services. After the user chooses a service, pass its id to page only that service's topics. Never pass a label, topic id, or proxy id.",
+                "title": "Semantic Service Config Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environment_id"
+            ],
+            "title": "list_model_proxy_semantic_routingArguments",
+            "type": "object"
+          },
+          "name": "list_model_proxy_semantic_routing",
+          "title": "List Model Proxy Semantic Routing"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the downloadable CSM v2 secret groups shown by the Model Proxy wizard's From Vault picker. Use only after the user chooses From Vault for a new or replaced route credential. Present group names, never ids, then stop and wait for the user's selection. After the user chooses a name, match it to one returned row and pass that row's id internally to list_model_proxy_vault_secrets. The response contains metadata only and never secret values. If no groups are returned, offer Dynamic credentials; never request a raw/static key.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "description": "Anypoint environment ID from list_omni_gateway_environments; never ask the user to provide an id",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environment_id"
+            ],
+            "title": "list_model_proxy_vault_secret_groupsArguments",
+            "type": "object"
+          },
+          "name": "list_model_proxy_vault_secret_groups",
+          "title": "List Model Proxy Vault Secret Groups"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the eligible Blob secrets in one group returned by list_model_proxy_vault_secret_groups. Pass the chosen row's id as secret_group_id internally. Present secret names, never ids or URNs, then stop and wait for the user's selection. After the user chooses, copy that row's id and its group id into the appropriate typed *_vault_ref route field; do not construct a URN and do not ask for secret values. Bedrock requires separate selections for access key id and secret access key, with an optional session-token selection.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "description": "Anypoint environment ID used for the active Model Proxy journey",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "secret_group_id": {
+                "description": "Internal id copied from list_model_proxy_vault_secret_groups; never ask the user to type it",
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                "title": "Secret Group Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "environment_id",
+              "secret_group_id"
+            ],
+            "title": "list_model_proxy_vault_secretsArguments",
+            "type": "object"
+          },
+          "name": "list_model_proxy_vault_secrets",
+          "title": "List Model Proxy Vault Secrets"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to read the user's currently configured API Manager alerts (notifications) so the agent can answer questions about alert coverage, redundancy, or staleness without navigating to the Notifications page. Returns one page of basic alerts with fields: id, name, conditionType, severity, target (api / instance / application), responseCode (when applicable), lastTriggered (ISO timestamp or null when never triggered), createdAt, updatedAt. Pagination via offset/limit (defaults: offset=0, limit=20, max=100). Use this for prompts like 'which alerts haven't triggered recently?', 'which alert conditions are redundant?', 'do I have alerts on production?', 'show me my notifications'. Example: list_notifications(organization_id=<organization_id>). Example: list_notifications(organization_id=<organization_id>, offset=20, limit=20).",
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "default": 20,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Organization Id"
+              }
+            },
+            "title": "list_notificationsArguments",
+            "type": "object"
+          },
+          "name": "list_notifications",
+          "title": "List Notifications"
         },
         {
           "annotations": {
@@ -3756,9 +6639,19 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "List gateways for the active provider. Today only MuleSoft is supported (Kong / Apigee are roadmap), so the tool defaults ``provider_id`` to ``provider-mulesoft`` and returns Omni Gateways without requiring ``select_active_provider`` to be called first. ``organization_id`` defaults to the caller's active Anypoint org. Both parameters are optional.",
+          "description": "List gateways for the active provider. Today only MuleSoft is supported (Kong / Apigee are roadmap), so the tool defaults ``provider_id`` to ``provider-mulesoft`` and returns Omni Gateways without requiring ``select_active_provider`` to be called first. ``organization_id`` defaults to the caller's active Anypoint org. Both parameters are optional. Paginated: pass offset/limit; if the response has has_more=true, request the next page with the returned next_offset.",
           "inputSchema": {
             "properties": {
+              "limit": {
+                "default": 50,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
               "organization_id": {
                 "anyOf": [
                   {
@@ -3816,27 +6709,25 @@
         {
           "annotations": {
             "destructiveHint": null,
-            "idempotentHint": true,
+            "idempotentHint": null,
             "openWorldHint": true,
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Authenticate with MuleSoft Platform. MUST be called before any other tool. Call WITHOUT arguments to display the interactive login panel where the user enters their credentials. Do NOT ask the user for username/password in the chat.",
+          "description": "Use this tool to read all configured scanners with their last-run timestamps so the agent can answer questions about scanner schedule, freshness, and run-history without navigating to the Scanners page. Returns one row per scanner with: id, name, provider, status, lastRun (ISO timestamp or null when never run), schedule (cron), and agentsFound (count from the most recent run).\n\nOptional filter: ``provider_id`` (case-insensitive substring match against the scanner's provider key/label) restricts the result to scanners for one provider — useful for prompts like 'which scanners for OpenAI haven't run recently'.\n\nUse this for prompts like 'which scanners haven't run recently?', 'what scanners do I have?', 'is the X scanner running on schedule?', 'show me my scan history'.\n\nExample: list_scanner_runs(organization_id=<organization_id>).\nExample: list_scanner_runs(organization_id=<organization_id>, provider_id='openai').",
           "inputSchema": {
             "properties": {
-              "password": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Password"
+              "limit": {
+                "default": 20,
+                "title": "Limit",
+                "type": "integer"
               },
-              "username": {
+              "offset": {
+                "default": 0,
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
                 "anyOf": [
                   {
                     "type": "string"
@@ -3846,37 +6737,400 @@
                   }
                 ],
                 "default": null,
-                "title": "Username"
+                "title": "Organization Id"
+              },
+              "provider_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Provider Id"
               }
             },
-            "title": "loginArguments",
+            "title": "list_scanner_runsArguments",
             "type": "object"
           },
-          "meta": {
-            "ui": {
-              "resourceUri": "ui://auth/login-v2.html"
-            },
-            "ui/resourceUri": "ui://auth/login-v2.html"
-          },
-          "name": "login",
-          "title": "Login to MuleSoft Platform"
+          "name": "list_scanner_runs",
+          "title": "List Scanner Runs"
         },
         {
           "annotations": {
             "destructiveHint": null,
-            "idempotentHint": true,
-            "openWorldHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List ALL secret references (names and types) across every secret group in an organization + environment. Returns metadata only — never secret values or internal storage identifiers. Supports pagination via offset/limit. USE THIS for 'list/show the secrets in my environment'. Use list_integration_secrets instead to list only the secrets synced by ONE vault integration; use search_secrets to find a secret by name; use check_secret to verify one exists.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "limit": {
+                "default": 50,
+                "description": "Maximum number of items to return in this page.",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Zero-based index of the first item to return (pagination).",
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "list_secret_refsArguments",
+            "type": "object"
+          },
+          "name": "list_secret_refs",
+          "title": "List All Secrets in Environment"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to list all semantic cache configurations for a given organization and environment. Returns config IDs, labels, embedding provider, and vector DB provider for each config. Use get_semantic_cache_config_detail to see full settings (threshold, TTL, etc.). Requires both organization_id and environment_id. Example: list_semantic_cache_configs(organization_id=<org_id>, environment_id=<env_id>).",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "environment_id"
+            ],
+            "title": "list_semantic_cache_configsArguments",
+            "type": "object"
+          },
+          "name": "list_semantic_cache_configs",
+          "title": "List Semantic Cache Configs"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Use this tool to read an organization's Anypoint **Teams** (the platform identity construct — NOT the Microsoft Teams messaging channel). Returns lightweight team rows so the agent can read the team tree or locate the root team (the team with no parent). Optional filters: `search` (by team name), `parent_team_id` (direct children of a team), and `limit`/`offset` pagination (default limit 50, max 200). Use for prompts like 'what teams exist in this org?', 'list all teams', 'find the root team', 'show the child teams of team X'. Example: list_teams(organization_id=<organization_id>). Example: list_teams(organization_id=<organization_id>, search=Payments).",
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "default": 50,
+                "description": "Maximum teams to return (1-200, default 50).",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Zero-based pagination offset (default 0).",
+                "title": "Offset",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization ID whose teams to list. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              },
+              "parent_team_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Restrict the result to the direct child teams of this team ID.",
+                "title": "Parent Team Id"
+              },
+              "search": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Filter to teams whose name matches this text.",
+                "title": "Search"
+              }
+            },
+            "title": "list_teamsArguments",
+            "type": "object"
+          },
+          "name": "list_teams",
+          "title": "List Teams"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "List the Universal (canonical) policy templates available to an organization. Each entry returns the template's 'configurationSchema' — a standard JSON Schema (type/properties/required/enum/const/minItems, incl. nested objects and arrays) describing the exact config fields to collect from the user before applying — plus which providers (mulesoft/anypoint, kong, apigee, azure, aws) each supports and the native policy name it becomes on each. Call this before 'apply_universal_policy' so you can render the config form from 'configurationSchema', present the right template name, and show provider coverage — all from one call; the values you gather go straight into apply_universal_policy's 'configuration' argument.",
+          "inputSchema": {
+            "properties": {
+              "organization_id": {
+                "default": "",
+                "description": "Anypoint organization id. Defaults to the session's current organization.",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "policy_name_hint": {
+                "default": "",
+                "description": "Optional case-insensitive substring filter matched against each policy's kebab ``name`` or its display ``label`` (e.g. 'rate' matches 'rate-limiting'). Leave empty to list every canonical policy template available to the organization.",
+                "title": "Policy Name Hint",
+                "type": "string"
+              }
+            },
+            "title": "list_universal_policiesArguments",
+            "type": "object"
+          },
+          "name": "list_universal_policies",
+          "title": "List Universal Policies"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
             "readOnlyHint": false,
             "title": null
           },
-          "description": "Clear the stored authentication token.",
+          "description": "Create, add, set up, connect, or register a new external vault provider integration (AWS Secrets Manager, Azure Key Vault, or HashiCorp Vault) using the managed raw-value flow — this is the tool for 'create an external vault for AWS Secrets Manager'. Common provider phrasings are normalized (e.g. 'aws', 'aws secret manager' -> aws_secrets_manager). Credentials are supplied as raw_secrets (the managed flow); credential_refs is NOT accepted here. Resolves the provider/auth-method auth schema and validates the supplied raw_secrets/connection_config against it, then connects to the vault and ABORTS if the connection fails — the integration is only created after a successful live connectivity test. The connection is considered successful ONLY if the vault is reachable AND the credential grants all required permissions (list, describe, get-value); a reachable vault whose credential is missing any of these is rejected and the response lists the missing permissions in 'missingPermissions' so the user knows exactly what to grant. Returns the created integration on success.",
           "inputSchema": {
-            "properties": {},
-            "title": "logoutArguments",
+            "properties": {
+              "auth_method": {
+                "default": "",
+                "description": "Authentication method for the provider, e.g. 'aws_static', 'aws_assume_role', 'aws_oidc', 'azure_sp_secret', 'azure_sp_certificate', 'hashicorp_approle', 'hashicorp_mtls'. Must be compatible with the provider (see describe_vault_auth_schema).",
+                "title": "Auth Method",
+                "type": "string"
+              },
+              "connection_config": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Non-secret connection configuration, keyed by the auth schema's config-field key (e.g. 'azure.spSecret.clientId', 'azure.spSecret.tenantId'). Provide the required config fields for the chosen provider/auth_method.",
+                "title": "Connection Config"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Optional human-readable description (max 512 chars).",
+                "title": "Description"
+              },
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "name": {
+                "default": "",
+                "description": "Display name for the integration (3-64 chars; letters, digits, spaces, hyphens, underscores). Must be unique per org+environment.",
+                "title": "Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "provider": {
+                "default": "",
+                "description": "Vault provider. Canonical values: 'aws_secrets_manager', 'azure_key_vault', 'hashicorp_vault'. Common phrasings are accepted and normalized (e.g. 'aws', 'aws secret manager' -> 'aws_secrets_manager'; 'azure' -> 'azure_key_vault'; 'hashicorp' -> 'hashicorp_vault'). Call describe_vault_auth_schema to confirm valid provider/auth_method pairings.",
+                "title": "Provider",
+                "type": "string"
+              },
+              "raw_secrets": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "DEFAULT / RECOMMENDED way to supply credentials: the raw secret credential VALUES for the managed flow, keyed by the auth schema's secret-field key (the field 'key' from describe_vault_auth_schema, e.g. 'azure.spSecret.clientSecret'). This is the credential input for onboarding a vault. Never echoed back. Provide exactly the required secret fields for the chosen provider/auth_method. Do NOT also send credential_refs — they are two different, mutually-exclusive flows.",
+                "title": "Raw Secrets"
+              },
+              "sync_interval_minutes": {
+                "default": 120,
+                "description": "How often (minutes) to re-sync secret metadata from the vault. Must be between 120 and 1440.",
+                "title": "Sync Interval Minutes",
+                "type": "integer"
+              },
+              "vault_url": {
+                "default": "",
+                "description": "Vault endpoint URL, e.g. 'https://secretsmanager.us-east-1.amazonaws.com' or 'https://my-vault.vault.azure.net'. Max 1024 chars.",
+                "title": "Vault Url",
+                "type": "string"
+              }
+            },
+            "title": "onboard_vaultArguments",
             "type": "object"
           },
-          "name": "logout",
-          "title": "Logout from MuleSoft Platform"
+          "name": "onboard_vault",
+          "title": "Create / Onboard Vault Integration"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Cross-environment policy diff for one API. Caller supplies a list of ``(instance_id, environment_id, environment_name)`` tuples (typically from ``read_app_view_state(scope='service_instances')``); the tool partitions them by environment, runs ``audit_api_policies`` against the production + sandbox samples, and returns the policy-name diff between the two environments. Use this for prompts like 'compare policy coverage between production and staging' (W-22750961 #72). Args: organization_id (required), asset_id (required), instances (required, list of {id, environment_id, environment_name}). Returns: ``{summary, by_environment: {env_name: {instance_count, sampled, policy_names}}, diff: {shared, only_in_<env_a>, only_in_<env_b>}}``.",
+          "inputSchema": {
+            "properties": {
+              "asset_id": {
+                "title": "Asset Id",
+                "type": "string"
+              },
+              "instances": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "title": "Instances"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "asset_id",
+              "instances"
+            ],
+            "title": "policy_coverage_summaryArguments",
+            "type": "object"
+          },
+          "name": "policy_coverage_summary",
+          "title": "Compare policy coverage across environments"
         },
         {
           "annotations": {
@@ -3958,7 +7212,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Load policy options for one asset instance. Returns only policies that are not already applied. Accepts api_instance_id (numeric) or asset_id (Exchange asset ID) — when asset_id is provided the numeric instance ID is resolved automatically. Pass policy_name_hint to filter the list to policies matching a name — use this when the user names a specific policy. After the user selects a policy from the selector UI, call get_policy_template_form with the same organization_id, environment_id, api_instance_id, plus the selected template_id/asset_id/group_id/asset_version/direction to open the policy form UI. Set provider to a non-MuleSoft platform (e.g. 'kong') and gateway_id to dispatch to that provider's policy backend instead of Anypoint API Manager.",
+          "description": "Load policy options for one asset instance. Returns only policies that are not already applied. Accepts api_instance_id (numeric) or asset_id (Exchange asset ID) — when asset_id is provided the numeric instance ID is resolved automatically. Pass policy_name_hint to filter the list to policies matching a name — use this when the user names a specific policy. After the user selects a policy from the selector UI, call get_policy_template_form with the same organization_id, environment_id, api_instance_id, plus the selected template_id/asset_id/group_id/asset_version/direction to open the policy form UI. For a non-MuleSoft external gateway (provider='kong'/'apigee'/'azure'), set provider and pass the numeric api_instance_id — the native policy catalog is read through the Anypoint API Manager Universal API (gateway_id is not used on this path). This routing is gated per organization; a closed gate returns a structured error.",
           "inputSchema": {
             "properties": {
               "api_instance_id": {
@@ -3971,6 +7225,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Numeric API Manager instance ID. Provide this or asset_id; when asset_id is given the numeric ID is resolved automatically.",
                 "title": "Api Instance Id"
               },
               "asset_id": {
@@ -3983,6 +7238,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Exchange asset ID of the API. Alternative to api_instance_id.",
                 "title": "Asset Id"
               },
               "environment_id": {
@@ -3995,6 +7251,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Anypoint environment ID. Optional on the external-gateway (Universal API) path, where api_instance_id alone identifies the instance.",
                 "title": "Environment Id"
               },
               "gateway_id": {
@@ -4007,9 +7264,11 @@
                   }
                 ],
                 "default": null,
+                "description": "Gateway ID. Not used on the external-gateway Universal API path.",
                 "title": "Gateway Id"
               },
               "organization_id": {
+                "description": "Anypoint organization (business group) ID that owns the instance.",
                 "title": "Organization Id",
                 "type": "string"
               },
@@ -4023,6 +7282,7 @@
                   }
                 ],
                 "default": null,
+                "description": "Filter the returned policies to those whose name matches this hint. Use when the user names a specific policy.",
                 "title": "Policy Name Hint"
               },
               "provider": {
@@ -4035,6 +7295,7 @@
                   }
                 ],
                 "default": null,
+                "description": "External gateway provider: 'kong', 'apigee', or 'azure'. Set for a non-MuleSoft gateway to read the native policy catalog through the APIM Universal API. Omit for MuleSoft.",
                 "title": "Provider"
               }
             },
@@ -4061,7 +7322,7 @@
             "readOnlyHint": false,
             "title": null
           },
-          "description": "Provision a composite MCP server on Omni Gateway from selected catalog systems. Returns a job_id — poll with get_provision_status until complete or failed. PRECONDITIONS: organization_id and environment_id must be UUIDs (call list_business_groups + list_environments first — do NOT pass friendly names like 'development'). target_id / target_name come from list_provider_gateways. Each servers[] entry needs assetId + tools[] from get_trusted_mcp_catalog (the catalog tools include the upstream config and credential schema). If any lookup returns no usable entry, STOP and ask the user — do not invent IDs.",
+          "description": "Provision a composite MCP server on Omni Gateway from selected catalog systems. Returns a job_id — poll with get_provision_status until complete or failed. PRECONDITIONS: organization_id and environment_id must be UUIDs (call list_business_groups + list_environments first — do NOT pass friendly names like 'development'). target_id / target_name come from list_provider_gateways. Each servers[] entry needs assetId + tools[] (tool names) from get_trusted_mcp_catalog; the upstream config and credential schema are resolved server-side from the assetId. For an org-owned Anypoint API (any assetId from this org's API catalog, not just get_trusted_mcp_catalog) you may instead pass a bare {assetId} or {assetId, tools} entry — the OpenAPI spec, per-operation tool schemas, and the upstream URL of one of its deployed instances are resolved server-side; tools is a list of \"METHOD:/path\" op keys (omit or leave empty to expose every operation). environment_id is the destination gateway environment, not a filter on the source instance: with one deployed instance it is used regardless of its own environment; with several, environment_id only disambiguates between them, and a still-ambiguous set is reported so you can pass servers[].upstream.url to pick one explicitly. If that assetId matches more than one API across this org's business groups, also pass groupId (and version, if needed) to disambiguate — the tool will report the candidates if you don't. If any lookup returns no usable entry, STOP and ask the user — do not invent IDs.",
           "inputSchema": {
             "properties": {
               "base_path": {
@@ -4115,16 +7376,43 @@
         {
           "annotations": {
             "destructiveHint": null,
-            "idempotentHint": false,
+            "idempotentHint": null,
+            "openWorldHint": false,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Read the frontend's current render state for the active thread. The frontend pushes its state on every navigation; this tool returns the latest snapshot for the requested scope. Use this INSTEAD of the legacy bridge tools (get_app_view_state, get_service_detail_state, get_instance_detail_state, get_notification_list_state, get_policy_form_state, get_policy_selector_state) — same data, no round-trip. scope values: 'app_view' (route + viewKind + entity ids + tabs), 'service_detail', 'instance_detail', 'service_governance', 'service_overview', 'service_instances', 'service_monitoring', 'service_listing', 'policy_form', 'policy_selector', 'notification_list', 'notification_create', 'notification_settings', 'cost_management'. Returns ``{has_state: bool, scope, payload, updated_at}``. When ``has_state`` is False, the page hasn't pushed that slice — fall back to a server-side data-fetch tool for the relevant entity. Example: read_app_view_state(scope='app_view').",
+          "inputSchema": {
+            "properties": {
+              "scope": {
+                "title": "Scope",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scope"
+            ],
+            "title": "read_app_view_stateArguments",
+            "type": "object"
+          },
+          "name": "read_app_view_state",
+          "title": "Read app view state"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": false,
             "title": null
           },
-          "description": "Resume a failed provisioning or update job from its last checkpoint. Only works on jobs with status 'failed' that have completed steps.",
+          "description": "Use this tool to change ONLY the display name of an Anypoint business group. Write operation. Renaming is the sole business-group attribute editable headlessly — for ANY other change (owner, quota/entitlements) or to delete a business group, tell the user to use the Anypoint Access Management UI. Resolves the business group from the session when `organization_id` is omitted. Use for prompts like 'rename my business group to Acme Corp'. Example: rename_business_group(organization_id=<id>, new_name=Acme).",
           "inputSchema": {
             "properties": {
-              "job_id": {
-                "title": "Job Id",
+              "new_name": {
+                "default": "",
+                "description": "New display name for the business group.",
+                "title": "New Name",
                 "type": "string"
               },
               "organization_id": {
@@ -4137,40 +7425,38 @@
                   }
                 ],
                 "default": null,
+                "description": "Business-group ID to rename. Resolves from the active session when omitted.",
                 "title": "Organization Id"
               }
             },
-            "required": [
-              "job_id"
-            ],
-            "title": "resume_provision_jobArguments",
+            "title": "rename_business_groupArguments",
             "type": "object"
           },
-          "name": "resume_provision_job",
-          "title": "Resume Provision Job"
+          "name": "rename_business_group",
+          "title": "Rename Business Group"
         },
         {
           "annotations": {
-            "destructiveHint": null,
-            "idempotentHint": null,
+            "destructiveHint": false,
+            "idempotentHint": true,
             "openWorldHint": true,
-            "readOnlyHint": true,
+            "readOnlyHint": false,
             "title": null
           },
-          "description": "Search portfolio assets using natural language semantic search. Use this when the user asks for assets related to a concept or use case, not just keyword matching. Examples: 'Find services for payment processing', 'Search for customer authentication services'. Returns asset names, descriptions, relevance scores, and types.",
+          "description": "Use this tool to change ONLY the display name of an Anypoint connected app. Write operation — it NEVER rotates the client secret. Renaming is the sole connected-app attribute editable headlessly; for any other change (scopes, grant types, secret reset) or to delete an app, tell the user to use the Anypoint UI. `client_id` is the connected app's client id (from `list_connected_apps`). Use for prompts like 'rename the CI/CD connected app to Deploy Bot'. Example: rename_connected_app(client_id=<id>, new_name=Deploy Bot).",
           "inputSchema": {
             "properties": {
-              "asset_type": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "default": null,
-                "title": "Asset Type"
+              "client_id": {
+                "default": "",
+                "description": "client id of the connected app to rename.",
+                "title": "Client Id",
+                "type": "string"
+              },
+              "new_name": {
+                "default": "",
+                "description": "New display name for the connected app.",
+                "title": "New Name",
+                "type": "string"
               },
               "organization_id": {
                 "anyOf": [
@@ -4182,26 +7468,58 @@
                   }
                 ],
                 "default": null,
+                "description": "Anypoint organization ID that owns the connected app. Resolves from the active session when omitted.",
                 "title": "Organization Id"
-              },
-              "query": {
-                "title": "Query",
-                "type": "string"
-              },
-              "rows": {
-                "default": 10,
-                "title": "Rows",
-                "type": "integer"
               }
             },
-            "required": [
-              "query"
-            ],
-            "title": "search_assets_semanticArguments",
+            "title": "rename_connected_appArguments",
             "type": "object"
           },
-          "name": "search_assets_semantic",
-          "title": "Semantic Search Portfolio Assets"
+          "name": "rename_connected_app",
+          "title": "Rename Connected App"
+        },
+        {
+          "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to change ONLY the name of an Anypoint environment. Write operation. Renaming is the sole environment attribute editable headlessly — the type (sandbox/production) is immutable, and for any other change or to delete an environment, tell the user to use the Anypoint UI. Resolves the org from the session when `organization_id` is omitted. Use for prompts like 'rename environment X to QA'. Example: rename_environment(environment_id=<id>, new_name=QA).",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "default": "",
+                "description": "environment id of the environment to rename.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "new_name": {
+                "default": "",
+                "description": "New name for the environment (alphanumeric, 2-65 characters).",
+                "title": "New Name",
+                "type": "string"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization / business-group ID that owns the environment. Resolves from the active session when omitted.",
+                "title": "Organization Id"
+              }
+            },
+            "title": "rename_environmentArguments",
+            "type": "object"
+          },
+          "name": "rename_environment",
+          "title": "Rename Environment"
         },
         {
           "annotations": {
@@ -4245,31 +7563,112 @@
           "title": "Search Global Content"
         },
         {
-          "description": "🔍 PRIMARY DISCOVERY TOOL - ALWAYS USE THIS FIRST when user wants to FIND/SEARCH/DISCOVER assets by what they DO or their capabilities.\n\nUSE THIS TOOL WHEN USER ASKS:\n- 'find [type] that can [action]' → e.g., 'find agents that can automate invoices', 'find APIs that handle payments'\n- 'search for [capability] [type]' → e.g., 'search for customer support agents', 'search for fraud detection APIs'\n- '[type] for [use case]' → e.g., 'agents for employee wellbeing', 'LLMs for code generation'\n- 'what [type] are available for [use case]' → e.g., 'what MCP servers are available for data transformation'\n- 'which [type] can [capability]' → e.g., 'which agents can automate approval', 'which LLMs generate SQL'\n- '[type] that [action]' → e.g., 'agents that automate workflows', 'APIs that detect fraud'\n\nEXAMPLES REQUIRING THIS TOOL:\n✓ 'find payment APIs' ← semantic match by purpose\n✓ 'search for customer support agents' ← capability-based discovery\n✓ 'agents for employee wellbeing' ← use case discovery\n✓ 'LLMs that can generate SQL queries' ← capability matching\n✓ 'APIs for fraud detection' ← functional discovery\n✓ 'what MCP servers handle data transformation' ← capability query\n✓ 'agents that automate invoice approval' ← workflow discovery\n\nASSET_TYPE PARAMETER:\nLeave empty (\"\") to search across ALL asset types — that is the right choice for most\nuser prompts ('find APIs that…' usually means 'find any matching asset, an API or otherwise').\nWhen you DO want to constrain, prefer a canonical Exchange type:\n  • API types: 'rest-api', 'http-api', 'graphql', 'soap-api', 'grpc-api', 'evented-api'\n  • AI types: 'agent', 'mcp', 'mcp-server', 'llm', 'model'\n  • Infra types: 'vector-database', 'gateway'\nFriendly aliases ('apis', 'agents', 'mcp-servers', 'llms') are also accepted and expand\nto the matching canonical set, so 'apis' searches all API subtypes.\n\nDO NOT USE fetch_services FOR DISCOVERY:\n❌ fetch_services only lists ALL assets without semantic/capability matching\n❌ fetch_services cannot find assets by what they DO\n✅ Use THIS tool (search_portfolio_services) for discovery by capability/use case\n✅ Only use fetch_services AFTER this tool, if you need additional metadata\n\nDO NOT USE THIS TOOL FOR:\n✗ Performance metrics (use fetch_monitoring_*)\n✗ Cost analysis (use fetch_cost_*)\n✗ Governance/policy data (use fetch_governance_*)\n✗ Listing all deployed instances (use fetch_services)\n✗ Documentation/how-to guides (use search_repository_knowledge)\n\nReturns: Semantically matched assets with names, descriptions, versions, and relevance scores.",
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Search MuleSoft Known Issues database by query, product, and status. Returns issue details with workarounds and status information.",
           "inputSchema": {
             "properties": {
-              "asset_type": {
-                "default": "",
-                "title": "Asset Type",
-                "type": "string"
-              },
-              "max_results": {
+              "limit": {
                 "default": 10,
-                "title": "Max Results",
+                "title": "Limit",
                 "type": "integer"
+              },
+              "product": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Product"
               },
               "query": {
                 "title": "Query",
                 "type": "string"
+              },
+              "status": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Status"
               }
             },
             "required": [
               "query"
             ],
-            "title": "search_portfolio_servicesArguments",
+            "title": "search_known_issuesArguments",
             "type": "object"
           },
-          "name": "search_portfolio_services"
+          "name": "search_known_issues",
+          "title": "Search Known Issues"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Search official MuleSoft product documentation to answer how-to questions, feature explanations, configuration guides, best practices, and version release notes. Use when the user asks HOW to do something, WHAT a MuleSoft product or concept is, or WHAT CHANGED in a specific version — not for live data about the user's org (use run_graphql_query or domain fetch tools for that). Supports optional version (e.g. '4.6') and product (e.g. 'API Manager') filters.",
+          "inputSchema": {
+            "properties": {
+              "limit": {
+                "default": 10,
+                "title": "Limit",
+                "type": "integer"
+              },
+              "product": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Product"
+              },
+              "query": {
+                "title": "Query",
+                "type": "string"
+              },
+              "version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Version"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "title": "search_mulesoft_documentationArguments",
+            "type": "object"
+          },
+          "name": "search_mulesoft_documentation",
+          "title": "Search MuleSoft Documentation"
         },
         {
           "annotations": {
@@ -4279,7 +7678,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Use this tool for repository-grounded conceptual questions. It searches a curated static corpus (policy/governance/security docs and rulesets) and returns cited snippets. Prefer this tool for prompts like 'what policies can I use to secure access to my APIs' or 'where is X documented'. Returns structured matches with sourcePath, snippet, lexical/semantic scores, and metadata. This tool is read-only and does not modify repository files. Use top_k to bound result size and source_path_prefixes for targeted lookup.",
+          "description": "Search a curated static corpus of MuleSoft governance rulesets and ruleset YAML files. Use ONLY for ruleset-grounded questions: 'find a ruleset for API versioning', 'what does the anypoint-best-practices ruleset check', 'which rulesets enforce security headers'. Returns matches with sourcePath, rulesetKey (use with fetch_ruleset_details), snippet, and scores. Do NOT use for product how-to questions, feature explanations, or release notes — use search_mulesoft_documentation for those.",
           "inputSchema": {
             "properties": {
               "lexical_top_n": {
@@ -4323,6 +7722,75 @@
           },
           "name": "search_repository_knowledge",
           "title": "Search Repository Knowledge"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": true,
+            "title": null
+          },
+          "description": "Search for secrets by PARTIAL name across ALL secret groups in an environment (requires at least 3 characters). Returns matching secret metadata (name, type, group name, expiration). USE THIS to find candidates when you know only part of a secret's name. Use check_secret instead to confirm one exact secret exists, or list_secret_refs to enumerate every secret.",
+          "inputSchema": {
+            "properties": {
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "limit": {
+                "default": 25,
+                "description": "Maximum number of results to return (default 25, max 100). If more results exist than a single page, multiple pages are fetched automatically.",
+                "title": "Limit",
+                "type": "integer"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "search_term": {
+                "default": "",
+                "description": "The secret name (or partial name) to search for. Must be at least 3 characters. Searches across ALL secret groups in the environment.",
+                "title": "Search Term",
+                "type": "string"
+              }
+            },
+            "title": "search_secretsArguments",
+            "type": "object"
+          },
+          "name": "search_secrets",
+          "title": "Search Secrets by Name"
         },
         {
           "annotations": {
@@ -4434,7 +7902,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Pick the active gateway provider context for Omni Gateway tools (e.g. list_provider_gateways and the Omni Gateway wizard). Two-phase: call with no provider_id to present the available providers, then call again with the selected provider_id to commit. Do NOT use this tool for managing MuleSoft / Anypoint account credentials, logging in, logging out, or switching Anypoint user accounts — those flows are handled by the Anypoint connected-app session and are not user-driven in Omni; under the connected-app setup users do not need to log in or out.",
+          "description": "Pick the active gateway provider context for Omni Gateway tools (e.g. list_provider_gateways and the Omni Gateway wizard). Two-phase: call with no provider_id to present the available providers, then call again with the selected provider_id to commit. Do NOT use this tool for managing MuleSoft / Anypoint account credentials, logging in, logging out, or switching Anypoint user accounts — those flows are handled by the Anypoint connected-app session and are not user-driven in the MuleSoft Platform; under the connected-app setup users do not need to log in or out.",
           "inputSchema": {
             "properties": {
               "provider_id": {
@@ -4547,6 +8015,172 @@
         {
           "annotations": {
             "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Validate vault connectivity. Two modes: (1) Pre-create — provide provider, auth_method, vault_url, and credentials to validate BEFORE saving. Supply raw_secrets for the managed flow (the default) OR credential_refs for the reference flow; the mode is inferred from which one you send — do not send both. (2) Post-create — provide only integration_name or integration_id to validate an already-saved integration against its stored credentials (works for both managed and reference integrations). Returns connected=true ONLY when the vault is reachable AND the credential grants all required permissions (list, describe, get-value). When the vault is reachable but under-permissioned, connected=false, reachable=true, and 'missingPermissions' lists what must be granted before onboard_vault / edit_integration will save.",
+          "inputSchema": {
+            "properties": {
+              "auth_method": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Authentication method for the provider, e.g. 'aws_static', 'aws_assume_role', 'aws_oidc', 'azure_sp_secret', 'azure_sp_certificate', 'hashicorp_approle', 'hashicorp_mtls'. Must be compatible with the provider (see describe_vault_auth_schema).",
+                "title": "Auth Method"
+              },
+              "connection_config": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Non-secret connection configuration, keyed by the auth schema's config-field key (e.g. 'azure.spSecret.clientId', 'azure.spSecret.tenantId'). Provide the required config fields for the chosen provider/auth_method.",
+                "title": "Connection Config"
+              },
+              "credential_refs": {
+                "anyOf": [
+                  {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "ADVANCED — most callers should use raw_secrets instead. Credential references for the REFERENCE-based flow (pointers to secrets already stored in Anypoint, NOT raw values): an object with 'secretRefs' (map of field key -> {secretGroupId, secretId, secretType}) and optional 'connectionConfig'. onboard_vault does NOT accept this — it is only for editing or connectivity-testing an existing reference-based integration. Do NOT combine with raw_secrets.",
+                "title": "Credential Refs"
+              },
+              "environment_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Target Anypoint environment UUID. Required unless environment_name is provided instead.",
+                "title": "Environment Id"
+              },
+              "environment_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the target environment (e.g. 'Production', 'Sandbox'). Provide this OR environment_id — not both. Resolved case-insensitively.",
+                "title": "Environment Name"
+              },
+              "integration_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Set for a POST-CREATE test of an already-saved integration (tests its stored credentials, no other fields needed). Omit for a PRE-CREATE test, and instead supply provider/auth_method/vault_url plus credentials. Use integration_name as an alternative when you only know the display name.",
+                "title": "Integration Id"
+              },
+              "integration_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Human-readable name of the vault integration (as shown by onboard_vault). Provide this OR integration_id — not both.",
+                "title": "Integration Name"
+              },
+              "organization_id": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Anypoint organization (or business-group) UUID. Optional — when omitted the caller's authenticated org is used. A supplied value must be the caller's org or a business group they belong to.",
+                "title": "Organization Id"
+              },
+              "provider": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Vault provider. Canonical values: 'aws_secrets_manager', 'azure_key_vault', 'hashicorp_vault'. Common phrasings are accepted and normalized (e.g. 'aws', 'aws secret manager' -> 'aws_secrets_manager'; 'azure' -> 'azure_key_vault'; 'hashicorp' -> 'hashicorp_vault'). Call describe_vault_auth_schema to confirm valid provider/auth_method pairings.",
+                "title": "Provider"
+              },
+              "raw_secrets": {
+                "anyOf": [
+                  {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "DEFAULT / RECOMMENDED way to supply credentials: the raw secret credential VALUES for the managed flow, keyed by the auth schema's secret-field key (the field 'key' from describe_vault_auth_schema, e.g. 'azure.spSecret.clientSecret'). This is the credential input for onboarding a vault. Never echoed back. Provide exactly the required secret fields for the chosen provider/auth_method. Do NOT also send credential_refs — they are two different, mutually-exclusive flows.",
+                "title": "Raw Secrets"
+              },
+              "vault_url": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Vault endpoint URL, e.g. 'https://secretsmanager.us-east-1.amazonaws.com' or 'https://my-vault.vault.azure.net'. Max 1024 chars.",
+                "title": "Vault Url"
+              }
+            },
+            "title": "test_integration_connectionArguments",
+            "type": "object"
+          },
+          "name": "test_integration_connection",
+          "title": "Validate Integration Connection"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
             "idempotentHint": true,
             "openWorldHint": null,
             "readOnlyHint": true,
@@ -4602,7 +8236,7 @@
             "readOnlyHint": false,
             "title": null
           },
-          "description": "Update an existing catalog-managed MCP server. Diffs new configuration against deployed state and applies incremental changes. Returns a job_id for status polling. PRECONDITIONS: requires the same UUID-based IDs as provision_mcp_server (organization_id, environment_id, target_id all UUIDs from list_* tools), plus the deployed state from get_mcp_server_state. Never pass friendly names — every ID must be a UUID or a catalog-supplied identifier.",
+          "description": "Update an existing catalog-managed MCP server. Diffs new configuration against deployed state and applies incremental changes. Returns a job_id for status polling. PRECONDITIONS: requires the same UUID-based IDs as provision_mcp_server (organization_id, environment_id, target_id all UUIDs from list_* tools), plus the deployed state from get_mcp_server_state. Never pass friendly names — every ID must be a UUID or a catalog-supplied identifier. servers[] entries follow the same shape as provision_mcp_server, including the bare {assetId} / {assetId, tools} form for org-owned Anypoint APIs and the groupId/version disambiguation for an assetId shared across business groups.",
           "inputSchema": {
             "properties": {
               "api_id": {
@@ -4688,6 +8322,482 @@
           },
           "name": "update_mcp_server",
           "title": "Update MCP Server"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Update routes and routing config on an existing Model Proxy — the same PATCH the detail-page Save uses (xapi /apis/{id}, top-level upstreams + id-refs). Pass organization_id, the typed routes list, and asset_id (or api_instance_id). Omit environment_id.\nMANDATORY, EVERY call, NO exceptions: call `get_llm_proxy_routes` IN THIS SAME TURN, immediately before this tool, and build `routes` list by taking its full route list and only applying the user's requested change on top — even if you (or an earlier turn in this conversation) already fetched the routes before. This tool REPLACES the whole route list and every semantic field wholesale: a route, `upstream_ids`, `prompt_topic_ids`, fallback_*, deny_topic_ids, or semantic_cache_config_id you don't resend is silently dropped from the proxy — not left unchanged. Do not rely on routes you constructed in an earlier turn or reconstructed from memory/chat history: multi-turn conversations lose context (older tool results get pruned), and a stale or partial re-send has broken production proxies by omitting `prompt_topic_ids`/`upstream_ids` on routes the user wasn't editing, which Anypoint then rejects or silently detaches. For every route the user is NOT changing this turn: carry over its `upstream_ids` and, on semantic proxies, its `prompt_topic_ids` verbatim from the fresh `get_llm_proxy_routes` read — do not omit them just because the user didn't mention that route. Do NOT ask the user to retype a credential for a kept route — copy its upstream_ids and omit selector fields so the stored key is reused (same as the UI leaving the key blank). Only new routes need provider + model + upstream_url plus an explicit credential_source chosen by the user. Dynamic uses the selector field(s); From Vault uses selections from the two Model Proxy vault lookup tools. The backend constructs the wire credential shape; literal API/AWS keys and caller-built URNs are rejected. Semantic updates follow the same topicMode as create: select existing `prompt_topic_ids` on advanced services, or `prompt_topic` `{name, utterances}` on basic (created on save). Resend fallback_*, deny_topic_ids_json / deny_topics_json, and semantic_cache_config_id from the fresh `get_llm_proxy_routes` read so those wizard fields are not cleared. REPLACES the full list: omit a current route to remove it.",
+          "inputSchema": {
+            "$defs": {
+              "LlmProxyUpdateRouteInput": {
+                "additionalProperties": false,
+                "description": "One update route; stored credentials are reusable only by upstream id.",
+                "properties": {
+                  "api_key_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "DataWeave expression locating the API key in the inbound request, for example #[attributes.headers['X-API-KEY']]. Required for a new non-Bedrock route; an existing update route may omit it when upstream_ids are preserved.",
+                    "title": "Api Key Selector"
+                  },
+                  "api_key_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "OpenAI/Gemini/Azure/NVIDIA/Anthropic only: selected API-key secret from the Model Proxy vault lookup tools"
+                  },
+                  "api_version": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Azure OpenAI API version (optional in the wizard)",
+                    "title": "Api Version"
+                  },
+                  "aws_access_key_id_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: DataWeave expression locating the AWS access key id; required with the secret selector on a new route",
+                    "title": "Aws Access Key Id Selector"
+                  },
+                  "aws_access_key_id_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: selected AWS access-key-id secret"
+                  },
+                  "aws_region": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock AWS region; defaults to us-east-1",
+                    "title": "Aws Region"
+                  },
+                  "aws_secret_access_key_selector": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: DataWeave expression locating the AWS secret access key; required with the access-key selector on a new route",
+                    "title": "Aws Secret Access Key Selector"
+                  },
+                  "aws_secret_access_key_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: selected AWS secret-access-key secret"
+                  },
+                  "aws_session_token_vault_ref": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/VaultSecretRefInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Bedrock only: optional selected AWS session-token secret"
+                  },
+                  "credential_source": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "dataweave",
+                          "from_vault"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Required for a new route: dataweave or from_vault. Existing update routes may omit it when upstream_ids are preserved. Never use static keys.",
+                    "title": "Credential Source"
+                  },
+                  "deployment_id": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Azure OpenAI deployment id (optional in the wizard)",
+                    "title": "Deployment Id"
+                  },
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Optional route label; defaults positionally to Route A, Route B, and so on",
+                    "title": "Label"
+                  },
+                  "model": {
+                    "description": "Bare model value returned for that provider; never a catalog UUID",
+                    "minLength": 1,
+                    "title": "Model",
+                    "type": "string"
+                  },
+                  "prompt_topic": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/$defs/PromptTopicInput"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Basic semantic service: topic to create and assign to this route"
+                  },
+                  "prompt_topic_ids": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Advanced semantic service: existing topic ids assigned to this route",
+                    "title": "Prompt Topic Ids"
+                  },
+                  "provider": {
+                    "description": "Provider id returned by list_model_proxy_providers",
+                    "enum": [
+                      "openai",
+                      "gemini",
+                      "azure",
+                      "bedrock",
+                      "nvidia",
+                      "anthropic"
+                    ],
+                    "title": "Provider",
+                    "type": "string"
+                  },
+                  "rule_headers": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Optional request-routing headers; never put credentials here",
+                    "title": "Rule Headers"
+                  },
+                  "upstream_ids": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null,
+                    "description": "Existing upstream ids copied verbatim from get_llm_proxy_routes. Omit only for a new route, which requires dynamic selector fields.",
+                    "title": "Upstream Ids"
+                  },
+                  "upstream_url": {
+                    "description": "Destination URL; use the provider's defaultUrl unless the wizard requires one",
+                    "minLength": 1,
+                    "title": "Upstream Url",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "provider",
+                  "model",
+                  "upstream_url"
+                ],
+                "title": "LlmProxyUpdateRouteInput",
+                "type": "object"
+              },
+              "PromptTopicInput": {
+                "additionalProperties": false,
+                "description": "Inline topic authored by the basic semantic-routing wizard.",
+                "properties": {
+                  "name": {
+                    "description": "Prompt-topic display name",
+                    "minLength": 1,
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "utterances": {
+                    "description": "Representative prompts, separated by newlines",
+                    "minLength": 1,
+                    "title": "Utterances",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "utterances"
+                ],
+                "title": "PromptTopicInput",
+                "type": "object"
+              },
+              "VaultSecretRefInput": {
+                "additionalProperties": false,
+                "description": "Opaque CSM selection returned by the Model Proxy vault lookup tools.",
+                "properties": {
+                  "secret_group_id": {
+                    "description": "Internal group id copied from list_model_proxy_vault_secret_groups; never ask the user to type it",
+                    "title": "Secret Group Id",
+                    "type": "string"
+                  },
+                  "secret_id": {
+                    "description": "Internal secret id copied from list_model_proxy_vault_secrets; never ask the user to type it",
+                    "title": "Secret Id",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secret_group_id",
+                  "secret_id"
+                ],
+                "title": "VaultSecretRefInput",
+                "type": "object"
+              }
+            },
+            "properties": {
+              "api_instance_id": {
+                "default": "",
+                "description": "API Manager instance ID (preferred when known)",
+                "title": "Api Instance Id",
+                "type": "string"
+              },
+              "asset_id": {
+                "default": "",
+                "description": "Exchange asset ID; resolved when api_instance_id is empty",
+                "title": "Asset Id",
+                "type": "string"
+              },
+              "deny_topic_ids_json": {
+                "default": "",
+                "description": "Optional JSON array or comma list of prompt-guard topic ids (wizard Advanced options deny list). Advanced services: pick unused catalog ids from list_model_proxy_semantic_routing denyTopics.",
+                "title": "Deny Topic Ids Json",
+                "type": "string"
+              },
+              "deny_topics_json": {
+                "default": "",
+                "description": "Optional JSON array of {name, utterances} prompt-guard topics to create on save (wizard prompt-guard modal, usedForDenyList). Use on basic semantic services the same way as prompt_topic.",
+                "title": "Deny Topics Json",
+                "type": "string"
+              },
+              "environment_id": {
+                "default": "",
+                "description": "Optional. The proxy's own environment `id` from `list_llms`. Do NOT reuse a create-flow env from `list_omni_gateway_environments`. Prefer omitting this and passing `asset_id`.",
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "fallback_model": {
+                "default": "",
+                "description": "Optional fallback model",
+                "title": "Fallback Model",
+                "type": "string"
+              },
+              "fallback_route": {
+                "default": "",
+                "description": "Optional. Must equal one route's exact `label` from the route list — or, if that route left `label` unset, the positional default 'Route A' / 'Route B' / 'Route C' (by index). NOT a provider name or semantic topic name — the gateway resolves this against route labels, not providers or topics.",
+                "title": "Fallback Route",
+                "type": "string"
+              },
+              "fallback_threshold": {
+                "default": -1.0,
+                "description": "Optional semantic fallback threshold; use -1 to omit",
+                "title": "Fallback Threshold",
+                "type": "number"
+              },
+              "organization_id": {
+                "description": "Anypoint organization ID",
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "routes": {
+                "description": "Complete replacement route list, copied from a fresh get_llm_proxy_routes result and modified only as requested. Each route uses direct typed fields rather than encoded JSON. Keep upstream_ids on existing routes so stored credentials are reused. New routes require credential_source=dataweave with the provider's selector field(s), or credential_source=from_vault with selections from the Model Proxy vault lookup tools. The server constructs the wire credential shape; literal API/AWS keys and caller-built URNs are not accepted.",
+                "items": {
+                  "$ref": "#/$defs/LlmProxyUpdateRouteInput"
+                },
+                "maxItems": 50,
+                "minItems": 1,
+                "title": "Routes",
+                "type": "array"
+              },
+              "routing_strategy": {
+                "default": "",
+                "description": "model-based or semantic. Omit on update to keep the proxy's current routing; sending model-based resets semantic config.",
+                "title": "Routing Strategy",
+                "type": "string"
+              },
+              "semantic_cache_config_id": {
+                "default": "",
+                "description": "Optional semantic cache config ID",
+                "title": "Semantic Cache Config Id",
+                "type": "string"
+              },
+              "semantic_service_config_id": {
+                "default": "",
+                "description": "Required when routing_strategy=semantic: a service `id` from `list_model_proxy_semantic_routing`. Use that row's topicMode: select = prompt_topic_ids; create = prompt_topic {name, utterances} on each route. Leave empty for model-based.",
+                "title": "Semantic Service Config Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "organization_id",
+              "routes"
+            ],
+            "title": "update_model_proxyArguments",
+            "type": "object"
+          },
+          "name": "update_model_proxy",
+          "title": "Update Model Proxy"
+        },
+        {
+          "annotations": {
+            "destructiveHint": null,
+            "idempotentHint": null,
+            "openWorldHint": true,
+            "readOnlyHint": false,
+            "title": null
+          },
+          "description": "Use this tool to update a semantic cache configuration. Supports updating TTL (in seconds), similarity threshold (0.0 to 1.0), and LLM-based cache eligibility (enabled/disabled). Requires organization_id, environment_id, config_id, and at least one field to update. config_id accepts either the UUID or the config label. Example: update_semantic_cache_config(organization_id=<org_id>, environment_id=<env_id>, config_id='semantic-cache-16', ttl=10). Do not use it for Model Proxy routes, providers, models, routing strategies, or fallback changes. Obtain all values from the user request or a preceding semantic-cache lookup; never infer values from examples.",
+          "inputSchema": {
+            "properties": {
+              "config_id": {
+                "title": "Config Id",
+                "type": "string"
+              },
+              "environment_id": {
+                "title": "Environment Id",
+                "type": "string"
+              },
+              "llm_eligibility_enabled": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Llm Eligibility Enabled"
+              },
+              "organization_id": {
+                "title": "Organization Id",
+                "type": "string"
+              },
+              "similarity_threshold": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Similarity Threshold"
+              },
+              "ttl": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Ttl"
+              }
+            },
+            "required": [
+              "organization_id",
+              "environment_id",
+              "config_id"
+            ],
+            "title": "update_semantic_cache_configArguments",
+            "type": "object"
+          },
+          "name": "update_semantic_cache_config",
+          "title": "Update Semantic Cache Config"
         },
         {
           "annotations": {
@@ -4920,7 +9030,7 @@
             "readOnlyHint": true,
             "title": null
           },
-          "description": "Show the applied policies for one API instance with the same grouping UI as the web app.",
+          "description": "Show the applied policies for one API instance, MuleSoft-hosted or external. A MuleSoft (Flex Gateway) instance is read from Anypoint API Manager with the same grouping UI as the web app; an EXTERNAL gateway instance (Kong / Apigee / Azure / AWS) has its native applied policies read through the Anypoint API Manager Universal API (gated per organization). Provider is deduced from the instance; pass provider only to force it. To CHANGE an external policy, use edit_applied_policy with the policyId listed here.",
           "inputSchema": {
             "properties": {
               "api_version": {
@@ -4951,6 +9061,18 @@
                 "default": null,
                 "title": "Asset Version"
               },
+              "environment": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "title": "Environment"
+              },
               "instance": {
                 "anyOf": [
                   {
@@ -4978,6 +9100,12 @@
               },
               "organization_id": {
                 "title": "Organization Id",
+                "type": "string"
+              },
+              "provider": {
+                "default": "",
+                "description": "Optional gateway provider of the instance: 'kong', 'apigee', 'azure', or 'aws' for an external gateway, or 'mulesoft' (default). Leave empty to deduce it from the instance. For an external provider the native applied policies (with each policy's policyId, current configurationData, readOnly flag, and Exchange coordinates for edit_applied_policy) are read through the Anypoint API Manager Universal API; this routing is gated per organization.",
+                "title": "Provider",
                 "type": "string"
               }
             },
@@ -5370,8 +9498,8 @@
         }
       ],
       "totals": {
-        "resources": 30,
-        "tools": 68
+        "resources": 29,
+        "tools": 120
       }
     }
   },


### PR DESCRIPTION
## Summary
- Regenerates `mcps/mulesoft-platform/server.json` from the live Omni MCP server so the dev-portal catalog matches production tools.
- Publishes the Universal policy surface the skill in W-23941113 needs: `list_universal_policies`, `apply_universal_policy`, `get_policy_operation_status`, plus native `edit_applied_policy` / `list_instance_policy_operations` and `find_assets` with `include_applied_policies`.
- Bumps the Exchange asset to `2.5.0`, points `exchange.json` `main` at `server.json`, and enriches `instance_ids` / `policy_id` for the portal try-it console.

## Test plan
- [ ] `python3 scripts/build/validate_mcp_server.py` passes (already green locally)
- [ ] Portal MCP detail page for MuleSoft Platform lists the new policy tools
- [ ] `find_assets` schema shows `include_applied_policies` and `policy_name_filter`
- [ ] `apply_universal_policy` / `get_policy_operation_status` / `edit_applied_policy` appear and are invokable in try-it