### PR TITLE
@W-23941113: add apply-universal-policy skill

### DIFF
--- a/skills/apply-native-policy-to-instance/SKILL.md
+++ b/skills/apply-native-policy-to-instance/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: apply-native-policy-to-instance
+description: |
+  Apply one provider-native policy to a SINGLE already-chosen API instance
+  (Kong plugin, Apigee template, Azure policy, or one MuleSoft/Anypoint
+  instance) via the MuleSoft Platform MCP Server. Use when the user has one
+  instance in context and wants a native plugin — "add ip-restriction on this
+  Kong service", "apply that Apigee quota to prod", "rate limiting on this API
+  Manager instance". DO NOT TRIGGER for a Universal/canonical policy across
+  many instances or providers — use skill apply-universal-policy. DO NOT
+  TRIGGER to remove, detach, enable, or disable a policy.
+license: Apache-2.0
+compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with prepare_policy_creation, get_policy_template_form, apply_policy_to_instance. If those tools are missing, stop.
+metadata:
+  author: mulesoft-omni
+  version: "1.0.0"
+---
+
+# Apply Native Policy to an Instance
+
+Apply one native policy to one instance: pick the instance, load the
+provider catalog, collect configuration once, apply, and wait until it
+has actually finished.
+
+## When to Use This Skill
+
+**Use this skill when the user asks to:**
+
+- "Add ip-restriction to this Kong instance"
+- "Apply quota to that Apigee proxy"
+- "Put JWT validation on this API Manager instance"
+- Apply a **native** plugin/template to **one** already-identified instance
+
+**Trigger keywords:** this instance · this Kong service · this Apigee
+proxy · native policy · Kong plugin · apply to this API.
+
+**Do NOT use this skill when:**
+
+- They want the **same canonical policy on many instances / providers**
+  → **skill apply-universal-policy** (`apply_universal_policy`)
+- They want to **audit or edit** an already-applied policy → **skill apply-universal-policy**
+  (Audit / Edit paths)
+- They are driving **Anypoint REST** (OpenAPI `urn:api:*`), not MCP →
+  **skill apply-policy-to-api-instance**
+- They need to **create** the instance first → **skill secure-api**
+- They want to **remove / disable** a policy — say so and stop
+
+## Prerequisites
+
+Connected to `urn:mcp:mulesoft-platform`. Probe with
+`prepare_policy_creation` for the target instance. If the tool is missing,
+stop. On 403 / gate-closed (`enabled: false`), say they are not entitled
+and stop — never silently switch provider.
+
+## Reference files
+
+- **`references/native-apply.md`** — provider routing, required arguments,
+  and how to wait for completion. Read it before the apply call.
+
+## Workflow
+
+### Rules that always apply
+
+1. **One instance.** If more than one instance matches, ask which one.
+   Do not silently apply to a set — that is skill apply-universal-policy.
+2. **Native catalog, not Universal.** `prepare_policy_creation` lists
+   plugins/templates for **this** provider. Never send a Kong plugin name
+   to `apply_universal_policy`.
+3. **Confirm before acting.** Show instance + native policy name + schema,
+   then wait for an explicit yes.
+4. **One-shot config.** Show the schema table (required-only when it is
+   longer than about 12 flattened rows, disclosing hidden optionals and
+   offering to expand — same rule as skill apply-universal-policy). Collect
+   the visible fields in one reply. Do not invent optionals.
+5. **Wait for completion.** External apply `httpStatus` 202 /
+   `operationStatus=accepted` is not success. Poll
+   `list_instance_policy_operations`. MuleSoft apply is typically
+   synchronous (2xx without `operationStatus`).
+
+### Step 1: Identify the instance
+
+If the user already named an instance, use that `api_instance_id` (and
+`environment_id` for MuleSoft). Otherwise `find_assets` (`asset_type=api`,
+`user_query` verbatim) and pick **one**. If several remain, list them
+(API name · instance · environment · provider) and wait.
+
+Resolve `provider`: `kong` / `apigee` / `azure` for external; omit (or
+`mulesoft`) for Anypoint. Do not guess.
+
+### Step 2: List native policies that are not yet applied
+
+Call `prepare_policy_creation` with `organization_id`, `api_instance_id`,
+`provider` (external), and `policy_name_hint` when they named a policy.
+MuleSoft also needs `environment_id`.
+
+If more than one template matches the hint, list `name`s and ask. If
+none match, say so and stop.
+
+### Step 3: Load the schema and collect configuration
+
+Call `get_policy_template_form` with the selected template's Exchange
+coordinates (`group_id`, `asset_id`, `asset_version` — required on the
+external path) plus `provider` / `environment_id` as in Step 2.
+
+Present the schema table. **[GATE] Wait for the whole config in one
+reply, then for okay to apply.**
+
+### Step 4: Apply once
+
+Call `apply_policy_to_instance` **once** with:
+
+- `api_instance_id`
+- `configuration_data` — the collected object
+- `asset.{group_id,asset_id,asset_version}` from Step 2 (required external)
+- `provider` for Kong / Apigee / Azure
+- `environment_id` for MuleSoft
+- `injection_point` only if the template requires it and the user set it
+
+Do not loop this tool. Do not call `apply_universal_policy`.
+
+### Step 5: Wait until it is actually done
+
+See `references/native-apply.md`. Report the native policy name → this
+API instance (environment / provider). On failure, say whether it is
+retryable when `error.retryable` is present.
+
+## Troubleshooting
+
+**Tools missing:** the Platform MCP catalog on this host is stale. Stop.
+Do not fall back to Anypoint REST unless the user is on
+skill apply-policy-to-api-instance.
+
+**Gate closed / 403:** say they are not entitled for that provider. Stop.
+
+**More than one instance:** ask. Do not fan out.
+
+**User named a Universal/canonical template for many APIs:** switch to
+skill apply-universal-policy.
+
+## Related Skills
+
+- **skill apply-universal-policy**: one canonical policy across many
+  instances or providers; also audit/edit of already-applied policies.
+- **skill apply-policy-to-api-instance**: same job over Anypoint REST
+  (`urn:api:*`), not MCP.
+- **skill secure-api**: create/deploy the instance first.

--- a/skills/apply-native-policy-to-instance/SKILL.md
+++ b/skills/apply-native-policy-to-instance/SKILL.md
@@ -1,45 +1,47 @@
 ---
 name: apply-native-policy-to-instance
 description: |
-  Apply one provider-native policy to a SINGLE already-chosen API instance
-  (Kong plugin, Apigee template, Azure policy, or one MuleSoft/Anypoint
-  instance) via the MuleSoft Platform MCP Server. Use when the user has one
-  instance in context and wants a native plugin — "add ip-restriction on this
-  Kong service", "apply that Apigee quota to prod", "rate limiting on this API
-  Manager instance". DO NOT TRIGGER for a Universal/canonical policy across
-  many instances or providers — use skill apply-universal-policy. DO NOT
-  TRIGGER to remove, detach, enable, or disable a policy.
+  Apply, list, or edit provider-native policies on API instances (Kong plugin,
+  Apigee template, Azure policy, or MuleSoft/Anypoint) via the MuleSoft
+  Platform MCP Server. TRIGGER when: the user asks what protection they have
+  on a provider's APIs ("what protection do I have for my Apigee APIs"), wants
+  to change an already-applied native policy ("improve the IP filtering to
+  include 1.1.1.1"), or apply one native plugin to an already-chosen instance
+  ("add ip-restriction on this Kong service"). DO NOT TRIGGER when: they want
+  one Universal/canonical policy across many instances or providers — use
+  skill apply-universal-policy. DO NOT TRIGGER to remove, detach, enable, or
+  disable a policy, or when they are driving Anypoint REST (skill
+  apply-policy-to-api-instance).
 license: Apache-2.0
-compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with prepare_policy_creation, get_policy_template_form, apply_policy_to_instance. If those tools are missing, stop.
+compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with find_assets, view_api_instance_policies, prepare_policy_creation, get_policy_template_form, apply_policy_to_instance, edit_applied_policy, list_instance_policy_operations. If those tools are missing, stop.
 metadata:
   author: mulesoft-omni
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Apply Native Policy to an Instance
 
-Apply one native policy to one instance: pick the instance, load the
-provider catalog, collect configuration once, apply, and wait until it
-has actually finished.
+List what is already applied, change it, or apply one native plugin to one
+instance — then wait until the write has actually finished.
 
 ## When to Use This Skill
 
 **Use this skill when the user asks to:**
 
+- "What protection do I have for my Apigee APIs?"
+- "Improve the IP filtering to include 1.1.1.1"
 - "Add ip-restriction to this Kong instance"
 - "Apply quota to that Apigee proxy"
-- "Put JWT validation on this API Manager instance"
-- Apply a **native** plugin/template to **one** already-identified instance
+- List, edit, or apply a **native** plugin/template (not a Universal/canonical
+  template)
 
-**Trigger keywords:** this instance · this Kong service · this Apigee
-proxy · native policy · Kong plugin · apply to this API.
+**Trigger keywords:** what protection · what's applied · change this policy ·
+IP filtering · this instance · Kong plugin · Apigee · Azure · native policy.
 
 **Do NOT use this skill when:**
 
 - They want the **same canonical policy on many instances / providers**
   → **skill apply-universal-policy** (`apply_universal_policy`)
-- They want to **audit or edit** an already-applied policy → **skill apply-universal-policy**
-  (Audit / Edit paths)
 - They are driving **Anypoint REST** (OpenAPI `urn:api:*`), not MCP →
   **skill apply-policy-to-api-instance**
 - They need to **create** the instance first → **skill secure-api**
@@ -48,36 +50,98 @@ proxy · native policy · Kong plugin · apply to this API.
 ## Prerequisites
 
 Connected to `urn:mcp:mulesoft-platform`. Probe with
-`prepare_policy_creation` for the target instance. If the tool is missing,
-stop. On 403 / gate-closed (`enabled: false`), say they are not entitled
-and stop — never silently switch provider.
+`view_api_instance_policies` or `prepare_policy_creation`. If the tools are
+missing, stop. On 403 / gate-closed (`enabled: false`), say they are not
+entitled and stop — never silently switch provider.
 
 ## Reference files
 
-- **`references/native-apply.md`** — provider routing, required arguments,
-  and how to wait for completion. Read it before the apply call.
+- **`references/native-apply.md`** — provider routing, `find_assets` join,
+  edit merge, Apigee rename rule, and how to wait for completion. Read it
+  before the first write.
 
 ## Workflow
 
+### Pick the path first
+
+Read the latest user turn and choose **one** path. Do not run Apply steps for
+an Audit or Edit request.
+
+| Path | When | Go to |
+| --- | --- | --- |
+| **Audit** | "What protection / what's applied" with no change yet | Step A |
+| **Edit** | Change an already-applied native policy ("add 1.1.1.1") | Step E |
+| **Apply** | Add a native plugin that is **not** already on this instance | Steps 1–5 |
+
 ### Rules that always apply
 
-1. **One instance.** If more than one instance matches, ask which one.
-   Do not silently apply to a set — that is skill apply-universal-policy.
-2. **Native catalog, not Universal.** `prepare_policy_creation` lists
-   plugins/templates for **this** provider. Never send a Kong plugin name
-   to `apply_universal_policy`.
-3. **Confirm before acting.** Show instance + native policy name + schema,
-   then wait for an explicit yes.
+1. **Native catalog, not Universal.** Never send a Kong plugin name (or an
+   Apigee template id) to `apply_universal_policy`.
+2. **Confirm before acting.** Show the mapping (native policy name → API
+   instances), then wait for an explicit yes before apply or edit.
+3. **Do not guess property names.** Build `configuration_data` from
+   `get_policy_template_form` (`template.configuration`). Apigee uses nested
+   objects and `@`-prefixed attributes — copy those names.
 4. **One-shot config.** Show the schema table (required-only when it is
    longer than about 12 flattened rows, disclosing hidden optionals and
-   offering to expand — same rule as skill apply-universal-policy). Collect
-   the visible fields in one reply. Do not invent optionals.
-5. **Wait for completion.** External apply `httpStatus` 202 /
-   `operationStatus=accepted` is not success. Poll
-   `list_instance_policy_operations`. MuleSoft apply is typically
-   synchronous (2xx without `operationStatus`).
+   offering to expand). Collect the visible fields in one reply. Do not
+   invent optionals. On **edit**, prompt only for fields the merge left
+   empty — do not re-ask the whole schema when the delta is complete.
+5. **Wait for completion.** External writes often return `status: "success"`
+   with `httpStatus` 202 / `operationStatus=accepted`. That is **acceptance**,
+   not done. Poll `list_instance_policy_operations`. MuleSoft writes are
+   typically synchronous (2xx without `operationStatus`).
 
-### Step 1: Identify the instance
+### Step A: Audit — what is already applied
+
+Skip Apply. Do **not** pass `policy_name_filter`. Do **not** offer to apply
+a Universal policy unless they ask.
+
+This is the "what protection do I have for my Apigee APIs?" path: they may
+name a **provider slice** (several APIs), not a single instance.
+
+1. Call `find_assets` with `include_applied_policies=true`, `asset_type=api`,
+   `user_query` verbatim. Put a named provider in `query`, then filter
+   client-side (`references/native-apply.md`).
+2. Present the **applied-policy list** grouped by API, then instance — policy
+   **names** with each API instance. When they named a provider, show only
+   that provider's instances.
+3. Ask whether they want to change any. If they do, go to Step E.
+
+Example shape:
+
+```
+Payments API
+  prod (Production · apigee)
+    - Access control (inbound, enabled)
+  sandbox (Sandbox · apigee)
+    - (none)
+```
+
+### Step E: Edit an already-applied native policy
+
+Skip Apply unless you still need the instance list from Step A.
+
+There is no bulk-edit tool: loop **once per instance**. Several Apigee APIs
+with the same native policy is still one `edit_applied_policy` each.
+
+1. Identify `api_instance_id` + `policy_id` + Exchange
+   `asset.{group_id,asset_id,asset_version}` + `provider` (and
+   `environment_id` on MuleSoft) from `view_api_instance_policies`
+   (do not guess). Skip `readOnly: true` — say so and stop for those.
+2. Load the schema with `get_policy_template_form` using those coordinates.
+3. Read current `configurationData`. Merge the requested **delta** into that
+   full object (`configuration_data` replaces wholesale — omitted keys are
+   dropped). Prompt only for required fields the merge left empty.
+4. **Apigee: never change `@name` / display name** on an existing policy.
+   Edit configuration values only. A rename makes the async `UPDATE` fail
+   (`BAD_REQUEST`) even though the tool reported `success` on the 202.
+5. Show the **native-policy → API + instance mapping** of every instance you
+   will loop. **[GATE] Wait for okay.**
+6. Call `edit_applied_policy` per instance. Then wait
+   (`references/native-apply.md`). Confirm per API instance.
+
+### Step 1: Identify the instance (Apply)
 
 If the user already named an instance, use that `api_instance_id` (and
 `environment_id` for MuleSoft). Otherwise `find_assets` (`asset_type=api`,
@@ -87,14 +151,23 @@ If the user already named an instance, use that `api_instance_id` (and
 Resolve `provider`: `kong` / `apigee` / `azure` for external; omit (or
 `mulesoft`) for Anypoint. Do not guess.
 
+Do not silently apply a **new** native plugin to a set — that fan-out is
+skill apply-universal-policy (canonical) or a confirmed Edit loop (already
+applied).
+
 ### Step 2: List native policies that are not yet applied
 
 Call `prepare_policy_creation` with `organization_id`, `api_instance_id`,
 `provider` (external), and `policy_name_hint` when they named a policy.
 MuleSoft also needs `environment_id`.
 
-If more than one template matches the hint, list `name`s and ask. If
-none match, say so and stop.
+Each entry carries Exchange coordinates (`groupId` / `assetId` /
+`assetVersion`) plus `capabilities.injectionPoints` and `applicationLimit`
+(`MULTIPLE` = the same template may be applied more than once). Applied
+policies are filtered out (`alreadyApplied` is always false here).
+
+If more than one template matches the hint, list `name`s and ask. If none
+match, say so and stop.
 
 ### Step 3: Load the schema and collect configuration
 
@@ -110,19 +183,38 @@ reply, then for okay to apply.**
 Call `apply_policy_to_instance` **once** with:
 
 - `api_instance_id`
-- `configuration_data` — the collected object
+- `configuration_data` — the collected object (schema property names, not
+  guessed ones)
 - `asset.{group_id,asset_id,asset_version}` from Step 2 (required external)
 - `provider` for Kong / Apigee / Azure
 - `environment_id` for MuleSoft
-- `injection_point` only if the template requires it and the user set it
+- `injection_point` only if the template requires it and the user set it;
+  otherwise omit and let APIM default it
 
 Do not loop this tool. Do not call `apply_universal_policy`.
 
 ### Step 5: Wait until it is actually done
 
-See `references/native-apply.md`. Report the native policy name → this
-API instance (environment / provider). On failure, say whether it is
-retryable when `error.retryable` is present.
+See `references/native-apply.md`. Report the native policy name → API
+instances (environment / provider). On `FAILED`, say whether
+`error.retryable` is present. Optionally re-read
+`view_api_instance_policies` so the user sees the live `policyId` and
+config.
+
+## Best Practices
+
+- **Route first.** ✅ Audit stays on Step A; Edit on Step E; a new plugin
+  on one instance is Steps 1–5. ❌ running `prepare_policy_creation` /
+  apply because the file is numbered 1–5. ❌ sending a Kong plugin to
+  `apply_universal_policy`.
+- **Confirm the mapping, then wait.** ✅ native policy name → API
+  instances, then an explicit yes. ❌ writing on the schema reply. ❌
+  treating `status: "success"` + HTTP 202 as done — poll
+  `list_instance_policy_operations`.
+- **Don't guess coordinates or property names.** ✅ `policy_id` / `asset`
+  from `view_api_instance_policies`; config keys from
+  `get_policy_template_form`. ❌ inventing Apigee `@`-prefixed fields or
+  changing `@name` on edit.
 
 ## Troubleshooting
 
@@ -132,7 +224,16 @@ skill apply-policy-to-api-instance.
 
 **Gate closed / 403:** say they are not entitled for that provider. Stop.
 
-**More than one instance:** ask. Do not fan out.
+**Apply of a new plugin to more than one instance:** ask which one, or
+switch to skill apply-universal-policy if they meant a canonical template.
+
+**`httpStatus` 422 on apply/edit:** `configuration_data` does not match the
+provider schema. Re-read `get_policy_template_form` and use its exact
+property names.
+
+**Apigee edit failed after a 202 `success`:** you likely changed
+`AccessControl.@name` (or the equivalent display name). Keep `@name`
+identical to the applied value; delete-and-recreate is not on this surface.
 
 **User named a Universal/canonical template for many APIs:** switch to
 skill apply-universal-policy.
@@ -140,7 +241,7 @@ skill apply-universal-policy.
 ## Related Skills
 
 - **skill apply-universal-policy**: one canonical policy across many
-  instances or providers; also audit/edit of already-applied policies.
+  instances or providers (`apply_universal_policy`).
 - **skill apply-policy-to-api-instance**: same job over Anypoint REST
   (`urn:api:*`), not MCP.
 - **skill secure-api**: create/deploy the instance first.

--- a/skills/apply-native-policy-to-instance/references/native-apply.md
+++ b/skills/apply-native-policy-to-instance/references/native-apply.md
@@ -1,0 +1,29 @@
+# Native single-instance apply — routing
+
+## Which tool path
+
+| Instance | `provider` | Catalog / apply | Wait for completion |
+| --- | --- | --- | --- |
+| Kong / Apigee / Azure | `kong` / `apigee` / `azure` | Universal API via `prepare_policy_creation` → `get_policy_template_form` → `apply_policy_to_instance` (`asset` coordinates required) | If `httpStatus` is 202 or `operationStatus=accepted`, poll `list_instance_policy_operations` (`organization_id`, `api_instance_id`, `provider`) until that instance's latest APPLY is `COMPLETED` or `FAILED`. ~20 polls, a few seconds apart. A 202 is acceptance, not success. |
+| MuleSoft / Anypoint | omit, or `mulesoft` | API Manager via the same three tools (`environment_id` required) | 2xx without `operationStatus` is terminal. Do not poll `list_instance_policy_operations` (external-only). |
+
+AWS is not on this apply surface — say so and stop.
+
+## `apply_policy_to_instance` vs `apply_universal_policy`
+
+- Native plugin / template id on **one** instance → `apply_policy_to_instance`.
+- Canonical kebab name from `list_universal_policies` on **many** instances
+  → skill apply-universal-policy / `apply_universal_policy`.
+
+Never send a Kong plugin name to `apply_universal_policy`. Never loop
+`apply_policy_to_instance` to fake a Universal fan-out.
+
+## Required arguments (do not guess)
+
+External: `organization_id`, `api_instance_id`, `provider`,
+`asset.group_id`, `asset.asset_id`, `asset.asset_version`,
+`configuration_data`.
+
+MuleSoft: `organization_id`, `environment_id`, `api_instance_id`,
+`configuration_data`, plus template identity (`asset` or
+`policy_template_id`) from `get_policy_template_form`.

--- a/skills/apply-native-policy-to-instance/references/native-apply.md
+++ b/skills/apply-native-policy-to-instance/references/native-apply.md
@@ -1,13 +1,39 @@
-# Native single-instance apply — routing
+# Native policy apply / audit / edit — routing
 
 ## Which tool path
 
-| Instance | `provider` | Catalog / apply | Wait for completion |
-| --- | --- | --- | --- |
-| Kong / Apigee / Azure | `kong` / `apigee` / `azure` | Universal API via `prepare_policy_creation` → `get_policy_template_form` → `apply_policy_to_instance` (`asset` coordinates required) | If `httpStatus` is 202 or `operationStatus=accepted`, poll `list_instance_policy_operations` (`organization_id`, `api_instance_id`, `provider`) until that instance's latest APPLY is `COMPLETED` or `FAILED`. ~20 polls, a few seconds apart. A 202 is acceptance, not success. |
-| MuleSoft / Anypoint | omit, or `mulesoft` | API Manager via the same three tools (`environment_id` required) | 2xx without `operationStatus` is terminal. Do not poll `list_instance_policy_operations` (external-only). |
+| Instance | `provider` | Catalog / apply | Edit | Wait for completion |
+| --- | --- | --- | --- | --- |
+| Kong / Apigee / Azure | `kong` / `apigee` / `azure` | Universal API via `prepare_policy_creation` → `get_policy_template_form` → `apply_policy_to_instance` (`asset` coordinates required) | `edit_applied_policy` with `policy_id` + `asset` from `view_api_instance_policies`. Never send `injectionPoint` on edit (immutable). | If `httpStatus` is 202 or `operationStatus=accepted`, poll `list_instance_policy_operations` (`organization_id`, `api_instance_id`, `provider`) until that instance's latest `APPLY` / `UPDATE` is `COMPLETED` or `FAILED`. ~20 polls, a few seconds apart. The tool may still return `status: "success"` on that 202 — that means *accepted*, not *applied*. |
+| MuleSoft / Anypoint | omit, or `mulesoft` | API Manager via the same three tools (`environment_id` required) | Same `edit_applied_policy`; `environment_id` required; `asset` optional (forward it to bump version) | 2xx without `operationStatus` is terminal. Do not poll `list_instance_policy_operations` (external-only). |
 
-AWS is not on this apply surface — say so and stop.
+AWS is not on this apply/edit surface — say so and stop.
+
+Use `view_api_instance_policies` to list what is already applied (there is
+no `list_applied_policies_on_instance` tool). Pass `organization_id`,
+`api_instance_id`, and `provider` (plus `environment_id` on MuleSoft).
+
+## `find_assets` join (Audit)
+
+`include_applied_policies=true` annotates each **userOrgAssets** row.
+Public catalog hits have no applied-policy state — ignore them.
+
+Per user-org asset you get API display name and
+`appliedPolicies.instances[]` — `{instanceId, environment, policyNames}`.
+
+`find_assets` has no provider parameter. Put the provider word in `query`
+(and keep `user_query` verbatim), then **filter client-side**: keep
+instances whose provider matches (`apigee`, `kong`, `azure`, `mulesoft` /
+`anypoint`). If provider is still unknown, resolve it with
+`view_api_instance_policies` before including or excluding the row. Do not
+invent a provider.
+
+If `appliedPolicyEnrichment.assetCapApplied` (or `assetsDropped` > 0), fan
+out `view_api_instance_policies` rather than treating the truncated set as
+complete.
+
+Do **not** pass `policy_name_filter` on Audit — that path is for Universal
+Protect (skill apply-universal-policy).
 
 ## `apply_policy_to_instance` vs `apply_universal_policy`
 
@@ -20,10 +46,50 @@ Never send a Kong plugin name to `apply_universal_policy`. Never loop
 
 ## Required arguments (do not guess)
 
-External: `organization_id`, `api_instance_id`, `provider`,
+External apply: `organization_id`, `api_instance_id`, `provider`,
 `asset.group_id`, `asset.asset_id`, `asset.asset_version`,
 `configuration_data`.
 
-MuleSoft: `organization_id`, `environment_id`, `api_instance_id`,
+External edit: the apply set plus `policy_id`.
+
+MuleSoft apply/edit: `organization_id`, `environment_id`, `api_instance_id`,
 `configuration_data`, plus template identity (`asset` or
-`policy_template_id`) from `get_policy_template_form`.
+`policy_template_id`) from `get_policy_template_form`. Edit also needs
+`policy_id`.
+
+## Edit merge
+
+`configuration_data` is a **full** object. Omitted keys are dropped. Merge
+the user's delta onto the latest `configurationData` immediately before
+the call. There is no bulk-edit: one user request across many instances =
+one `edit_applied_policy` per instance.
+
+**Apigee cannot be renamed.** Keep `AccessControl.@name` (or the equivalent
+display-name field) identical to the applied value on every edit. Changing
+it makes the background `UPDATE` fail with:
+
+`BAD_REQUEST: "Apigee policies cannot be renamed …; delete and re-create instead"`
+
+There is no detach tool on this surface — so do not offer delete-and-recreate.
+Edit configuration values (IP rules, actions, headers) only.
+
+## Failed operations
+
+`list_instance_policy_operations` returns recent ops newest-first (`APPLY` /
+`UPDATE` / …) with `RUNNING` / `COMPLETED` / `FAILED`. A `FAILED` row is
+enriched with `error` `{code, retryable, message}`. `retryable` tells you
+whether a re-apply/re-edit is worth trying. Typical `error.code` values:
+`BAD_REQUEST`, `CONFLICT`, `BAD_GATEWAY`, `SCANNER_ERROR`,
+`INSTANCE_NOT_FOUND`, `NO_TRANSLATION`, `UNEXPECTED_ERROR`.
+
+The list is instance-scoped; per-operation detail is org-scoped (the tool
+already joins them). Cap: `limit` max 50; at most 10 FAILED rows are
+enriched (`failedDetailsTruncated` when more were skipped).
+
+## Mapping (confirm + result)
+
+| Native policy | API name | Instance name | Environment | Provider |
+| --- | --- | --- | --- | --- |
+| Access control | Payments API | prod | Production | apigee |
+
+Plain names, not IDs. Same table before the write (GATE) and after it lands.

--- a/skills/apply-native-policy-to-instance/skills-metadata.yaml
+++ b/skills/apply-native-policy-to-instance/skills-metadata.yaml
@@ -1,0 +1,1 @@
+type: prose

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -306,6 +306,7 @@ After completing all steps, verify the policy is properly applied:
 
 ## Related Jobs
 
+- **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user wants the same protection on many APIs/providers, not a single already-chosen API Manager instance.
 - **deploy-api-with-rate-limiting** — Full workflow including API creation and tiered rate limiting with OAuth2
 - **list-organization-api-instances** — Discover existing API instances across environments
 - **manage-consumer-contracts** — Manage client application access after policies are applied

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -306,7 +306,8 @@ After completing all steps, verify the policy is properly applied:
 
 ## Related Jobs
 
-- **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user says all / many / my APIs / a named provider, not a single already-chosen API Manager instance.
+- **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user says all / many / my APIs / a named provider.
+- **skill apply-native-policy-to-instance** — Apply one native plugin/template to one already-chosen instance via the MuleSoft Platform MCP Server (Kong / Apigee / Azure / MuleSoft).
 - **deploy-api-with-rate-limiting** — Full workflow including API creation and tiered rate limiting with OAuth2
 - **list-organization-api-instances** — Discover existing API instances across environments
 - **manage-consumer-contracts** — Manage client application access after policies are applied

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -306,7 +306,7 @@ After completing all steps, verify the policy is properly applied:
 
 ## Related Jobs
 
-- **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user wants the same protection on many APIs/providers, not a single already-chosen API Manager instance.
+- **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user says all / many / my APIs / a named provider, not a single already-chosen API Manager instance.
 - **deploy-api-with-rate-limiting** — Full workflow including API creation and tiered rate limiting with OAuth2
 - **list-organization-api-instances** — Discover existing API instances across environments
 - **manage-consumer-contracts** — Manage client application access after policies are applied

--- a/skills/apply-policy-to-api-instance/SKILL.md
+++ b/skills/apply-policy-to-api-instance/SKILL.md
@@ -307,7 +307,7 @@ After completing all steps, verify the policy is properly applied:
 ## Related Jobs
 
 - **skill apply-universal-policy** — Protect a portfolio slice with one Universal (canonical) policy across instances on any gateway. Use that when the user says all / many / my APIs / a named provider.
-- **skill apply-native-policy-to-instance** — Apply one native plugin/template to one already-chosen instance via the MuleSoft Platform MCP Server (Kong / Apigee / Azure / MuleSoft).
+- **skill apply-native-policy-to-instance** — List what's applied, edit an already-applied native policy, or apply one native plugin/template via the MuleSoft Platform MCP Server (Kong / Apigee / Azure / MuleSoft). Use that for "what protection do I have for my Apigee APIs" and "improve the IP filtering".
 - **deploy-api-with-rate-limiting** — Full workflow including API creation and tiered rate limiting with OAuth2
 - **list-organization-api-instances** — Discover existing API instances across environments
 - **manage-consumer-contracts** — Manage client application access after policies are applied

--- a/skills/apply-universal-policy/SKILL.md
+++ b/skills/apply-universal-policy/SKILL.md
@@ -2,19 +2,19 @@
 name: apply-universal-policy
 description: |
   Protect a portfolio slice by applying one Universal (canonical) policy across
-  API instances on any gateway (Kong, Apigee, Azure, AWS, MuleSoft), or audit
-  and edit already-applied native policies. Use when the user says all / many /
-  my APIs / a provider name / a portfolio slice — JWT validation, rate limiting,
-  spike arrest, IP filtering, "what protection do I have", tighten an existing
-  policy, or apply one config across providers. DO NOT TRIGGER for a single
-  already-chosen instance that needs a provider-native plugin — use skill
-  apply-native-policy-to-instance. Do not use to remove, detach, enable, or
-  disable a policy (those tools do not exist).
+  API instances on any gateway (Kong, Apigee, Azure, AWS, MuleSoft). Use when
+  the user says all / many / my APIs / a portfolio slice — JWT validation, rate
+  limiting, spike arrest, IP filtering, or apply one config across providers.
+  DO NOT TRIGGER for "what protection do I have" / listing or editing already-
+  applied native policies — use skill apply-native-policy-to-instance. DO NOT
+  TRIGGER for a single already-chosen instance that needs a provider-native
+  plugin — same skill. Do not use to remove, detach, enable, or disable a
+  policy (those tools do not exist).
 license: Apache-2.0
 compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with list_universal_policies, apply_universal_policy, get_policy_operation_status, and find_assets (include_applied_policies). If those tools are missing, stop.
 metadata:
   author: mulesoft-omni
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # Apply Universal Policy
@@ -28,17 +28,17 @@ work has actually finished.
 **Use this skill when the user asks to:**
 
 - "Ensure all my finance-tagged APIs have JWT validation"
-- "What protection do I have on my Apigee APIs?"
-- "Add 1.1.1.1 to the IP filtering on those APIs"
 - Apply one canonical policy (JWT, rate limiting, spike arrest, IP allow/deny)
   across many instances or many providers
 
 **Trigger keywords:** all my APIs · portfolio · missing this policy · universal
-policy · canonical policy · JWT validation · rate limiting · spike arrest ·
-IP filtering · IP allowlist · Kong · Apigee · Azure · AWS.
+policy · canonical policy · JWT validation · rate limiting · spike arrest.
 
 **Do NOT use this skill when:**
 
+- They ask **what protection they already have**, or want to **change** an
+  already-applied native policy ("improve IP filtering to include 1.1.1.1")
+  → **skill apply-native-policy-to-instance** (Audit / Edit)
 - The user already has **one** instance in context and wants a **native**
   plugin on it (Kong / Apigee / Azure / one MuleSoft instance) →
   **skill apply-native-policy-to-instance**
@@ -66,30 +66,22 @@ You must be connected to the MuleSoft Platform MCP Server
 
 - **`references/presentation-format.md`** — pinned tables. Read it when you
   are about to render a user-facing list, schema, mapping, or result.
-- **`references/payloads.md`** — how to join `find_assets` rows, branch on
-  apply `status`, and call `edit_applied_policy`. Read it before the first
-  apply or edit.
+- **`references/payloads.md`** — how to join `find_assets` rows and branch on
+  apply `status`. Read it before the first apply.
 
 ## Workflow
 
 ### Pick the path first
 
-Read the latest user turn and choose **one** path. Do not run Protect steps
-for an Audit or Edit request. Re-pick on every turn (a conversation can
-Protect, then Audit, then Edit).
-
-| Path | When | Go to |
-| --- | --- | --- |
-| **Protect** | A filter + a protection to apply ("JWT on finance APIs") | Steps 1–4 |
-| **Audit** | "What protection / what's applied" with no change yet | Step 5 |
-| **Edit** | Change an already-applied policy ("add 1.1.1.1") | Step 6 |
+This skill is **Protect only**. If the latest turn is "what's applied" or
+"change this native policy", switch to **skill apply-native-policy-to-instance**
+— do not run Steps 1–4.
 
 ### Rules that always apply
 
-1. **Confirm before acting.** Report found/missing (or the edit preview) and
-   wait for an explicit yes before `apply_universal_policy` or
-   `edit_applied_policy`. A missing confirmation writes policies the user did
-   not approve.
+1. **Confirm before acting.** Report found/missing and wait for an explicit
+   yes before `apply_universal_policy`. A missing confirmation writes
+   policies the user did not approve.
 2. **Instances, not APIs.** Users say "APIs"; policies attach to **deployed
    instances**. Gate apply on `policyCoverage` + `instancesMissingPolicy`,
    never on `hasPolicy` alone (`hasPolicy` is any-instance and would skip
@@ -101,9 +93,9 @@ Protect, then Audit, then Edit).
    required-only when it is too long — see `references/presentation-format.md`),
    then collect the **entire** configuration for the fields you showed in one
    reply. Reuse it across every targeted instance. Never walk field by field.
-5. **Wait for completion.** Acceptance (`accepted` / HTTP 202 / edit
-   `success`) is not success. Poll until `COMPLETED` or `FAILED`. Distinguish
-   retryable vs terminal from `error.retryable`.
+5. **Wait for completion.** Acceptance (`accepted` / HTTP 202) is not
+   success. Poll until `COMPLETED` or `FAILED`. Distinguish retryable vs
+   terminal from `error.retryable`.
 6. **Plain names.** Mappings use human-readable native policy names from
    `providerMapping`, not IDs.
 
@@ -193,44 +185,11 @@ Branch on the apply `status` (`references/payloads.md`):
 Then the same **policy → API + instance mapping** as the preview (now as
 the result). On `FAILED`, say whether `error.retryable` is true.
 
-### Step 5: Audit an existing slice
-
-Skip Steps 1–4. Do **not** pass `policy_name_filter`. Do **not** offer to
-apply unless the user asks.
-
-1. `find_assets` with `include_applied_policies=true`, `asset_type=api`,
-   `user_query` verbatim. Put a named provider in `query`, then filter
-   client-side (`references/payloads.md`).
-2. Present the **applied-policy list** (grouped by API, then instance),
-   only the requested provider's instances.
-3. Ask whether they want to change anything. If they do, go to Step 6.
-
-### Step 6: Edit an already-applied native policy
-
-Skip Steps 1–4 unless you still need the instance list from Step 5.
-
-There is no bulk-edit: loop **once per instance**.
-
-1. Identify `api_instance_id` + `policy_id` + Exchange
-   `asset.{group_id,asset_id,asset_version}` + `provider` (and
-   `environment_id` on MuleSoft) from `view_api_instance_policies`
-   (do not guess).
-2. Load the schema with `get_policy_template_form` using those coordinates.
-3. Read current `configurationData`. Merge the requested **delta** into that
-   full object (`configuration_data` replaces wholesale — omitted keys are
-   dropped). Prompt only for required fields the merge left empty — do not
-   re-ask the whole schema when the delta is complete.
-4. Show the **policy → API + instance mapping** of the edit (every instance
-   you will loop). **[GATE] Wait for okay.**
-5. Call `edit_applied_policy` per instance (`references/payloads.md`).
-   Confirm per API instance.
-
-A `readOnly: true` policy cannot be edited — say so and stop.
-
 ## Best Practices
 
-- **Route first.** ✅ Audit stays on Step 5. ❌ running Step 1's
-  `policy_name_filter` + apply GATE because the file is numbered 1–6.
+- **Route first.** ✅ "what's applied" / "change IP filtering" goes to
+  skill apply-native-policy-to-instance. ❌ running Step 1's
+  `policy_name_filter` + apply GATE on an audit turn.
 - **One apply call for Universal.** ✅ `apply_universal_policy` with the
   Step-2 remaining ids. ❌ looping native apply; ❌ sending the pre-drop
   Step 1 list.
@@ -253,18 +212,15 @@ policies. Say so plainly and stop.
 are already terminal. Report from `results`; only `accepted` has an
 `operationId` to poll.
 
-**Edit dropped fields the user did not mention:** `configuration_data` is a
-full replace. Merge onto the latest `configurationData` immediately before
-the edit.
-
 **User asks to undo / remove / disable the policy:** not supported. There is
 no detach tool and no enable/disable parameter on the agent surface. Explain
 and stop.
 
 ## Related Skills
 
-- **skill apply-native-policy-to-instance**: one native plugin/template on one
-  already-chosen instance (Kong / Apigee / Azure / MuleSoft) via MCP.
+- **skill apply-native-policy-to-instance**: list what's applied, edit an
+  already-applied native policy, or apply one native plugin/template to one
+  instance (Kong / Apigee / Azure / MuleSoft) via MCP.
 - **skill apply-policy-to-api-instance**: same single-instance job over
   Anypoint REST (`urn:api:*`), not MCP.
 - **skill secure-api**: create/deploy an instance and then apply a policy —

--- a/skills/apply-universal-policy/SKILL.md
+++ b/skills/apply-universal-policy/SKILL.md
@@ -7,14 +7,14 @@ description: |
   my APIs / a provider name / a portfolio slice — JWT validation, rate limiting,
   spike arrest, IP filtering, "what protection do I have", tighten an existing
   policy, or apply one config across providers. DO NOT TRIGGER for a single
-  already-chosen API Manager instance — use skill apply-policy-to-api-instance.
-  Do not use to remove, detach, enable, or disable a policy (those tools do not
-  exist).
+  already-chosen instance that needs a provider-native plugin — use skill
+  apply-native-policy-to-instance. Do not use to remove, detach, enable, or
+  disable a policy (those tools do not exist).
 license: Apache-2.0
 compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with list_universal_policies, apply_universal_policy, get_policy_operation_status, and find_assets (include_applied_policies). If those tools are missing, stop.
 metadata:
   author: mulesoft-omni
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Apply Universal Policy
@@ -39,8 +39,11 @@ IP filtering · IP allowlist · Kong · Apigee · Azure · AWS.
 
 **Do NOT use this skill when:**
 
-- The user already has **one** API Manager instance in context and wants a
-  single native policy on it → **skill apply-policy-to-api-instance**
+- The user already has **one** instance in context and wants a **native**
+  plugin on it (Kong / Apigee / Azure / one MuleSoft instance) →
+  **skill apply-native-policy-to-instance**
+- They are driving **Anypoint REST** rather than MCP →
+  **skill apply-policy-to-api-instance**
 - They need to **create** an instance or deploy a gateway first → **skill secure-api**
 - They want to **remove**, detach, or pause (enable/disable) a policy — say so
   and stop; those actions are not on the tool surface
@@ -174,7 +177,7 @@ Call `apply_universal_policy` once with:
 - `configuration` — the collected config, reused as-is
 
 Do **not** loop `apply_policy_to_instance` for a Universal/canonical template.
-Use that tool only for a provider-native plugin on a single instance.
+That tool is one native plugin on one instance — **skill apply-native-policy-to-instance**.
 
 ### Step 4: Wait until it is actually done (Protect)
 
@@ -206,14 +209,12 @@ apply unless the user asks.
 
 Skip Steps 1–4 unless you still need the instance list from Step 5.
 
-`edit_applied_policy` is **Kong / Apigee / Azure only**. If the instance is
-MuleSoft/Anypoint, say you cannot edit it with the current tools and stop.
-
 There is no bulk-edit: loop **once per instance**.
 
 1. Identify `api_instance_id` + `policy_id` + Exchange
-   `asset.{group_id,asset_id,asset_version}` + `provider` from
-   `view_api_instance_policies` (do not guess).
+   `asset.{group_id,asset_id,asset_version}` + `provider` (and
+   `environment_id` on MuleSoft) from `view_api_instance_policies`
+   (do not guess).
 2. Load the schema with `get_policy_template_form` using those coordinates.
 3. Read current `configurationData`. Merge the requested **delta** into that
    full object (`configuration_data` replaces wholesale — omitted keys are
@@ -221,9 +222,8 @@ There is no bulk-edit: loop **once per instance**.
    re-ask the whole schema when the delta is complete.
 4. Show the **policy → API + instance mapping** of the edit (every instance
    you will loop). **[GATE] Wait for okay.**
-5. Call `edit_applied_policy` per instance. A `success` / 202 is acceptance.
-   Poll `list_instance_policy_operations` per instance until `COMPLETED` /
-   `FAILED`. Confirm per API instance.
+5. Call `edit_applied_policy` per instance (`references/payloads.md`).
+   Confirm per API instance.
 
 A `readOnly: true` policy cannot be edited — say so and stop.
 
@@ -257,17 +257,16 @@ are already terminal. Report from `results`; only `accepted` has an
 full replace. Merge onto the latest `configurationData` immediately before
 the edit.
 
-**Edit failed on a MuleSoft instance:** expected — the tool is external-only.
-Stop and say so.
-
 **User asks to undo / remove / disable the policy:** not supported. There is
 no detach tool and no enable/disable parameter on the agent surface. Explain
 and stop.
 
 ## Related Skills
 
-- **skill apply-policy-to-api-instance**: apply one catalog policy to a single
-  already-chosen API Manager instance (Anypoint REST, not Universal fan-out).
+- **skill apply-native-policy-to-instance**: one native plugin/template on one
+  already-chosen instance (Kong / Apigee / Azure / MuleSoft) via MCP.
+- **skill apply-policy-to-api-instance**: same single-instance job over
+  Anypoint REST (`urn:api:*`), not MCP.
 - **skill secure-api**: create/deploy an instance and then apply a policy —
   use that when the API is not yet an instance.
 - **skill secure-mcp-server**: protect an MCP server, not an API instance.

--- a/skills/apply-universal-policy/SKILL.md
+++ b/skills/apply-universal-policy/SKILL.md
@@ -3,20 +3,18 @@ name: apply-universal-policy
 description: |
   Protect a portfolio slice by applying one Universal (canonical) policy across
   API instances on any gateway (Kong, Apigee, Azure, AWS, MuleSoft), or audit
-  and edit already-applied native policies. Use when the user wants JWT
-  validation on tagged APIs, rate limiting everywhere, IP filtering on Apigee,
-  "what protection do I have", tighten an existing policy, or apply one config
-  across providers. DO NOT TRIGGER when applying a policy to a single already
-  chosen API Manager instance — use skill apply-policy-to-api-instance. Do not
-  use to remove, detach, enable, or disable a policy (those tools do not exist).
+  and edit already-applied native policies. Use when the user says all / many /
+  my APIs / a provider name / a portfolio slice — JWT validation, rate limiting,
+  spike arrest, IP filtering, "what protection do I have", tighten an existing
+  policy, or apply one config across providers. DO NOT TRIGGER for a single
+  already-chosen API Manager instance — use skill apply-policy-to-api-instance.
+  Do not use to remove, detach, enable, or disable a policy (those tools do not
+  exist).
 license: Apache-2.0
-compatibility: >
-  Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform). The
-  Universal-policy tools this skill calls land in the portal catalog via
-  mulesoft-dx PR #222 — if they are missing, stop (see Prerequisites).
+compatibility: Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform) with list_universal_policies, apply_universal_policy, get_policy_operation_status, and find_assets (include_applied_policies). If those tools are missing, stop.
 metadata:
   author: mulesoft-omni
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Apply Universal Policy
@@ -32,17 +30,17 @@ work has actually finished.
 - "Ensure all my finance-tagged APIs have JWT validation"
 - "What protection do I have on my Apigee APIs?"
 - "Add 1.1.1.1 to the IP filtering on those APIs"
-- Apply one canonical policy (JWT, rate limiting, CORS, IP allow/deny, …)
+- Apply one canonical policy (JWT, rate limiting, spike arrest, IP allow/deny)
   across many instances or many providers
 
-**Trigger keywords:** universal policy · canonical policy · JWT validation ·
-rate limiting · spike arrest · IP filtering · IP allowlist · protect my APIs ·
-portfolio · missing this policy · Kong · Apigee · Azure · AWS.
+**Trigger keywords:** all my APIs · portfolio · missing this policy · universal
+policy · canonical policy · JWT validation · rate limiting · spike arrest ·
+IP filtering · IP allowlist · Kong · Apigee · Azure · AWS.
 
 **Do NOT use this skill when:**
 
-- The user already has **one** API Manager instance and wants a single native
-  policy on it → **skill apply-policy-to-api-instance**
+- The user already has **one** API Manager instance in context and wants a
+  single native policy on it → **skill apply-policy-to-api-instance**
 - They need to **create** an instance or deploy a gateway first → **skill secure-api**
 - They want to **remove**, detach, or pause (enable/disable) a policy — say so
   and stop; those actions are not on the tool surface
@@ -50,173 +48,212 @@ portfolio · missing this policy · Kong · Apigee · Azure · AWS.
 ## Prerequisites
 
 You must be connected to the MuleSoft Platform MCP Server
-(`urn:mcp:mulesoft-platform`). Probe availability with a read-only call:
+(`urn:mcp:mulesoft-platform`). Probe with a read-only call:
 
-1. Call `list_universal_policies`. If the tool is **not in the catalog**, STOP.
-   Tell the user the portal catalog does not yet include these tools — they
-   ship in [mulesoft-dx PR #222](https://github.com/mulesoft/mulesoft-dx/pull/222)
-   and this skill cannot execute until that PR is merged and published.
-2. If the tool returns that the Universal catalog is unavailable, say so and
-   stop — do not invent a fallback apply path.
-3. The caller needs policy-manage permission on the target org. On a 403 /
-   entitlement error, say they are not entitled and **stop**. Never silently
-   switch provider or org.
+1. Call `list_universal_policies`. If the tool is **not in the catalog**, STOP
+   and say the Platform MCP catalog on this host does not include the Universal
+   policy tools yet. Do not substitute Anypoint REST calls.
+2. If the tool returns the catalog is unavailable (`status=not_configured` or
+   an empty `policies` list with that message), say so and stop — do not invent
+   a fallback apply path.
+3. On a 403 / entitlement / gate-closed error, say they are not entitled and
+   **stop**. Never silently switch provider or org.
 
 ## Reference files
 
-- **`references/presentation-format.md`** — pinned tables for every output
-  (API-instance list, config schema, policy→API+instance mapping, applied-policy
-  list, operation result). Read it before the first user-facing table and reuse
-  those layouts for the rest of the run.
+- **`references/presentation-format.md`** — pinned tables. Read it when you
+  are about to render a user-facing list, schema, mapping, or result.
+- **`references/payloads.md`** — how to join `find_assets` rows, branch on
+  apply `status`, and call `edit_applied_policy`. Read it before the first
+  apply or edit.
 
 ## Workflow
+
+### Pick the path first
+
+Read the latest user turn and choose **one** path. Do not run Protect steps
+for an Audit or Edit request. Re-pick on every turn (a conversation can
+Protect, then Audit, then Edit).
+
+| Path | When | Go to |
+| --- | --- | --- |
+| **Protect** | A filter + a protection to apply ("JWT on finance APIs") | Steps 1–4 |
+| **Audit** | "What protection / what's applied" with no change yet | Step 5 |
+| **Edit** | Change an already-applied policy ("add 1.1.1.1") | Step 6 |
 
 ### Rules that always apply
 
 1. **Confirm before acting.** Report found/missing (or the edit preview) and
    wait for an explicit yes before `apply_universal_policy` or
-   `edit_applied_policy`. A missing confirmation is the most expensive mistake —
-   it writes policies the user did not approve.
+   `edit_applied_policy`. A missing confirmation writes policies the user did
+   not approve.
 2. **Instances, not APIs.** Users say "APIs"; policies attach to **deployed
-   instances**. Resolve that yourself. Gate apply on `policyCoverage` +
-   `instancesMissingPolicy`, never on `hasPolicy` alone (`hasPolicy` is
-   any-instance and would skip unprotected siblings).
-3. **One config, whole surface.** Show every field the template schema exposes
-   (required and optional), then collect the **entire** configuration in one
-   shot. Reuse it across every targeted instance. Never walk field by field.
-4. **Wait for completion.** A 202/`status=accepted` is not success. Poll
-   `get_policy_operation_status` (or `list_instance_policy_operations` for a
-   native edit) until `COMPLETED` or `FAILED`. Distinguish retryable vs
-   terminal from `error.retryable`.
-5. **Plain names.** Pre-apply and post-apply mappings use human-readable
-   native policy names from `providerMapping`, not IDs.
+   instances**. Gate apply on `policyCoverage` + `instancesMissingPolicy`,
+   never on `hasPolicy` alone (`hasPolicy` is any-instance and would skip
+   unprotected siblings).
+3. **Join before you talk.** `instancesMissingPolicy` is `{instanceId,
+   environment}` only. Build display rows and `instance_ids` using
+   `references/payloads.md` — do not invent names or providers.
+4. **Apply: one config, whole surface.** Show every field the template schema
+   exposes, then collect the **entire** configuration in one shot. Reuse it
+   across every targeted instance. Never walk field by field.
+5. **Wait for completion.** Acceptance (`accepted` / HTTP 202 / edit
+   `success`) is not success. Poll until `COMPLETED` or `FAILED`. Distinguish
+   retryable vs terminal from `error.retryable`.
+6. **Plain names.** Mappings use human-readable native policy names from
+   `providerMapping`, not IDs.
 
-### Step 1: Discover the slice and what's missing
+### Step 1: Discover the slice and what's missing (Protect)
 
 Call `find_assets` with:
 
-- `query` — the user's filter ("finance", "payments", a tag, a name)
-- `asset_type` — `rest-api` when they mean APIs
+- `query` — search terms from the request (names, "finance", "payments").
+  Include tag-like words when the user said "tagged", but do not claim a
+  tag filter the backend did not apply — if hits look unrelated, say you
+  searched by those terms.
+- `asset_type` — `api` when they mean APIs (expands to the API Exchange types)
 - `user_query` — the verbatim user message
 - `include_applied_policies` — `true`
 - `policy_name_filter` — the protection they named ("JWT validation",
   "rate-limiting"; matching is case- and separator-insensitive)
+- `max_results` — raise it when they asked for "all" / a large slice
+  (default is 20)
 
-Present the result with the **API-instance list** in
-`references/presentation-format.md`. Summarize **per instance**:
-"N instances found, M missing this policy."
+If `userOrgAssets` is empty, say you found no matching API instances and
+stop. Do not search the public catalog for apply targets.
+
+Present the **API-instance list** (`references/presentation-format.md`)
+using the join in `references/payloads.md`. Summarize **per instance**:
+"N instances found, M missing this policy, K unknown."
 
 Coverage rules:
 
 | `policyCoverage` | Meaning | Apply to |
 | --- | --- | --- |
 | `all` | Every readable instance has it | skip (already protected) |
-| `partial` / `none` | Some or none have it | exactly `instancesMissingPolicy` |
-| `unknown` | Incomplete read (error or cap) | re-check those instances with `view_api_instance_policies` before acting. Never count `unknown` as missing. |
+| `partial` / `none` | Some or none have it | exactly the joined `instancesMissingPolicy` |
+| `unknown` | Incomplete read (error or cap) | re-check with `view_api_instance_policies`. Never count as missing. |
 
-Enrichment is capped (about 12 assets, 3 production-first instances each). If
-`appliedPolicyEnrichment.assetCapApplied` is true, fan out
-`view_api_instance_policies` for the remaining instances rather than treating
-the truncated set as complete.
+If `appliedPolicyEnrichment.assetCapApplied` is true, fan out
+`view_api_instance_policies` for the remaining instances rather than
+treating the truncated set as complete.
 
 **[GATE] Wait for the user to confirm they want you to fix the gap.**
 
-### Step 2: Choose the Universal policy and show its schema
+### Step 2: Choose the Universal policy and show its schema (Protect)
 
-Call `list_universal_policies` (optional `policy_name_hint`). Pick the
-canonical template that matches the user's protection. Each entry has
-`configurationSchema`, `supportedProviders`, and `providerMapping` (what it
-becomes on Kong / Apigee / …).
+Call `list_universal_policies` with `policy_name_hint` from the user's
+protection. If more than one template matches, list their `label`s and ask
+which to use — do not pick silently.
+
+Each entry has `configurationSchema`, `supportedProviders`, and
+`providerMapping` (what it becomes on Kong / Apigee / …).
 
 Drop any target instance whose provider is not in `supportedProviders`. If
-that leaves none, say so and stop.
+that leaves none, say so and stop. Keep the surviving list — that is the
+apply set for Steps 3–4, **not** the raw Step 1 missing list.
 
 Present the **policy configuration schema** table (full surface). Then ask
-the user to fill **all** fields in one reply.
+the user to fill **all** fields in one reply. Do not invent optional values.
 
-### Step 3: Preview the native mapping, then apply
+### Step 3: Preview the native mapping, then apply (Protect)
 
-Build the **policy → API + instance mapping** by joining each remaining
+Build the **policy → API + instance mapping** by joining each **remaining**
 instance's provider to `providerMapping`. Show it. **[GATE] Wait for okay.**
 
 Call `apply_universal_policy` once with:
 
-- `policy_name` — the canonical kebab-case template name
-- `instance_ids` — every instance still missing the policy (from Step 1)
+- `policy_name` — the canonical kebab-case template `name`
+- `instance_ids` — remaining missing instances from Step 2 (after the
+  provider drop), not the raw Step 1 list
 - `configuration` — the collected config, reused as-is
 
-Do **not** loop `apply_policy_to_instance` for a Universal/canonical template
-across many instances or providers — that is what `apply_universal_policy` is
-for. Use `apply_policy_to_instance` only for a provider-native plugin on a
-single instance.
+Do **not** loop `apply_policy_to_instance` for a Universal/canonical template.
+Use that tool only for a provider-native plugin on a single instance.
 
-### Step 4: Poll until it is actually done
+### Step 4: Wait until it is actually done (Protect)
 
-If the apply returns `status=accepted` + `operationId`, poll
-`get_policy_operation_status` until `COMPLETED` or `FAILED` (not `RUNNING`).
+Branch on the apply `status` (`references/payloads.md`):
 
-Report with the **operation result** layout, then the same **policy → API +
-instance mapping** as the preview (now as the result). On partial failure,
-name the instances that failed. On `FAILED`, say whether `error.retryable`
-is true.
+- `accepted` — poll `get_policy_operation_status` with `operationId` until
+  `COMPLETED` or `FAILED` (not `RUNNING`). A few seconds between polls;
+  give up after ~20 attempts and report **Still running**.
+- `ok` — synchronous success. Report immediately. Do not poll.
+- `partial` — some targets failed. Report **Partially succeeded** from
+  `results`. Do not poll.
 
-### Step 5: Audit an existing slice (optional path)
+Then the same **policy → API + instance mapping** as the preview (now as
+the result). On `FAILED`, say whether `error.retryable` is true.
 
-When the user asks "what protection do I have on my \<provider\> APIs?":
+### Step 5: Audit an existing slice
 
-1. `find_assets` with `include_applied_policies=true` (no name filter needed).
-2. Present the **applied-policy list** (grouped by API, then instance).
-3. Ask whether they want to change anything.
+Skip Steps 1–4. Do **not** pass `policy_name_filter`. Do **not** offer to
+apply unless the user asks.
+
+1. `find_assets` with `include_applied_policies=true`, `asset_type=api`,
+   `user_query` verbatim. Put a named provider in `query`, then filter
+   client-side (`references/payloads.md`).
+2. Present the **applied-policy list** (grouped by API, then instance),
+   only the requested provider's instances.
+3. Ask whether they want to change anything. If they do, go to Step 6.
 
 ### Step 6: Edit an already-applied native policy
 
-When they ask to change an existing policy (e.g. add `1.1.1.1` to IP
-filtering):
+Skip Steps 1–4 unless you still need the instance list from Step 5.
 
-1. Identify the instance + `policy_id` + Exchange coordinates from
-   `view_api_instance_policies` (do not guess IDs).
+`edit_applied_policy` is **Kong / Apigee / Azure only**. If the instance is
+MuleSoft/Anypoint, say you cannot edit it with the current tools and stop.
+
+There is no bulk-edit: loop **once per instance**.
+
+1. Identify `api_instance_id` + `policy_id` + Exchange
+   `asset.{group_id,asset_id,asset_version}` + `provider` from
+   `view_api_instance_policies` (do not guess).
 2. Load the schema with `get_policy_template_form` using those coordinates.
-3. Read current `configurationData`, merge the requested delta into the
-   **full** object (`edit_applied_policy` replaces wholesale — omitted keys
-   are dropped).
-4. Show the schema (only extra fields if the delta needs them) and the
-   **policy → API + instance mapping** of the edit. **[GATE] Wait for okay.**
-5. Call `edit_applied_policy`. Poll `list_instance_policy_operations` until
-   `COMPLETED` / `FAILED`. Confirm per API instance.
+3. Read current `configurationData`. Merge the requested **delta** into that
+   full object (`configuration_data` replaces wholesale — omitted keys are
+   dropped). Prompt only for required fields the merge left empty — do not
+   re-ask the whole schema when the delta is complete.
+4. Show the **policy → API + instance mapping** of the edit (every instance
+   you will loop). **[GATE] Wait for okay.**
+5. Call `edit_applied_policy` per instance. A `success` / 202 is acceptance.
+   Poll `list_instance_policy_operations` per instance until `COMPLETED` /
+   `FAILED`. Confirm per API instance.
 
 A `readOnly: true` policy cannot be edited — say so and stop.
 
 ## Best Practices
 
-- **One apply call for Universal.** ✅ `apply_universal_policy` with every
-  missing `instance_id`. ❌ looping native apply for a canonical template.
-- **Don't trust `hasPolicy`.** ✅ `policyCoverage` + `instancesMissingPolicy`.
-  ❌ treating a True `hasPolicy` as "this API is done".
-- **Don't claim success early.** ✅ poll to `COMPLETED`. ❌ reporting the 202
-  as done.
-- **Don't invent config.** ✅ full schema table, then one user-provided
-  object. ❌ filling optional fields with guessed values.
+- **Route first.** ✅ Audit stays on Step 5. ❌ running Step 1's
+  `policy_name_filter` + apply GATE because the file is numbered 1–6.
+- **One apply call for Universal.** ✅ `apply_universal_policy` with the
+  Step-2 remaining ids. ❌ looping native apply; ❌ sending the pre-drop
+  Step 1 list.
+- **Don't invent display fields.** ✅ join `instanceId` as in
+  `references/payloads.md`. ❌ filling provider/name from memory.
 
 ## Troubleshooting
 
-**Tool `list_universal_policies` / `apply_universal_policy` / `find_assets`
-with `include_applied_policies` is missing:** the portal catalog is stale.
-These tools are published by [PR #222](https://github.com/mulesoft/mulesoft-dx/pull/222).
-Stop and tell the user; do not substitute Anypoint REST calls.
+**Universal policy tools are missing from the catalog:** say so and stop.
+Do not substitute Anypoint REST calls.
 
-**`policyCoverage` is `unknown`:** an instance read failed or sampling was
-capped. Re-read those instances with `view_api_instance_policies`. Do not
-apply as if they were missing.
+**`policyCoverage` is `unknown`, or the table shows `?`:** re-read those
+instances with `view_api_instance_policies`. Do not apply as if they were
+missing.
 
 **403 / not entitled / gate closed:** the org cannot manage that provider's
 policies. Say so plainly and stop.
 
-**Apply returns 202 / `accepted`:** poll `get_policy_operation_status`. The
-fan-out is one Temporal operation id for the whole apply, not per instance.
+**Apply returned `ok` or `partial` and you started polling:** those statuses
+are already terminal. Report from `results`; only `accepted` has an
+`operationId` to poll.
 
 **Edit dropped fields the user did not mention:** `configuration_data` is a
-full replace. Merge onto the latest `configurationData` from
-`view_api_instance_policies` immediately before the edit.
+full replace. Merge onto the latest `configurationData` immediately before
+the edit.
+
+**Edit failed on a MuleSoft instance:** expected — the tool is external-only.
+Stop and say so.
 
 **User asks to undo / remove / disable the policy:** not supported. There is
 no detach tool and no enable/disable parameter on the agent surface. Explain

--- a/skills/apply-universal-policy/SKILL.md
+++ b/skills/apply-universal-policy/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: apply-universal-policy
+description: |
+  Protect a portfolio slice by applying one Universal (canonical) policy across
+  API instances on any gateway (Kong, Apigee, Azure, AWS, MuleSoft), or audit
+  and edit already-applied native policies. Use when the user wants JWT
+  validation on tagged APIs, rate limiting everywhere, IP filtering on Apigee,
+  "what protection do I have", tighten an existing policy, or apply one config
+  across providers. DO NOT TRIGGER when applying a policy to a single already
+  chosen API Manager instance — use skill apply-policy-to-api-instance. Do not
+  use to remove, detach, enable, or disable a policy (those tools do not exist).
+license: Apache-2.0
+compatibility: >
+  Requires the MuleSoft Platform MCP Server (urn:mcp:mulesoft-platform). The
+  Universal-policy tools this skill calls land in the portal catalog via
+  mulesoft-dx PR #222 — if they are missing, stop (see Prerequisites).
+metadata:
+  author: mulesoft-omni
+  version: "1.0.0"
+---
+
+# Apply Universal Policy
+
+Protect APIs across gateways with one Universal policy: discover what is
+missing, collect configuration once, apply in one call, and wait until the
+work has actually finished.
+
+## When to Use This Skill
+
+**Use this skill when the user asks to:**
+
+- "Ensure all my finance-tagged APIs have JWT validation"
+- "What protection do I have on my Apigee APIs?"
+- "Add 1.1.1.1 to the IP filtering on those APIs"
+- Apply one canonical policy (JWT, rate limiting, CORS, IP allow/deny, …)
+  across many instances or many providers
+
+**Trigger keywords:** universal policy · canonical policy · JWT validation ·
+rate limiting · spike arrest · IP filtering · IP allowlist · protect my APIs ·
+portfolio · missing this policy · Kong · Apigee · Azure · AWS.
+
+**Do NOT use this skill when:**
+
+- The user already has **one** API Manager instance and wants a single native
+  policy on it → **skill apply-policy-to-api-instance**
+- They need to **create** an instance or deploy a gateway first → **skill secure-api**
+- They want to **remove**, detach, or pause (enable/disable) a policy — say so
+  and stop; those actions are not on the tool surface
+
+## Prerequisites
+
+You must be connected to the MuleSoft Platform MCP Server
+(`urn:mcp:mulesoft-platform`). Probe availability with a read-only call:
+
+1. Call `list_universal_policies`. If the tool is **not in the catalog**, STOP.
+   Tell the user the portal catalog does not yet include these tools — they
+   ship in [mulesoft-dx PR #222](https://github.com/mulesoft/mulesoft-dx/pull/222)
+   and this skill cannot execute until that PR is merged and published.
+2. If the tool returns that the Universal catalog is unavailable, say so and
+   stop — do not invent a fallback apply path.
+3. The caller needs policy-manage permission on the target org. On a 403 /
+   entitlement error, say they are not entitled and **stop**. Never silently
+   switch provider or org.
+
+## Reference files
+
+- **`references/presentation-format.md`** — pinned tables for every output
+  (API-instance list, config schema, policy→API+instance mapping, applied-policy
+  list, operation result). Read it before the first user-facing table and reuse
+  those layouts for the rest of the run.
+
+## Workflow
+
+### Rules that always apply
+
+1. **Confirm before acting.** Report found/missing (or the edit preview) and
+   wait for an explicit yes before `apply_universal_policy` or
+   `edit_applied_policy`. A missing confirmation is the most expensive mistake —
+   it writes policies the user did not approve.
+2. **Instances, not APIs.** Users say "APIs"; policies attach to **deployed
+   instances**. Resolve that yourself. Gate apply on `policyCoverage` +
+   `instancesMissingPolicy`, never on `hasPolicy` alone (`hasPolicy` is
+   any-instance and would skip unprotected siblings).
+3. **One config, whole surface.** Show every field the template schema exposes
+   (required and optional), then collect the **entire** configuration in one
+   shot. Reuse it across every targeted instance. Never walk field by field.
+4. **Wait for completion.** A 202/`status=accepted` is not success. Poll
+   `get_policy_operation_status` (or `list_instance_policy_operations` for a
+   native edit) until `COMPLETED` or `FAILED`. Distinguish retryable vs
+   terminal from `error.retryable`.
+5. **Plain names.** Pre-apply and post-apply mappings use human-readable
+   native policy names from `providerMapping`, not IDs.
+
+### Step 1: Discover the slice and what's missing
+
+Call `find_assets` with:
+
+- `query` — the user's filter ("finance", "payments", a tag, a name)
+- `asset_type` — `rest-api` when they mean APIs
+- `user_query` — the verbatim user message
+- `include_applied_policies` — `true`
+- `policy_name_filter` — the protection they named ("JWT validation",
+  "rate-limiting"; matching is case- and separator-insensitive)
+
+Present the result with the **API-instance list** in
+`references/presentation-format.md`. Summarize **per instance**:
+"N instances found, M missing this policy."
+
+Coverage rules:
+
+| `policyCoverage` | Meaning | Apply to |
+| --- | --- | --- |
+| `all` | Every readable instance has it | skip (already protected) |
+| `partial` / `none` | Some or none have it | exactly `instancesMissingPolicy` |
+| `unknown` | Incomplete read (error or cap) | re-check those instances with `view_api_instance_policies` before acting. Never count `unknown` as missing. |
+
+Enrichment is capped (about 12 assets, 3 production-first instances each). If
+`appliedPolicyEnrichment.assetCapApplied` is true, fan out
+`view_api_instance_policies` for the remaining instances rather than treating
+the truncated set as complete.
+
+**[GATE] Wait for the user to confirm they want you to fix the gap.**
+
+### Step 2: Choose the Universal policy and show its schema
+
+Call `list_universal_policies` (optional `policy_name_hint`). Pick the
+canonical template that matches the user's protection. Each entry has
+`configurationSchema`, `supportedProviders`, and `providerMapping` (what it
+becomes on Kong / Apigee / …).
+
+Drop any target instance whose provider is not in `supportedProviders`. If
+that leaves none, say so and stop.
+
+Present the **policy configuration schema** table (full surface). Then ask
+the user to fill **all** fields in one reply.
+
+### Step 3: Preview the native mapping, then apply
+
+Build the **policy → API + instance mapping** by joining each remaining
+instance's provider to `providerMapping`. Show it. **[GATE] Wait for okay.**
+
+Call `apply_universal_policy` once with:
+
+- `policy_name` — the canonical kebab-case template name
+- `instance_ids` — every instance still missing the policy (from Step 1)
+- `configuration` — the collected config, reused as-is
+
+Do **not** loop `apply_policy_to_instance` for a Universal/canonical template
+across many instances or providers — that is what `apply_universal_policy` is
+for. Use `apply_policy_to_instance` only for a provider-native plugin on a
+single instance.
+
+### Step 4: Poll until it is actually done
+
+If the apply returns `status=accepted` + `operationId`, poll
+`get_policy_operation_status` until `COMPLETED` or `FAILED` (not `RUNNING`).
+
+Report with the **operation result** layout, then the same **policy → API +
+instance mapping** as the preview (now as the result). On partial failure,
+name the instances that failed. On `FAILED`, say whether `error.retryable`
+is true.
+
+### Step 5: Audit an existing slice (optional path)
+
+When the user asks "what protection do I have on my \<provider\> APIs?":
+
+1. `find_assets` with `include_applied_policies=true` (no name filter needed).
+2. Present the **applied-policy list** (grouped by API, then instance).
+3. Ask whether they want to change anything.
+
+### Step 6: Edit an already-applied native policy
+
+When they ask to change an existing policy (e.g. add `1.1.1.1` to IP
+filtering):
+
+1. Identify the instance + `policy_id` + Exchange coordinates from
+   `view_api_instance_policies` (do not guess IDs).
+2. Load the schema with `get_policy_template_form` using those coordinates.
+3. Read current `configurationData`, merge the requested delta into the
+   **full** object (`edit_applied_policy` replaces wholesale — omitted keys
+   are dropped).
+4. Show the schema (only extra fields if the delta needs them) and the
+   **policy → API + instance mapping** of the edit. **[GATE] Wait for okay.**
+5. Call `edit_applied_policy`. Poll `list_instance_policy_operations` until
+   `COMPLETED` / `FAILED`. Confirm per API instance.
+
+A `readOnly: true` policy cannot be edited — say so and stop.
+
+## Best Practices
+
+- **One apply call for Universal.** ✅ `apply_universal_policy` with every
+  missing `instance_id`. ❌ looping native apply for a canonical template.
+- **Don't trust `hasPolicy`.** ✅ `policyCoverage` + `instancesMissingPolicy`.
+  ❌ treating a True `hasPolicy` as "this API is done".
+- **Don't claim success early.** ✅ poll to `COMPLETED`. ❌ reporting the 202
+  as done.
+- **Don't invent config.** ✅ full schema table, then one user-provided
+  object. ❌ filling optional fields with guessed values.
+
+## Troubleshooting
+
+**Tool `list_universal_policies` / `apply_universal_policy` / `find_assets`
+with `include_applied_policies` is missing:** the portal catalog is stale.
+These tools are published by [PR #222](https://github.com/mulesoft/mulesoft-dx/pull/222).
+Stop and tell the user; do not substitute Anypoint REST calls.
+
+**`policyCoverage` is `unknown`:** an instance read failed or sampling was
+capped. Re-read those instances with `view_api_instance_policies`. Do not
+apply as if they were missing.
+
+**403 / not entitled / gate closed:** the org cannot manage that provider's
+policies. Say so plainly and stop.
+
+**Apply returns 202 / `accepted`:** poll `get_policy_operation_status`. The
+fan-out is one Temporal operation id for the whole apply, not per instance.
+
+**Edit dropped fields the user did not mention:** `configuration_data` is a
+full replace. Merge onto the latest `configurationData` from
+`view_api_instance_policies` immediately before the edit.
+
+**User asks to undo / remove / disable the policy:** not supported. There is
+no detach tool and no enable/disable parameter on the agent surface. Explain
+and stop.
+
+## Related Skills
+
+- **skill apply-policy-to-api-instance**: apply one catalog policy to a single
+  already-chosen API Manager instance (Anypoint REST, not Universal fan-out).
+- **skill secure-api**: create/deploy an instance and then apply a policy —
+  use that when the API is not yet an instance.
+- **skill secure-mcp-server**: protect an MCP server, not an API instance.

--- a/skills/apply-universal-policy/SKILL.md
+++ b/skills/apply-universal-policy/SKILL.md
@@ -94,9 +94,10 @@ Protect, then Audit, then Edit).
 3. **Join before you talk.** `instancesMissingPolicy` is `{instanceId,
    environment}` only. Build display rows and `instance_ids` using
    `references/payloads.md` — do not invent names or providers.
-4. **Apply: one config, whole surface.** Show every field the template schema
-   exposes, then collect the **entire** configuration in one shot. Reuse it
-   across every targeted instance. Never walk field by field.
+4. **Apply: one config, one shot.** Show the schema table (full surface, or
+   required-only when it is too long — see `references/presentation-format.md`),
+   then collect the **entire** configuration for the fields you showed in one
+   reply. Reuse it across every targeted instance. Never walk field by field.
 5. **Wait for completion.** Acceptance (`accepted` / HTTP 202 / edit
    `success`) is not success. Poll until `COMPLETED` or `FAILED`. Distinguish
    retryable vs terminal from `error.retryable`.
@@ -153,8 +154,12 @@ Drop any target instance whose provider is not in `supportedProviders`. If
 that leaves none, say so and stop. Keep the surviving list — that is the
 apply set for Steps 3–4, **not** the raw Step 1 missing list.
 
-Present the **policy configuration schema** table (full surface). Then ask
-the user to fill **all** fields in one reply. Do not invent optional values.
+Present the **policy configuration schema** table
+(`references/presentation-format.md`). If the flattened schema is too long
+to scan, show required fields only, say how many optionals are hidden, and
+offer to expand. Then ask the user to fill the **visible** fields in one
+reply. Do not invent optional values; omitted hidden fields keep schema
+defaults.
 
 ### Step 3: Preview the native mapping, then apply (Protect)
 

--- a/skills/apply-universal-policy/references/payloads.md
+++ b/skills/apply-universal-policy/references/payloads.md
@@ -63,26 +63,15 @@ success. On `FAILED`, read `error.retryable`.
 `not_found` from the status tool means the id is unknown or aged out — say
 so; do not retry with a guessed id.
 
-## `edit_applied_policy` (external only)
+## `edit_applied_policy`
 
-This tool edits native policies on **Kong / Apigee / Azure** only. It
-rejects MuleSoft/Anypoint instances. If the target is MuleSoft, say you
-cannot edit it with the current tools and stop.
+Same tool, two write paths — branch on provider (`references` join first):
 
-Required on every call (do not guess):
+| Instance | `provider` | Also required | After the call |
+| --- | --- | --- | --- |
+| Kong / Apigee / Azure | `kong` / `apigee` / `azure` | `api_instance_id`, `policy_id`, `asset.{group_id,asset_id,asset_version}` | A `success` / 202 is **acceptance**. Poll `list_instance_policy_operations` per instance until `COMPLETED` / `FAILED`. |
+| MuleSoft / Anypoint | omit, or `mulesoft` | `environment_id`, `api_instance_id`, `policy_id`. `asset` optional (forward it to bump version). | Typically synchronous HTTP 200 (`via=apim`). Do **not** poll `list_instance_policy_operations` (that tool is external-only). |
 
-- `organization_id`
-- `api_instance_id`
-- `provider` — `kong` / `apigee` / `azure`
-- `policy_id` — from `view_api_instance_policies`
-- `asset.group_id`, `asset.asset_id`, `asset.asset_version` — Exchange
-  coordinates of the applied template, from the same read
-- `configuration_data` — **full** object. Omitted keys are dropped.
-
-There is no bulk-edit. One user request across many instances = one
-`edit_applied_policy` per instance, same merged config.
-
-A `success` / 202 from the edit is **acceptance**, not completion. Poll
-`list_instance_policy_operations` per instance (`organization_id`,
-`api_instance_id`, `provider`) until that instance's latest update is
-`COMPLETED` or `FAILED`.
+`configuration_data` is a **full** object on both paths. Omitted keys are
+dropped. There is no bulk-edit: one user request across many instances =
+one `edit_applied_policy` per instance, same merged config.

--- a/skills/apply-universal-policy/references/payloads.md
+++ b/skills/apply-universal-policy/references/payloads.md
@@ -1,10 +1,9 @@
 # Tool payloads — apply-universal-policy
 
-Read this when building tables, choosing `instance_ids`, or calling
-`edit_applied_policy`. Field names below are the structured tool output,
-not the chat rendering.
+Read this when building tables or choosing `instance_ids`. Field names
+below are the structured tool output, not the chat rendering.
 
-## `find_assets` join (Protect + Audit)
+## `find_assets` join (Protect)
 
 `include_applied_policies=true` annotates each **userOrgAssets** row. Public
 catalog hits have no applied-policy state — ignore them for this skill.
@@ -21,11 +20,10 @@ Per user-org asset you get:
 Build each table row by:
 
 1. Taking the API name from the parent asset.
-2. Joining `instanceId` to `appliedPolicies.instances` for `environment`
-   (and `policyNames` on the audit path).
+2. Joining `instanceId` to `appliedPolicies.instances` for `environment`.
 3. Taking provider from the asset/version if present. If it is missing,
-   call `view_api_instance_policies` for that `instanceId` before applying
-   or before filtering to "my Apigee APIs". Do not invent a provider.
+   call `view_api_instance_policies` for that `instanceId` before applying.
+   Do not invent a provider.
 4. Using `environment` as the instance-name fallback when the payload has
    no separate instance name.
 
@@ -36,14 +34,13 @@ Apply targets = the joined `instancesMissingPolicy` rows whose
 the list is truncated. Fan out `view_api_instance_policies` for remaining
 user-org assets rather than treating the truncated set as complete.
 
-## Provider slice ("my Apigee APIs")
+## Provider filter on Protect
 
-`find_assets` has no provider parameter. Put the provider word in `query`
-(and keep `user_query` verbatim), then **filter client-side**: keep
-instances whose provider matches (case-insensitive: `apigee`, `kong`,
-`azure`, `aws`, `mulesoft` / `anypoint`). If provider is still unknown
-after the join, resolve it with `view_api_instance_policies` before
-including or excluding the row.
+If they scoped Protect to a provider ("JWT on my Apigee APIs"), put the
+provider word in `query` (keep `user_query` verbatim), then **filter
+client-side**: keep instances whose provider matches (`apigee`, `kong`,
+`azure`, `aws`, `mulesoft` / `anypoint`). Audit and edit of already-applied
+native policies are **skill apply-native-policy-to-instance**, not this file.
 
 ## `apply_universal_policy` responses
 
@@ -62,16 +59,3 @@ success. On `FAILED`, read `error.retryable`.
 
 `not_found` from the status tool means the id is unknown or aged out — say
 so; do not retry with a guessed id.
-
-## `edit_applied_policy`
-
-Same tool, two write paths — branch on provider (`references` join first):
-
-| Instance | `provider` | Also required | After the call |
-| --- | --- | --- | --- |
-| Kong / Apigee / Azure | `kong` / `apigee` / `azure` | `api_instance_id`, `policy_id`, `asset.{group_id,asset_id,asset_version}` | A `success` / 202 is **acceptance**. Poll `list_instance_policy_operations` per instance until `COMPLETED` / `FAILED`. |
-| MuleSoft / Anypoint | omit, or `mulesoft` | `environment_id`, `api_instance_id`, `policy_id`. `asset` optional (forward it to bump version). | Typically synchronous HTTP 200 (`via=apim`). Do **not** poll `list_instance_policy_operations` (that tool is external-only). |
-
-`configuration_data` is a **full** object on both paths. Omitted keys are
-dropped. There is no bulk-edit: one user request across many instances =
-one `edit_applied_policy` per instance, same merged config.

--- a/skills/apply-universal-policy/references/payloads.md
+++ b/skills/apply-universal-policy/references/payloads.md
@@ -1,0 +1,88 @@
+# Tool payloads — apply-universal-policy
+
+Read this when building tables, choosing `instance_ids`, or calling
+`edit_applied_policy`. Field names below are the structured tool output,
+not the chat rendering.
+
+## `find_assets` join (Protect + Audit)
+
+`include_applied_policies=true` annotates each **userOrgAssets** row. Public
+catalog hits have no applied-policy state — ignore them for this skill.
+
+Per user-org asset you get:
+
+- API display name from the row (`name` / title).
+- `appliedPolicies.instances[]` — `{instanceId, environment, policyNames}`
+  for the **sampled** instances.
+- When `policy_name_filter` was set: `policyCoverage`, `hasPolicy`, and
+  `instancesMissingPolicy[]` — `{instanceId, environment}` only.
+
+`instancesMissingPolicy` does **not** carry instance name or provider.
+Build each table row by:
+
+1. Taking the API name from the parent asset.
+2. Joining `instanceId` to `appliedPolicies.instances` for `environment`
+   (and `policyNames` on the audit path).
+3. Taking provider from the asset/version if present. If it is missing,
+   call `view_api_instance_policies` for that `instanceId` before applying
+   or before filtering to "my Apigee APIs". Do not invent a provider.
+4. Using `environment` as the instance-name fallback when the payload has
+   no separate instance name.
+
+Apply targets = the joined `instancesMissingPolicy` rows whose
+`policyCoverage` is `partial` or `none`. Skip `all`. Re-check `unknown`.
+
+`appliedPolicyEnrichment.assetCapApplied` (or `assetsDropped` > 0) means
+the list is truncated. Fan out `view_api_instance_policies` for remaining
+user-org assets rather than treating the truncated set as complete.
+
+## Provider slice ("my Apigee APIs")
+
+`find_assets` has no provider parameter. Put the provider word in `query`
+(and keep `user_query` verbatim), then **filter client-side**: keep
+instances whose provider matches (case-insensitive: `apigee`, `kong`,
+`azure`, `aws`, `mulesoft` / `anypoint`). If provider is still unknown
+after the join, resolve it with `view_api_instance_policies` before
+including or excluding the row.
+
+## `apply_universal_policy` responses
+
+Branch on `status` — do not assume async:
+
+| `status` | Meaning | Next |
+| --- | --- | --- |
+| `accepted` | HTTP 202. Work is in flight. `operationId` is set. | Poll `get_policy_operation_status` |
+| `ok` | Synchronous success. `appliedCount` / `results` are final. | Report **Succeeded** + mapping. Do not poll. |
+| `partial` | HTTP 207. Some targets failed. | Report **Partially succeeded**; name failures from `results`. Do not poll. |
+
+Poll only the `accepted` branch. Same `operationId` covers the whole fan-out
+(not one id per instance). Poll every few seconds; stop at `COMPLETED` or
+`FAILED`, or after ~20 attempts — then report **Still running**, never
+success. On `FAILED`, read `error.retryable`.
+
+`not_found` from the status tool means the id is unknown or aged out — say
+so; do not retry with a guessed id.
+
+## `edit_applied_policy` (external only)
+
+This tool edits native policies on **Kong / Apigee / Azure** only. It
+rejects MuleSoft/Anypoint instances. If the target is MuleSoft, say you
+cannot edit it with the current tools and stop.
+
+Required on every call (do not guess):
+
+- `organization_id`
+- `api_instance_id`
+- `provider` — `kong` / `apigee` / `azure`
+- `policy_id` — from `view_api_instance_policies`
+- `asset.group_id`, `asset.asset_id`, `asset.asset_version` — Exchange
+  coordinates of the applied template, from the same read
+- `configuration_data` — **full** object. Omitted keys are dropped.
+
+There is no bulk-edit. One user request across many instances = one
+`edit_applied_policy` per instance, same merged config.
+
+A `success` / 202 from the edit is **acceptance**, not completion. Poll
+`list_instance_policy_operations` per instance (`organization_id`,
+`api_instance_id`, `provider`) until that instance's latest update is
+`COMPLETED` or `FAILED`.

--- a/skills/apply-universal-policy/references/presentation-format.md
+++ b/skills/apply-universal-policy/references/presentation-format.md
@@ -1,0 +1,73 @@
+# Presentation formats — apply-universal-policy
+
+Users say "APIs" when they mean **deployed instances**. Accept that phrasing
+and resolve API → instances yourself, but every table titles and lists
+**instances**. A protected instance must not hide an unprotected sibling of
+the same API.
+
+Reuse the **same** shape for the same kind of data everywhere it appears
+(pre-apply preview and post-apply confirmation use the identical mapping
+layout).
+
+## 1. API-instance list (discovery)
+
+Table titled **"API instances"**.
+
+| API name | Instance name | Environment | Provider | Policy present? |
+| --- | --- | --- | --- | --- |
+| Payments API | prod | Production | apigee | ✗ |
+| Payments API | sandbox | Sandbox | kong | ✓ |
+
+Plus a summary counted **per instance**: "N instances found, M missing this
+policy."
+
+Fallback for small results: a bullet list that still shows API name +
+instance name.
+
+## 2. Policy configuration schema
+
+Present the template's full `configurationSchema` (required **and** optional)
+as one table, then ask for **the whole configuration in one shot** — never
+field by field.
+
+| Field | Description | Required? | Default / allowed values |
+| --- | --- | --- | --- |
+| `jwksUrl` | JWKS endpoint | yes | — |
+| `skipClientIdValidation` | Skip client-id check | no | `false` |
+
+For nested objects/arrays, indent the child rows under the parent field
+(or flatten with dotted paths). Do not drop optional fields to "simplify".
+
+## 3. Policy → API + instance mapping
+
+Used for both the pre-apply confirmation and the post-apply result.
+
+| Native policy | API name | Instance name | Environment | Provider |
+| --- | --- | --- | --- | --- |
+| Spike arrest | Payments API | prod | Production | apigee |
+| Rate limiting | Orders API | prod | Production | kong |
+
+Plain native names from `list_universal_policies` → `providerMapping` (not
+IDs). Join each target instance's provider to that mapping.
+
+## 4. Applied-policy list (audit)
+
+Group by **API, then instance**. Under each instance list policy names (and
+direction / enabled state when the read returns them).
+
+```
+Payments API
+  prod (Production · apigee)
+    - Spike arrest (inbound, enabled)
+  sandbox (Sandbox · apigee)
+    - (none)
+```
+
+## 5. Operation result
+
+One short status line:
+
+- **Succeeded** — every targeted instance completed.
+- **Partially succeeded** — name the API instances that failed.
+- **Failed** — retryable vs terminal, using the operation `error.retryable`
+  flag when present. Never claim success while status is `RUNNING`.

--- a/skills/apply-universal-policy/references/presentation-format.md
+++ b/skills/apply-universal-policy/references/presentation-format.md
@@ -9,6 +9,8 @@ Reuse the **same** shape for the same kind of data everywhere it appears
 (pre-apply preview and post-apply confirmation use the identical mapping
 layout).
 
+How to fill columns from `find_assets` is in `references/payloads.md`.
+
 ## 1. API-instance list (discovery)
 
 Table titled **"API instances"**.
@@ -17,18 +19,26 @@ Table titled **"API instances"**.
 | --- | --- | --- | --- | --- |
 | Payments API | prod | Production | apigee | ✗ |
 | Payments API | sandbox | Sandbox | kong | ✓ |
+| Orders API | prod | Production | azure | ? |
+
+**Policy present?** is per instance, never per API:
+
+- **✓** — this instance has the named policy (a confirmed read)
+- **✗** — this instance lacks it (a confirmed read)
+- **?** — `unknown`: the read was incomplete (error or cap). Never treat `?`
+  as missing and never apply to it until a re-check resolves it to ✓ or ✗.
 
 Plus a summary counted **per instance**: "N instances found, M missing this
-policy."
+policy, K unknown." Do not fold unknown into missing.
 
 Fallback for small results: a bullet list that still shows API name +
-instance name.
+instance name + the same ✓/✗/? mark.
 
 ## 2. Policy configuration schema
 
 Present the template's full `configurationSchema` (required **and** optional)
 as one table, then ask for **the whole configuration in one shot** — never
-field by field.
+field by field. (Apply path only. Edit path is a delta merge — see the skill.)
 
 | Field | Description | Required? | Default / allowed values |
 | --- | --- | --- | --- |
@@ -48,7 +58,8 @@ Used for both the pre-apply confirmation and the post-apply result.
 | Rate limiting | Orders API | prod | Production | kong |
 
 Plain native names from `list_universal_policies` → `providerMapping` (not
-IDs). Join each target instance's provider to that mapping.
+IDs). Join each **remaining** target instance's provider to that mapping
+(after dropping unsupported providers).
 
 ## 4. Applied-policy list (audit)
 
@@ -63,6 +74,8 @@ Payments API
     - (none)
 ```
 
+When the user named a provider, show **only** that provider's instances.
+
 ## 5. Operation result
 
 One short status line:
@@ -70,4 +83,7 @@ One short status line:
 - **Succeeded** — every targeted instance completed.
 - **Partially succeeded** — name the API instances that failed.
 - **Failed** — retryable vs terminal, using the operation `error.retryable`
-  flag when present. Never claim success while status is `RUNNING`.
+  flag when present.
+- **Still running** — you hit the poll cap; say so. Never claim success
+  while status is `RUNNING` or while you only have an acceptance (`accepted`
+  / HTTP 202).

--- a/skills/apply-universal-policy/references/presentation-format.md
+++ b/skills/apply-universal-policy/references/presentation-format.md
@@ -36,9 +36,9 @@ instance name + the same ✓/✗/? mark.
 
 ## 2. Policy configuration schema
 
-Present the template's full `configurationSchema` (required **and** optional)
-as one table, then ask for **the whole configuration in one shot** — never
-field by field. (Apply path only. Edit path is a delta merge — see the skill.)
+Present `configurationSchema` as one table, then ask for **the whole
+configuration in one shot** against the fields you showed — never field by
+field. (Apply path only. Edit path is a delta merge — see the skill.)
 
 | Field | Description | Required? | Default / allowed values |
 | --- | --- | --- | --- |
@@ -46,7 +46,26 @@ field by field. (Apply path only. Edit path is a delta merge — see the skill.)
 | `skipClientIdValidation` | Skip client-id check | no | `false` |
 
 For nested objects/arrays, indent the child rows under the parent field
-(or flatten with dotted paths). Do not drop optional fields to "simplify".
+(or flatten with dotted paths). Count every child row toward the length
+check below.
+
+**When the schema is short** (about 12 flattened rows or fewer): show
+required **and** optional. Do not hide optionals just to "simplify".
+
+**When the schema is too long to scan** (more than about 12 flattened
+rows): show **required fields only**. Immediately under the table, say
+that optional fields are hidden because the schema is too long, how many
+are hidden, and that they keep their defaults unless the user asks to see
+them. Offer to expand:
+
+> Showing N required fields (M optional hidden — the full schema is too
+> long to display). Say if you want the hidden fields.
+
+If they ask, show the **full** table (required + optional) and let them
+add those values in the same one-shot reply. Do not walk field by field
+either way. Do not invent values for hidden optionals — omit them so
+schema defaults apply. Never hide a required field, even if required
+alone is still long.
 
 ## 3. Policy → API + instance mapping
 

--- a/skills/apply-universal-policy/references/presentation-format.md
+++ b/skills/apply-universal-policy/references/presentation-format.md
@@ -38,7 +38,7 @@ instance name + the same ✓/✗/? mark.
 
 Present `configurationSchema` as one table, then ask for **the whole
 configuration in one shot** against the fields you showed — never field by
-field. (Apply path only. Edit path is a delta merge — see the skill.)
+field.
 
 | Field | Description | Required? | Default / allowed values |
 | --- | --- | --- | --- |
@@ -80,22 +80,7 @@ Plain native names from `list_universal_policies` → `providerMapping` (not
 IDs). Join each **remaining** target instance's provider to that mapping
 (after dropping unsupported providers).
 
-## 4. Applied-policy list (audit)
-
-Group by **API, then instance**. Under each instance list policy names (and
-direction / enabled state when the read returns them).
-
-```
-Payments API
-  prod (Production · apigee)
-    - Spike arrest (inbound, enabled)
-  sandbox (Sandbox · apigee)
-    - (none)
-```
-
-When the user named a provider, show **only** that provider's instances.
-
-## 5. Operation result
+## 4. Operation result
 
 One short status line:
 

--- a/skills/apply-universal-policy/skills-metadata.yaml
+++ b/skills/apply-universal-policy/skills-metadata.yaml
@@ -1,0 +1,1 @@
+type: prose


### PR DESCRIPTION
## Summary
- Adds the `apply-universal-policy` prose skill (published next to `apply-policy-to-api-instance`) so an MCP-connected agent can protect a portfolio slice with one Universal policy, audit what's already applied, and edit native policies.
- Pins instance-grained presentation formats in `references/presentation-format.md` and points the neighbor JTBD (`apply-policy-to-api-instance`) at this skill so the two jobs stay disambiguated.

**Depends on #222.** This skill drives MCP tools that are not on the published portal catalog until #222 merges and the portal bakes (`list_universal_policies`, `apply_universal_policy`, `get_policy_operation_status`, and `find_assets` with `include_applied_policies` / `policyCoverage`). Authoring can land in parallel; an agent cannot execute the workflow until both PRs are live. The skill itself probes `list_universal_policies` first and stops if the catalog is still stale.

## Test plan
- [x] `python3 scripts/build/validate_skills.py --repo-root .` passes (R1–R7, including the new skill + the related-job link on `apply-policy-to-api-instance`)
- [ ] After **#222** merges and the portal republishes: install the skill from https://dev-portal.mulesoft.com/ and run the six W-23941113 acceptance conversations (protect a slice / show protection / edit / poll to completion / unentitled stop / confirm-before-apply)
- [ ] Confirm `list_universal_policies` is in the live `urn:mcp:mulesoft-platform` catalog before treating a missing-tool stop as a skill bug